### PR TITLE
Added names for U&U

### DIFF
--- a/pack/uau_encounter.json
+++ b/pack/uau_encounter.json
@@ -13,6 +13,7 @@
 	},
 	{
 		"back_flavor": "An old pickup truck rolls to a stop along the weathered trails of Dunwich. The driver - Joe Osborn - calls out to you through a shattered driver-side window, the truck's engine still running. \"IT's over at the Ericks' farm!\" he shouts. \"Done blasted their place apart. Poor Henry and Martha...\"\nYou ask Osborn for the location of the Ericks' homestead, and it confirms your worst fear. For that attack to have occurred recently, there must be more of the monsters on the loose.",
+		"back_name": "Calamity Strikes",
 		"back_text": "Shuffle the encounter discard pile into the encounter deck.\nSpawn 1 of the set-aside Brood of Yog-Sothoth enemies at a random location, if able.",
 		"code": "02237",
 		"doom": 5,
@@ -30,6 +31,7 @@
 		"type_code": "agenda"
 	},
 	{
+		"back_name": "No Place to Hide",
 		"back_text": "Shuffle the encounter discard pile into the encounter deck. <b>If there is a set-aside Brood of Yog-Sothoth, the lead investigator reads the following (out loud):\n<i>Bleak storm clouds churn overhead and a blanket of rain pelts the countryside. As the downpour grows in intensity, you take refuge in a half-ruined shack nearby. There is a flash of lightning, and in the brief illumination, you spot the outline of something large in the rain. Without warning, the distant trees bend, though nothing seems to be bending them. Moments later, a force with the strength of a truck crashes into your refuge.</i>\n</b>Spawn 1 of the set-aside Brood of Yog-Sothoth enemies at the lead investigator's location, if able. Then, each investigator at that location tests [agility] (4). The newly spawned Brood of Yog-Sothoth makes an attack against each investigator who fails this skill test.",
 		"code": "02238",
 		"doom": 6,
@@ -48,6 +50,7 @@
 	},
 	{
 		"back_flavor": "There is a monstrous rumbling throughout the countryside, though it is impossible to tell whether its source is the creatures you hunt or the very mountains themselves. Soon after, you find more of the creatures' tracks leading up toward the hills: a thirty-foot path of crushed underbrush and trees snapped like twigs. Exhausted from battle, and with night fast approaching, you decide to head to safety rather than follow these hellish tracks.",
+		"back_name": "Into the Hills",
 		"back_text": "<b>(→R1)</b>",
 		"code": "02239",
 		"doom": 7,
@@ -65,6 +68,7 @@
 		"type_code": "agenda"
 	},
 	{
+		"back_name": "Obtaining the Formula",
 		"back_text": "<b>Check Campaign Log. If Dr. Armitage survived The Dunwich Legacy:</b>\n<i>\"There!\" Armitage sighs a breath of relief, jotting down the last phrases of the formula. \"I have translated the last of it.\" He shudders as he hands you the script, the words conjuring forth memories of his battle with the creature. \"I hope this is the last time I'll have to read it,\" he admits. \"But if we do nothing, the end result will be much, much worse.\"</i>\nEach investigator puts into play 1 set-aside Esoteric Formula.\n<b>If Dr. Armitage is listed under \"Sacrificed to Yog-Sothoth\":</b>\n<i>Using the information contained within the ruins of the Whateley homestead, you are able to transcribe the remainder of the formula previously used by Dr. Armitage to destroy the beast that plagued Dunwich. However, the endeavor sets you back several hours.</i>\nEach investigator puts into play 1 set-aside Esoteric Formula. Place 1 doom on the current agenda.",
 		"clues": 2,
 		"code": "02240",
@@ -83,6 +87,7 @@
 	},
 	{
 		"back_flavor": "As you complete the incantation, the foul creature cries out with a raucous, inhuman voice. It rumbles and cracks, the syllables of its croaking far from English. As its cry plays out, the creature shrinks upon itself, and then, with little warning, it is gone. All that remains is a foul stench and a repulsive mark that mars the vegetation where the beast once stood.",
+		"back_name": "The Brood is Ended",
 		"back_text": "<b>(→R2)</b>",
 		"clues": null,
 		"code": "02241",


### PR DESCRIPTION
I've added back names for U&U agenda & act cards. They are quite strangely formatted cards, with bold text, indented flavor and the like, and I think what we have at the moment is fine but please advise if it can be altered.