### PR TITLE
Fix three typos found in icon markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ These can be used in a card's `text` section.
 
 * `[reaction]`
 * `[action]`
-* `[lightning]`
+* `[free]`
 * `[eldersign]`
 * `[will]`
 * `[lore]`

--- a/pack/dwl/dwl_encounter.json
+++ b/pack/dwl/dwl_encounter.json
@@ -366,7 +366,7 @@
         "position": 58,
         "quantity": 1,
         "subname": "Something Went Terribly Wrong",
-        "text": "Massive.\nThe Experiment gets +3[per investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
+        "text": "Massive.\nThe Experiment gets +3[per_investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
         "traits": "Monster. Abomination. Elite.",
         "type_code": "enemy",
         "victory": 2
@@ -557,7 +557,7 @@
         "position": 68,
         "quantity": 1,
         "stage": 3,
-        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "type_code": "act"
     },
     {
@@ -577,7 +577,7 @@
         "position": 69,
         "quantity": 1,
         "stage": 3,
-        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "type_code": "act"
     },
     {

--- a/pack/dwl/tmm_encounter.json
+++ b/pack/dwl/tmm_encounter.json
@@ -451,7 +451,7 @@
         "position": 141,
         "quantity": 1,
         "subname": "Spawned from the Void",
-        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto-fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
+        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
         "traits": "Monster. Elite.",
         "type_code": "enemy"
     },

--- a/pack/dwl/wda_encounter.json
+++ b/pack/dwl/wda_encounter.json
@@ -108,7 +108,7 @@
 	{
 		"back_flavor": "Approaching the peak of Sentinel Hill, you are confronted by several citizens of Dunwich. The man in the center of their circle is desperately trying to complete a Latin incantation. \"It's not working, Seth!\" one of the other men cries out. \"What're we gonna do?\" The man in the center stops his chant and pulls out a cobbler's knife. \"The father demands a blood sacrifice,\" he declares, and his face twists into a crazed expression. Before you can react, he slits his left wrist with the knife, dropping to his knees in agony. The headstone of the altar behind him splits open. A torrent of energy pours out of the stone, coalescing into the form of an open gate. Seth holds onto the stone in front of him to prevent himself from being sucked into the gate, but several of the others are startled and pulled through it. You barely manage to dig your heels in and grab hold of a nearby rock in time to resist the pull of the gate. Seth rises, wounded but alive. An expression of pride spreads across his pained face.",
 		"back_name": "Will the Change",
-		"back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per investigator] damage on him.",
+		"back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per_investigator] damage on him.",
 		"clues": null,
 		"code": "02280",
 		"double_sided": true,
@@ -185,7 +185,7 @@
 	{
 		"back_flavor": "An arcane wall blocks the path further up the hill, leading towards the peak.",
 		"back_illustrator": "Patrick McEvoy",
-		"back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per investigator] clues, as a group",
+		"back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per_investigator] clues, as a group",
 		"clues": 2,
 		"code": "02284",
 		"double_sided": true,

--- a/pack/ptc/apot.json
+++ b/pack/ptc/apot.json
@@ -171,7 +171,7 @@
 		"slot": "Ally",
 		"skill_intellect": 1,
 		"subname": "Mysterious Benefactress",
-		"text": "[lightning] If you have no cards in your hand, exhaust Madame Labranche: Draw 1 card.\n[lightning] If you have no resources, exhaust Madame Labranche: Gain 1 resource.",
+		"text": "[free] If you have no cards in your hand, exhaust Madame Labranche: Draw 1 card.\n[free] If you have no resources, exhaust Madame Labranche: Gain 1 resource.",
 		"traits": "Ally. Patron.",
 		"type_code": "asset",
 		"xp": 0

--- a/pack/ptc/apot_encounter.json
+++ b/pack/ptc/apot_encounter.json
@@ -148,7 +148,7 @@
 		"position": 207,
 		"quantity": 1,
 		"stage": 2,
-		"text": "[lightning] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
+		"text": "[free] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
 		"type_code": "act"
 	},
 	{
@@ -165,7 +165,7 @@
 		"position": 208,
 		"quantity": 1,
 		"shroud": 2,
-		"text": "[lightning] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
+		"text": "[free] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
 		"traits": "Paris. Rail.",
 		"type_code": "location"
 	},

--- a/pack/ptc/dca.json
+++ b/pack/ptc/dca.json
@@ -28,7 +28,7 @@
 		"quantity": 2,
 		"skill_intellect": 1,
 		"skill_wild": 1,
-		"text": "Fast. Play during any [lightning] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
+		"text": "Fast. Play during any [free] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
 		"traits": "Insight.",
 		"type_code": "event",
 		"xp": 5

--- a/pack/ptc/ptc.json
+++ b/pack/ptc/ptc.json
@@ -175,7 +175,7 @@
 		"skill_combat": 3,
 		"skill_willpower": 3,
 		"subname": "The Actress",
-		"text": "<b>Forced</b> - After you draw your opening hand: Choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\nYou can only play, commit, or trigger abilities on Neutral cards or cards of your role.\n[lightning]: Switch your role. (Limit once per round.)\n[elder_sign] effect: +2. You may switch roles.",
+		"text": "<b>Forced</b> - After you draw your opening hand: Choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\nYou can only play, commit, or trigger abilities on Neutral cards or cards of your role.\n[free]: Switch your role. (Limit once per round.)\n[elder_sign] effect: +2. You may switch roles.",
 		"traits": "Performer.",
 		"type_code": "investigator"
 	},
@@ -226,7 +226,7 @@
 		"quantity": 1,
 		"restrictions": "investigator:03001",
 		"subname": "In Loving Memory",
-		"text": "Mark Harrigan deck only.\nSophie cannot leave play.\n[lightning] Take 1 direct damage: You get +2 to your skill value for this skill test.\n<b>Forced</b> - If Mark Harrigan has 5 or more damage on him: Flip Sophie.",
+		"text": "Mark Harrigan deck only.\nSophie cannot leave play.\n[free] Take 1 direct damage: You get +2 to your skill value for this skill test.\n<b>Forced</b> - If Mark Harrigan has 5 or more damage on him: Flip Sophie.",
 		"traits": "Item. Spirit",
 		"type_code": "asset"
 	},
@@ -312,7 +312,7 @@
 		"skill_wild": 1,
 		"skill_willpower": 1,
 		"subname": "Envoy of the Alusi",
-		"text": "Akachi Onyele deck only.\n[lightning] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
+		"text": "Akachi Onyele deck only.\n[free] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
 		"traits": "Ritual.",
 		"type_code": "asset"
 	},
@@ -327,7 +327,7 @@
 		"quantity": 1,
 		"restrictions": "investigator:03004",
 		"subtype_code": "weakness",
-		"text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[lightning] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
+		"text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[free] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
 		"traits": "Task.",
 		"type_code": "treachery"
 	},
@@ -671,7 +671,7 @@
 		"quantity": 2,
 		"skill_combat": 1,
 		"slot": "Hand",
-		"text": "[lightning] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
+		"text": "[free] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
 		"traits": "Item. Relic. Weapon. Melee.",
 		"type_code": "asset",
 		"xp": 1

--- a/pack/ptc/ptc_encounter.json
+++ b/pack/ptc/ptc_encounter.json
@@ -1000,7 +1000,7 @@
 		"pack_code": "ptc",
 		"position": 84,
 		"quantity": 1,
-		"text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [lightning] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
+		"text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [free] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
 		"traits": "Terror.",
 		"type_code": "treachery"
 	},

--- a/pack/ptc/tuo.json
+++ b/pack/ptc/tuo.json
@@ -50,7 +50,7 @@
 		"skill_intellect": 1,
 		"slot": "Ally",
 		"subname": "Acquisitions and Solicitation",
-		"text": "You may spend resources to pay for <b>Item</b> assets played by other investigators at your location.\n[lightning] Exhaust Charles Ross, Esq.: Reduce the cost of the next <b>Item</b> asset played by an investigator at your location by 1.",
+		"text": "You may spend resources to pay for <b>Item</b> assets played by other investigators at your location.\n[free] Exhaust Charles Ross, Esq.: Reduce the cost of the next <b>Item</b> asset played by an investigator at your location by 1.",
 		"traits": "Ally. Patron.",
 		"type_code": "asset",
 		"xp": 0

--- a/translations/de/pack/dwl/dwl_encounter.json
+++ b/translations/de/pack/dwl/dwl_encounter.json
@@ -151,7 +151,7 @@
         "code": "02058",
         "name": "The Experiment",
         "subname": "Something Went Terribly Wrong",
-        "text": "Massive.\nThe Experiment gets +3[per investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
+        "text": "Massive.\nThe Experiment gets +3[per_investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
         "traits": "Monster. Abomination. Elite."
     },
     {
@@ -228,7 +228,7 @@
         "code": "02068",
         "flavor": "With or without Dr. Morgan, you have to get out of here. Fast.",
         "name": "All In",
-        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "back_name": "Safe... For Now",
         "back_flavor": "You escape the club, doing your best to look inconspicuous as several cars pull up near the street. A handful of grim-faced men and women exit, running toward the restaurant's entrance to take control of the situation. One of them catches your eye, his hand on the grip of his .38, but thankfully he turns his attention back to the rest of his crew and follows them into the club. You breathe a sigh of relief...",
         "back_text": "— If an investigator resigned with Dr. Francis Morgan under his or her control, <b>(→R2)</b>\n— Otherwise, <b>(→R1)</b>"
@@ -237,7 +237,7 @@
         "code": "02069",
         "flavor": "\"Free drinks for whoever gets me the hell out of here!\" A man exclaims from the bar.",
         "name": "Fold",
-        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "back_name": "Escaping the Club",
         "back_flavor": "You make your way toward the rain-slicked streets of Arkham.",
         "back_text": "— If an investigator resigned with Peter Clover under his or her control, <b>(→R3)</b>\n— Otherwise, <b>(→R1)</b>"

--- a/translations/de/pack/dwl/tmm_encounter.json
+++ b/translations/de/pack/dwl/tmm_encounter.json
@@ -188,7 +188,7 @@
         "code": "02141",
         "name": "Hunting Horror",
         "subname": "Spawned from the Void",
-        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto-fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
+        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
         "traits": "Monster. Elite."
     },
     {

--- a/translations/de/pack/dwl/wda_encounter.json
+++ b/translations/de/pack/dwl/wda_encounter.json
@@ -55,7 +55,7 @@
         "text": "Clues cannot be placed on non-<i>Altered</i> locations.\n<b>Objective</b> - When an investigator enters Sentinel Peak, advance.",
         "back_name": "Will the Change",
         "back_flavor": "Approaching the peak of Sentinel Hill, you are confronted by several citizens of Dunwich. The man in the center of their circle is desperately trying to complete a Latin incantation. \"It's not working, Seth!\" one of the other men cries out. \"What're we gonna do?\" The man in the center stops his chant and pulls out a cobbler's knife. \"The father demands a blood sacrifice,\" he declares, and his face twists into a crazed expression. Before you can react, he slits his left wrist with the knife, dropping to his knees in agony. The headstone of the altar behind him splits open. A torrent of energy pours out of the stone, coalescing into the form of an open gate. Seth holds onto the stone in front of him to prevent himself from being sucked into the gate, but several of the others are startled and pulled through it. You barely manage to dig your heels in and grab hold of a nearby rock in time to resist the pull of the gate. Seth rises, wounded but alive. An expression of pride spreads across his pained face.",
-        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per investigator] damage on him."
+        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per_investigator] damage on him."
     },
     {
         "code": "02281",
@@ -88,7 +88,7 @@
         "text": "<b>Forced</b> - When an investigator at this location draws a <i>Hex</i> card: That investigator takes 1 damage.",
         "traits": "Dunwich. Sentinel Hill.",
         "back_flavor": "An arcane wall blocks the path further up the hill, leading towards the peak.",
-        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per investigator] clues, as a group"
+        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per_investigator] clues, as a group"
     },
     {
         "code": "02285",

--- a/translations/de/pack/ptc/apot.json
+++ b/translations/de/pack/ptc/apot.json
@@ -65,7 +65,7 @@
         "code": "03198",
         "name": "Madame Labranche",
         "subname": "Mysterious Benefactress",
-        "text": "[lightning] If you have no cards in your hand, exhaust Madame Labranche: Draw 1 card.\n[lightning] If you have no resources, exhaust Madame Labranche: Gain 1 resource.",
+        "text": "[free] If you have no cards in your hand, exhaust Madame Labranche: Draw 1 card.\n[free] If you have no resources, exhaust Madame Labranche: Gain 1 resource.",
         "traits": "Ally. Patron.",
         "slot": "Ally"
     },

--- a/translations/de/pack/ptc/apot_encounter.json
+++ b/translations/de/pack/ptc/apot_encounter.json
@@ -61,7 +61,7 @@
         "code": "03207",
         "flavor": "I knew that every time I met him brought him nearer to the accomplishment of his purpose and my fate. And still I tried to save myself.\n–Robert W. Chambers, \"In the Court of the Dragon,\" <u>The King in Yellow</u>",
         "name": "Stalked by Shadows",
-        "text": "[lightning] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
+        "text": "[free] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
         "back_name": "Shepherd's Crook",
         "back_flavor": "You lose track of yourself within the city as you flee for your life. Your feet move of their own accord. The beating of sinewy wings and screeching of creatures above you spurs you onward. Soon you find yourself running down a narrow avenue, passing a set of heavy iron gates. You are in a dead end - a court with tall, old houses on either side. You turn back toward the entrance and breathe a sigh of relief as you see the sun rising once more over the skyline of Paris. As though dispersed by the sunlight, the figure that had been chasing you folds into the shadows and vanishes. Just as you are about to leave, you spot a plaque next to a red-brown door atop a steep, narrow staircase. It reads: \"N. Engram.\"",
         "back_text": "Check Campaign Log.\n-<i>If you intruded on a secret meeting</i>, proceed to <b>(→R2)</b>.\n-Otherwise, proceed to <b>(→R1)</b>."
@@ -69,7 +69,7 @@
     {
         "code": "03208",
         "name": "Montparnasse",
-        "text": "[lightning] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
+        "text": "[free] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
         "traits": "Paris. Rail.",
         "back_flavor": "This area is known for its cafés and bars, and is often frequented by starving artists. Perhaps some of these creative types will become famous someday. Most, you assume, will fade into obscurity."
     },

--- a/translations/de/pack/ptc/dca.json
+++ b/translations/de/pack/ptc/dca.json
@@ -8,7 +8,7 @@
     {
         "code": "03307",
         "name": "No Stone Unturned",
-        "text": "Fast. Play during any [lightning] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
+        "text": "Fast. Play during any [free] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
         "traits": "Insight."
     },
     {

--- a/translations/de/pack/ptc/ptc.json
+++ b/translations/de/pack/ptc/ptc.json
@@ -53,7 +53,7 @@
         "flavor": "Perhaps this would be her big comeback.",
         "name": "Lola Hayes",
         "subname": "The Actress",
-        "text": "<b>Forced</b> - After you draw your opening hand: Choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\nYou can only play, commit, or trigger abilities on Neutral cards or cards of your role.\n[lightning]: Switch your role. (Limit once per round.)\n[elder_sign] effect: +2. You may switch roles.",
+        "text": "<b>Forced</b> - After you draw your opening hand: Choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\nYou can only play, commit, or trigger abilities on Neutral cards or cards of your role.\n[free]: Switch your role. (Limit once per round.)\n[elder_sign] effect: +2. You may switch roles.",
         "traits": "Performer.",
         "back_flavor": "Lola has performed to sold-out houses worldwide, but no play has been as haunting or as odd as The King in Yellow. Even during rehearsals, everything about it brought calamity and dread. When her co-star, Miriam, was found floating dead in the Seine, she decided she'd had enough, and penned a letter to the director explaining that her next performance would be her last. Now she heads home to Arkham for one final show, hoping she can finally be rid of this dreadful play.",
         "back_text": "<b>Deck size</b>: 35.\n<b>Deckbuilding Options</b>: Survivor, Guardian, Seeker, Rogue, and Mystic cards ([survivor], [guardian], [seeker], [rogue], and [mystic]) level 0-3, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): 2 copies of Improvisation, 2 copies of Crisis of Identity, 1 random basic weakness.\n<b>Additional Requirements</b>: Your deck must include at least 7 cards each from 3 different classes ([survivor], [guardian], [seeker], [rogue], or [mystic])."
@@ -76,7 +76,7 @@
         "code": "03009",
         "name": "Sophie",
         "subname": "In Loving Memory",
-        "text": "Mark Harrigan deck only.\nSophie cannot leave play.\n[lightning] Take 1 direct damage: You get +2 to your skill value for this skill test.\n<b>Forced</b> - If Mark Harrigan has 5 or more damage on him: Flip Sophie.",
+        "text": "Mark Harrigan deck only.\nSophie cannot leave play.\n[free] Take 1 direct damage: You get +2 to your skill value for this skill test.\n<b>Forced</b> - If Mark Harrigan has 5 or more damage on him: Flip Sophie.",
         "traits": "Item. Spirit",
         "back_text": "Sophie cannot leave play.\nYou get -1 to each of your skills.\n<b>Forced</b> - If Mark Harrigan has 4 or less damage on him: Flip Sophie."
     },
@@ -111,13 +111,13 @@
         "code": "03014",
         "name": "Spirit-Speaker",
         "subname": "Envoy of the Alusi",
-        "text": "Akachi Onyele deck only.\n[lightning] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
+        "text": "Akachi Onyele deck only.\n[free] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
         "traits": "Ritual."
     },
     {
         "code": "03015",
         "name": "Angered Spirits",
-        "text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[lightning] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
+        "text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[free] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
         "traits": "Task."
     },
     {
@@ -252,7 +252,7 @@
     {
         "code": "03035",
         "name": "Spirit Athame",
-        "text": "[lightning] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
+        "text": "[free] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
         "traits": "Item. Relic. Weapon. Melee.",
         "slot": "Hand"
     },

--- a/translations/de/pack/ptc/ptc_encounter.json
+++ b/translations/de/pack/ptc/ptc_encounter.json
@@ -407,7 +407,7 @@
     {
         "code": "03084c",
         "name": "Whispers in Your Head (Anxiety)",
-        "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [lightning] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
+        "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [free] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
         "traits": "Terror."
     },
     {

--- a/translations/de/pack/ptc/tpm_encounter.json
+++ b/translations/de/pack/ptc/tpm_encounter.json
@@ -52,77 +52,77 @@
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When The Gate to Hell is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and below The Gate to Hell.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03248",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "Ignore the text on unrevealed locations adjacent to Stone Archways.\n<b>Forced</b> - When Stone Archways is revealed: Put the topmost Catacombs in the Catacombs deck into play to the right of Stone Archways.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03249",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "Crypt of the Sepulchral Lamp is investigated using [willpower] instead of the skill indicated by the investigation attempt.\n<b>Forced</b> - When Crypt of the Sepulchral Lamp is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and to the right of Crypt of the Sepulchral Lamp.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03250",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "While you are investigating Bone-Filled Cavern, you have 1 fewer hand slot.\n<b>Forced</b> - When Bone-Filled Cavern is revealed: Put the top 2 Catacombs in the Catacombs deck into play below and to the right of Bone-Filled Cavern.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03251",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - After you end your turn at Well of Souls: You must either take 1 direct horror or discard 2 random cards from your hand.\n<b>Forced</b> - When Well of Souls is revealed: Put the topmost Catacombs in the Catacombs deck into play above, below, or to the right of Well of Souls.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03252",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "[action]: Test [intellect] (3) to read an ancient sign. If you succeed, look at the revealed side of any Catacombs location in play. (Group limit once per game.)\n<b>Forced</b> - When Candlelit Tunnels is revealed: Put the top 2 Catacombs in the Catacombs deck into play to the left and right of Candlelit Tunnels.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03253",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When Labyrinth of Bones is revealed: Put the top 3 Catacombs in the Catacombs deck into play above, below, and to the right of Labyrinth of Bones.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03254",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When you would move from Narrow Shaft to an unrevealed location: Test [agility] (3). If you fail, take 1 damage and cancel the effects of the move.\n<b>Forced</b> - When Narrow Shaft is revealed: Put the topmost Catacombs in the Catacombs deck into play above or to the right of Narrow Shaft.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03255",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - After you end your turn at Shivering Pools: You must either take 1 direct damage or lose 5 resources.\n<b>Forced</b> - When Shivering Pools is revealed: Put the topmost Catacombs in the Catacombs deck into play below or to the right of Shivering Pools.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03256",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When you reveal Blocked Passage: Take 2 damage. You cannot leave Blocked Passage this round.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03257",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
-        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per investigator] health and cannot be defeated by his [action] ability.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per_investigator] health and cannot be defeated by his [action] ability.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03258",

--- a/translations/de/pack/ptc/tuo.json
+++ b/translations/de/pack/ptc/tuo.json
@@ -17,7 +17,7 @@
         "code": "03149",
         "name": "Charles Ross, Esq.",
         "subname": "Acquisitions and Solicitation",
-        "text": "You may spend resources to pay for <b>Item</b> assets played by other investigators at your location.\n[lightning] Exhaust Charles Ross, Esq.: Reduce the cost of the next <b>Item</b> asset played by an investigator at your location by 1.",
+        "text": "You may spend resources to pay for <b>Item</b> assets played by other investigators at your location.\n[free] Exhaust Charles Ross, Esq.: Reduce the cost of the next <b>Item</b> asset played by an investigator at your location by 1.",
         "traits": "Ally. Patron.",
         "slot": "Ally"
     },

--- a/translations/es/pack/dwl/dwl_encounter.json
+++ b/translations/es/pack/dwl/dwl_encounter.json
@@ -100,7 +100,7 @@
         "code": "02052",
         "flavor": "As you explore these old, well-kept buildings, you find yourself wondering whether the beds are comfortable...",
         "name": "Dormitories",
-        "text": "<b>Objective</b> - If investigators in the Dormitories spend 3[per investigator] clues, as a group: <b>(→R2)</b>",
+        "text": "<b>Objective</b> - If investigators in the Dormitories spend 3[per_investigator] clues, as a group: <b>(→R2)</b>",
         "traits": "Miskatonic.",
         "back_flavor": "The red brick form of the west dormitory could be seen through the trees...<br><cite>Graham McNeill, Ghouls of the Miskatonic</cite>",
         "back_text": "The door leading into the Dormitories is locked. You cannot move into the Dormitories."
@@ -116,7 +116,7 @@
         "code": "02054",
         "name": "Faculty Offices",
         "subname": "The Night is Still Young",
-        "text": "<b>Forced</b> - After Faculty Offices is revealed: Search the encounter deck and discard pile for a <i>Humanoid</i> enemy and spawn it here. Shuffle the encounter deck.\n<b>Objective</b> - If investigators in the Faculty Offices spend 2[per investigator] clues, as a group: <b>(→R1)</b>",
+        "text": "<b>Forced</b> - After Faculty Offices is revealed: Search the encounter deck and discard pile for a <i>Humanoid</i> enemy and spawn it here. Shuffle the encounter deck.\n<b>Objective</b> - If investigators in the Faculty Offices spend 2[per_investigator] clues, as a group: <b>(→R1)</b>",
         "traits": "Miskatonic.",
         "back_flavor": "You come to a locked door at the top of the stairs leading to the third floor of the administration building. Through its frosted window, you glimpse a shadow darting across the hall.",
         "back_text": "The door leading into the Faculty Offices is locked. You cannot move into the Faculty Offices."
@@ -151,7 +151,7 @@
         "code": "02058",
         "name": "The Experiment",
         "subname": "Something Went Terribly Wrong",
-        "text": "Massive.\nThe Experiment gets +3[per investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
+        "text": "Massive.\nThe Experiment gets +3[per_investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
         "traits": "Monster. Abomination. Elite."
     },
     {
@@ -228,7 +228,7 @@
         "code": "02068",
         "flavor": "With or without Dr. Morgan, you have to get out of here. Fast.",
         "name": "All In",
-        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "back_name": "Safe... For Now",
         "back_flavor": "You escape the club, doing your best to look inconspicuous as several cars pull up near the street. A handful of grim-faced men and women exit, running toward the restaurant's entrance to take control of the situation. One of them catches your eye, his hand on the grip of his .38, but thankfully he turns his attention back to the rest of his crew and follows them into the club. You breathe a sigh of relief...",
         "back_text": "— If an investigator resigned with Dr. Francis Morgan under his or her control, <b>(→R2)</b>\n— Otherwise, <b>(→R1)</b>"
@@ -237,7 +237,7 @@
         "code": "02069",
         "flavor": "\"Free drinks for whoever gets me the hell out of here!\" A man exclaims from the bar.",
         "name": "Fold",
-        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "back_name": "Escaping the Club",
         "back_flavor": "You make your way toward the rain-slicked streets of Arkham.",
         "back_text": "— If an investigator resigned with Peter Clover under his or her control, <b>(→R3)</b>\n— Otherwise, <b>(→R1)</b>"

--- a/translations/es/pack/dwl/tmm_encounter.json
+++ b/translations/es/pack/dwl/tmm_encounter.json
@@ -71,7 +71,7 @@
     {
         "code": "02127",
         "name": "Museum Halls",
-        "text": "Museum Halls is connected to each copy of Exhibit Hall.\n[action] Investigators in the Museum Halls spend 1[per investigator] clues, as a group: Put the top card of the Exhibit deck into play, unrevealed.",
+        "text": "Museum Halls is connected to each copy of Exhibit Hall.\n[action] Investigators in the Museum Halls spend 1[per_investigator] clues, as a group: Put the top card of the Exhibit deck into play, unrevealed.",
         "traits": "Miskatonic.",
         "back_text": "The entrance to the Museum Halls is locked. You cannot move into the Museum Halls.\nMuseum Entrance gains: \"[action]: Test [combat] (5) to attempt to break down the door to the Museum. If you are successful, immediately advance to Act 1b.\""
     },
@@ -188,7 +188,7 @@
         "code": "02141",
         "name": "Hunting Horror",
         "subname": "Spawned from the Void",
-        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto-fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
+        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
         "traits": "Monster. Elite."
     },
     {

--- a/translations/es/pack/dwl/wda_encounter.json
+++ b/translations/es/pack/dwl/wda_encounter.json
@@ -55,7 +55,7 @@
         "text": "Clues cannot be placed on non-<i>Altered</i> locations.\n<b>Objective</b> - When an investigator enters Sentinel Peak, advance.",
         "back_name": "Will the Change",
         "back_flavor": "Approaching the peak of Sentinel Hill, you are confronted by several citizens of Dunwich. The man in the center of their circle is desperately trying to complete a Latin incantation. \"It's not working, Seth!\" one of the other men cries out. \"What're we gonna do?\" The man in the center stops his chant and pulls out a cobbler's knife. \"The father demands a blood sacrifice,\" he declares, and his face twists into a crazed expression. Before you can react, he slits his left wrist with the knife, dropping to his knees in agony. The headstone of the altar behind him splits open. A torrent of energy pours out of the stone, coalescing into the form of an open gate. Seth holds onto the stone in front of him to prevent himself from being sucked into the gate, but several of the others are startled and pulled through it. You barely manage to dig your heels in and grab hold of a nearby rock in time to resist the pull of the gate. Seth rises, wounded but alive. An expression of pride spreads across his pained face.",
-        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per investigator] damage on him."
+        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per_investigator] damage on him."
     },
     {
         "code": "02281",
@@ -88,7 +88,7 @@
         "text": "<b>Forced</b> - When an investigator at this location draws a <i>Hex</i> card: That investigator takes 1 damage.",
         "traits": "Dunwich. Sentinel Hill.",
         "back_flavor": "An arcane wall blocks the path further up the hill, leading towards the peak.",
-        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per investigator] clues, as a group"
+        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per_investigator] clues, as a group"
     },
     {
         "code": "02285",

--- a/translations/es/pack/ptc/apot.json
+++ b/translations/es/pack/ptc/apot.json
@@ -65,7 +65,7 @@
         "code": "03198",
         "name": "Madame Labranche",
         "subname": "Misteriosa benefactora",
-        "text": "[lightning] Si no tienes cartas en la mano, agota a Madame Labranche: Roba 1 carta.\n[lightning] Si no tienes recursos, agota a Madame Labranche: Obtén 1 recurso.",
+        "text": "[free] Si no tienes cartas en la mano, agota a Madame Labranche: Roba 1 carta.\n[free] Si no tienes recursos, agota a Madame Labranche: Obtén 1 recurso.",
         "traits": "Aliado. Mecenas.",
         "slot": "Aliado"
     },

--- a/translations/es/pack/ptc/apot_encounter.json
+++ b/translations/es/pack/ptc/apot_encounter.json
@@ -61,7 +61,7 @@
         "code": "03207",
         "flavor": "I knew that every time I met him brought him nearer to the accomplishment of his purpose and my fate. And still I tried to save myself.\n–Robert W. Chambers, \"In the Court of the Dragon,\" <u>The King in Yellow</u>",
         "name": "Stalked by Shadows",
-        "text": "[lightning] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
+        "text": "[free] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
         "back_name": "Shepherd's Crook",
         "back_flavor": "You lose track of yourself within the city as you flee for your life. Your feet move of their own accord. The beating of sinewy wings and screeching of creatures above you spurs you onward. Soon you find yourself running down a narrow avenue, passing a set of heavy iron gates. You are in a dead end - a court with tall, old houses on either side. You turn back toward the entrance and breathe a sigh of relief as you see the sun rising once more over the skyline of Paris. As though dispersed by the sunlight, the figure that had been chasing you folds into the shadows and vanishes. Just as you are about to leave, you spot a plaque next to a red-brown door atop a steep, narrow staircase. It reads: \"N. Engram.\"",
         "back_text": "Check Campaign Log.\n-<i>If you intruded on a secret meeting</i>, proceed to <b>(→R2)</b>.\n-Otherwise, proceed to <b>(→R1)</b>."
@@ -69,7 +69,7 @@
     {
         "code": "03208",
         "name": "Montparnasse",
-        "text": "[lightning] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
+        "text": "[free] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
         "traits": "Paris. Rail.",
         "back_flavor": "This area is known for its cafés and bars, and is often frequented by starving artists. Perhaps some of these creative types will become famous someday. Most, you assume, will fade into obscurity."
     },

--- a/translations/es/pack/ptc/dca.json
+++ b/translations/es/pack/ptc/dca.json
@@ -8,7 +8,7 @@
     {
         "code": "03307",
         "name": "No Stone Unturned",
-        "text": "Fast. Play during any [lightning] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
+        "text": "Fast. Play during any [free] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
         "traits": "Insight."
     },
     {

--- a/translations/es/pack/ptc/ptc_encounter.json
+++ b/translations/es/pack/ptc/ptc_encounter.json
@@ -407,7 +407,7 @@
     {
         "code": "03084c",
         "name": "Whispers in Your Head (Anxiety)",
-        "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [lightning] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
+        "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [free] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
         "traits": "Terror."
     },
     {

--- a/translations/es/pack/ptc/tpm_encounter.json
+++ b/translations/es/pack/ptc/tpm_encounter.json
@@ -82,7 +82,7 @@
         "text": "<b>Forced</b> - When The Gate to Hell is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and below The Gate to Hell.",
         "back_name": "Catacombs",
         "back_flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03248",
@@ -90,7 +90,7 @@
         "text": "Ignore the text on unrevealed locations adjacent to Stone Archways.\n<b>Forced</b> - When Stone Archways is revealed: Put the topmost Catacombs in the Catacombs deck into play to the right of Stone Archways.",
         "back_name": "Catacombs",
         "back_flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group.",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion."
     },
     {
@@ -99,7 +99,7 @@
         "text": "Crypt of the Sepulchral Lamp is investigated using [willpower] instead of the skill indicated by the investigation attempt.\n<b>Forced</b> - When Crypt of the Sepulchral Lamp is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and to the right of Crypt of the Sepulchral Lamp.",
         "back_name": "Catacombs",
         "back_flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group.",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion."
     },
     {
@@ -108,7 +108,7 @@
         "text": "While you are investigating Bone-Filled Cavern, you have 1 fewer hand slot.\n<b>Forced</b> - When Bone-Filled Cavern is revealed: Put the top 2 Catacombs in the Catacombs deck into play below and to the right of Bone-Filled Cavern.",
         "back_name": "Catacombs",
         "back_flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group.",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion."
     },
     {
@@ -117,7 +117,7 @@
         "text": "<b>Forced</b> - After you end your turn at Well of Souls: You must either take 1 direct horror or discard 2 random cards from your hand.\n<b>Forced</b> - When Well of Souls is revealed: Put the topmost Catacombs in the Catacombs deck into play above, below, or to the right of Well of Souls.",
         "back_name": "Catacombs",
         "back_flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group.",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion."
     },
     {
@@ -126,7 +126,7 @@
         "text": "[action]: Test [intellect] (3) to read an ancient sign. If you succeed, look at the revealed side of any Catacombs location in play. (Group limit once per game.)\n<b>Forced</b> - When Candlelit Tunnels is revealed: Put the top 2 Catacombs in the Catacombs deck into play to the left and right of Candlelit Tunnels.",
         "back_name": "Catacombs",
         "back_flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group.",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion."
     },
     {
@@ -136,7 +136,7 @@
         "text": "<b>Forced</b> - When Labyrinth of Bones is revealed: Put the top 3 Catacombs in the Catacombs deck into play above, below, and to the right of Labyrinth of Bones.",
         "back_name": "Catacombs",
         "back_flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03254",
@@ -144,7 +144,7 @@
         "text": "<b>Forced</b> - When you would move from Narrow Shaft to an unrevealed location: Test [agility] (3). If you fail, take 1 damage and cancel the effects of the move.\n<b>Forced</b> - When Narrow Shaft is revealed: Put the topmost Catacombs in the Catacombs deck into play above or to the right of Narrow Shaft.",
         "back_name": "Catacombs",
         "back_flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group.",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion."
     },
     {
@@ -153,7 +153,7 @@
         "text": "<b>Forced</b> - After you end your turn at Shivering Pools: You must either take 1 direct damage or lose 5 resources.\n<b>Forced</b> - When Shivering Pools is revealed: Put the topmost Catacombs in the Catacombs deck into play below or to the right of Shivering Pools.",
         "back_name": "Catacombs",
         "back_flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group.",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion."
     },
     {
@@ -163,15 +163,15 @@
         "text": "<b>Forced</b> - When you reveal Blocked Passage: Take 2 damage. You cannot leave Blocked Passage this round.",
         "back_name": "Catacombs",
         "back_flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03257",
         "name": "Catacombs",
-        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per investigator] health and cannot be defeated by his [action] ability.",
+        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per_investigator] health and cannot be defeated by his [action] ability.",
         "back_name": "Catacombs",
         "back_flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group.",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion."
     },
     {

--- a/translations/es/pack/tpm_encounter.json
+++ b/translations/es/pack/tpm_encounter.json
@@ -52,77 +52,77 @@
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When The Gate to Hell is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and below The Gate to Hell.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03248",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "Ignore the text on unrevealed locations adjacent to Stone Archways.\n<b>Forced</b> - When Stone Archways is revealed: Put the topmost Catacombs in the Catacombs deck into play to the right of Stone Archways.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03249",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "Crypt of the Sepulchral Lamp is investigated using [willpower] instead of the skill indicated by the investigation attempt.\n<b>Forced</b> - When Crypt of the Sepulchral Lamp is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and to the right of Crypt of the Sepulchral Lamp.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03250",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "While you are investigating Bone-Filled Cavern, you have 1 fewer hand slot.\n<b>Forced</b> - When Bone-Filled Cavern is revealed: Put the top 2 Catacombs in the Catacombs deck into play below and to the right of Bone-Filled Cavern.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03251",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - After you end your turn at Well of Souls: You must either take 1 direct horror or discard 2 random cards from your hand.\n<b>Forced</b> - When Well of Souls is revealed: Put the topmost Catacombs in the Catacombs deck into play above, below, or to the right of Well of Souls.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03252",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "[action]: Test [intellect] (3) to read an ancient sign. If you succeed, look at the revealed side of any Catacombs location in play. (Group limit once per game.)\n<b>Forced</b> - When Candlelit Tunnels is revealed: Put the top 2 Catacombs in the Catacombs deck into play to the left and right of Candlelit Tunnels.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03253",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When Labyrinth of Bones is revealed: Put the top 3 Catacombs in the Catacombs deck into play above, below, and to the right of Labyrinth of Bones.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03254",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When you would move from Narrow Shaft to an unrevealed location: Test [agility] (3). If you fail, take 1 damage and cancel the effects of the move.\n<b>Forced</b> - When Narrow Shaft is revealed: Put the topmost Catacombs in the Catacombs deck into play above or to the right of Narrow Shaft.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03255",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - After you end your turn at Shivering Pools: You must either take 1 direct damage or lose 5 resources.\n<b>Forced</b> - When Shivering Pools is revealed: Put the topmost Catacombs in the Catacombs deck into play below or to the right of Shivering Pools.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03256",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When you reveal Blocked Passage: Take 2 damage. You cannot leave Blocked Passage this round.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03257",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
-        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per investigator] health and cannot be defeated by his [action] ability.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per_investigator] health and cannot be defeated by his [action] ability.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03258",

--- a/translations/it/pack/dwl/dwl_encounter.json
+++ b/translations/it/pack/dwl/dwl_encounter.json
@@ -151,7 +151,7 @@
         "code": "02058",
         "name": "The Experiment",
         "subname": "Something Went Terribly Wrong",
-        "text": "Massive.\nThe Experiment gets +3[per investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
+        "text": "Massive.\nThe Experiment gets +3[per_investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
         "traits": "Monster. Abomination. Elite."
     },
     {
@@ -228,7 +228,7 @@
         "code": "02068",
         "flavor": "With or without Dr. Morgan, you have to get out of here. Fast.",
         "name": "All In",
-        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "back_name": "Safe... For Now",
         "back_flavor": "You escape the club, doing your best to look inconspicuous as several cars pull up near the street. A handful of grim-faced men and women exit, running toward the restaurant's entrance to take control of the situation. One of them catches your eye, his hand on the grip of his .38, but thankfully he turns his attention back to the rest of his crew and follows them into the club. You breathe a sigh of relief...",
         "back_text": "— If an investigator resigned with Dr. Francis Morgan under his or her control, <b>(→R2)</b>\n— Otherwise, <b>(→R1)</b>"
@@ -237,7 +237,7 @@
         "code": "02069",
         "flavor": "\"Free drinks for whoever gets me the hell out of here!\" A man exclaims from the bar.",
         "name": "Fold",
-        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "back_name": "Escaping the Club",
         "back_flavor": "You make your way toward the rain-slicked streets of Arkham.",
         "back_text": "— If an investigator resigned with Peter Clover under his or her control, <b>(→R3)</b>\n— Otherwise, <b>(→R1)</b>"

--- a/translations/it/pack/dwl/tmm_encounter.json
+++ b/translations/it/pack/dwl/tmm_encounter.json
@@ -188,7 +188,7 @@
         "code": "02141",
         "name": "Hunting Horror",
         "subname": "Spawned from the Void",
-        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto-fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
+        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
         "traits": "Monster. Elite."
     },
     {

--- a/translations/it/pack/dwl/wda_encounter.json
+++ b/translations/it/pack/dwl/wda_encounter.json
@@ -55,7 +55,7 @@
         "text": "Clues cannot be placed on non-<i>Altered</i> locations.\n<b>Objective</b> - When an investigator enters Sentinel Peak, advance.",
         "back_name": "Will the Change",
         "back_flavor": "Approaching the peak of Sentinel Hill, you are confronted by several citizens of Dunwich. The man in the center of their circle is desperately trying to complete a Latin incantation. \"It's not working, Seth!\" one of the other men cries out. \"What're we gonna do?\" The man in the center stops his chant and pulls out a cobbler's knife. \"The father demands a blood sacrifice,\" he declares, and his face twists into a crazed expression. Before you can react, he slits his left wrist with the knife, dropping to his knees in agony. The headstone of the altar behind him splits open. A torrent of energy pours out of the stone, coalescing into the form of an open gate. Seth holds onto the stone in front of him to prevent himself from being sucked into the gate, but several of the others are startled and pulled through it. You barely manage to dig your heels in and grab hold of a nearby rock in time to resist the pull of the gate. Seth rises, wounded but alive. An expression of pride spreads across his pained face.",
-        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per investigator] damage on him."
+        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per_investigator] damage on him."
     },
     {
         "code": "02281",
@@ -88,7 +88,7 @@
         "text": "<b>Forced</b> - When an investigator at this location draws a <i>Hex</i> card: That investigator takes 1 damage.",
         "traits": "Dunwich. Sentinel Hill.",
         "back_flavor": "An arcane wall blocks the path further up the hill, leading towards the peak.",
-        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per investigator] clues, as a group"
+        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per_investigator] clues, as a group"
     },
     {
         "code": "02285",

--- a/translations/it/pack/ptc/apot.json
+++ b/translations/it/pack/ptc/apot.json
@@ -65,7 +65,7 @@
         "code": "03198",
         "name": "Madame Labranche",
         "subname": "Mysterious Benefactress",
-        "text": "[lightning] If you have no cards in your hand, exhaust Madame Labranche: Draw 1 card.\n[lightning] If you have no resources, exhaust Madame Labranche: Gain 1 resource.",
+        "text": "[free] If you have no cards in your hand, exhaust Madame Labranche: Draw 1 card.\n[free] If you have no resources, exhaust Madame Labranche: Gain 1 resource.",
         "traits": "Ally. Patron.",
         "slot": "Ally"
     },

--- a/translations/it/pack/ptc/apot_encounter.json
+++ b/translations/it/pack/ptc/apot_encounter.json
@@ -61,7 +61,7 @@
         "code": "03207",
         "flavor": "I knew that every time I met him brought him nearer to the accomplishment of his purpose and my fate. And still I tried to save myself.\n–Robert W. Chambers, \"In the Court of the Dragon,\" <u>The King in Yellow</u>",
         "name": "Stalked by Shadows",
-        "text": "[lightning] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
+        "text": "[free] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
         "back_name": "Shepherd's Crook",
         "back_flavor": "You lose track of yourself within the city as you flee for your life. Your feet move of their own accord. The beating of sinewy wings and screeching of creatures above you spurs you onward. Soon you find yourself running down a narrow avenue, passing a set of heavy iron gates. You are in a dead end - a court with tall, old houses on either side. You turn back toward the entrance and breathe a sigh of relief as you see the sun rising once more over the skyline of Paris. As though dispersed by the sunlight, the figure that had been chasing you folds into the shadows and vanishes. Just as you are about to leave, you spot a plaque next to a red-brown door atop a steep, narrow staircase. It reads: \"N. Engram.\"",
         "back_text": "Check Campaign Log.\n-<i>If you intruded on a secret meeting</i>, proceed to <b>(→R2)</b>.\n-Otherwise, proceed to <b>(→R1)</b>."
@@ -69,7 +69,7 @@
     {
         "code": "03208",
         "name": "Montparnasse",
-        "text": "[lightning] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
+        "text": "[free] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
         "traits": "Paris. Rail.",
         "back_flavor": "This area is known for its cafés and bars, and is often frequented by starving artists. Perhaps some of these creative types will become famous someday. Most, you assume, will fade into obscurity."
     },

--- a/translations/it/pack/ptc/dca.json
+++ b/translations/it/pack/ptc/dca.json
@@ -8,7 +8,7 @@
     {
         "code": "03307",
         "name": "No Stone Unturned",
-        "text": "Fast. Play during any [lightning] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
+        "text": "Fast. Play during any [free] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
         "traits": "Insight."
     },
     {

--- a/translations/it/pack/ptc/ptc.json
+++ b/translations/it/pack/ptc/ptc.json
@@ -53,7 +53,7 @@
         "flavor": "Perhaps this would be her big comeback.",
         "name": "Lola Hayes",
         "subname": "The Actress",
-        "text": "<b>Forced</b> - After you draw your opening hand: Choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\nYou can only play, commit, or trigger abilities on Neutral cards or cards of your role.\n[lightning]: Switch your role. (Limit once per round.)\n[elder_sign] effect: +2. You may switch roles.",
+        "text": "<b>Forced</b> - After you draw your opening hand: Choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\nYou can only play, commit, or trigger abilities on Neutral cards or cards of your role.\n[free]: Switch your role. (Limit once per round.)\n[elder_sign] effect: +2. You may switch roles.",
         "traits": "Performer.",
         "back_flavor": "Lola has performed to sold-out houses worldwide, but no play has been as haunting or as odd as The King in Yellow. Even during rehearsals, everything about it brought calamity and dread. When her co-star, Miriam, was found floating dead in the Seine, she decided she'd had enough, and penned a letter to the director explaining that her next performance would be her last. Now she heads home to Arkham for one final show, hoping she can finally be rid of this dreadful play.",
         "back_text": "<b>Deck size</b>: 35.\n<b>Deckbuilding Options</b>: Survivor, Guardian, Seeker, Rogue, and Mystic cards ([survivor], [guardian], [seeker], [rogue], and [mystic]) level 0-3, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): 2 copies of Improvisation, 2 copies of Crisis of Identity, 1 random basic weakness.\n<b>Additional Requirements</b>: Your deck must include at least 7 cards each from 3 different classes ([survivor], [guardian], [seeker], [rogue], or [mystic])."
@@ -76,7 +76,7 @@
         "code": "03009",
         "name": "Sophie",
         "subname": "In Loving Memory",
-        "text": "Mark Harrigan deck only.\nSophie cannot leave play.\n[lightning] Take 1 direct damage: You get +2 to your skill value for this skill test.\n<b>Forced</b> - If Mark Harrigan has 5 or more damage on him: Flip Sophie.",
+        "text": "Mark Harrigan deck only.\nSophie cannot leave play.\n[free] Take 1 direct damage: You get +2 to your skill value for this skill test.\n<b>Forced</b> - If Mark Harrigan has 5 or more damage on him: Flip Sophie.",
         "traits": "Item. Spirit",
         "back_text": "Sophie cannot leave play.\nYou get -1 to each of your skills.\n<b>Forced</b> - If Mark Harrigan has 4 or less damage on him: Flip Sophie."
     },
@@ -111,13 +111,13 @@
         "code": "03014",
         "name": "Spirit-Speaker",
         "subname": "Envoy of the Alusi",
-        "text": "Akachi Onyele deck only.\n[lightning] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
+        "text": "Akachi Onyele deck only.\n[free] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
         "traits": "Ritual."
     },
     {
         "code": "03015",
         "name": "Angered Spirits",
-        "text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[lightning] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
+        "text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[free] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
         "traits": "Task."
     },
     {
@@ -252,7 +252,7 @@
     {
         "code": "03035",
         "name": "Spirit Athame",
-        "text": "[lightning] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
+        "text": "[free] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
         "traits": "Item. Relic. Weapon. Melee.",
         "slot": "Hand"
     },

--- a/translations/it/pack/ptc/ptc_encounter.json
+++ b/translations/it/pack/ptc/ptc_encounter.json
@@ -407,7 +407,7 @@
     {
         "code": "03084c",
         "name": "Whispers in Your Head (Anxiety)",
-        "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [lightning] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
+        "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [free] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
         "traits": "Terror."
     },
     {

--- a/translations/it/pack/ptc/tpm_encounter.json
+++ b/translations/it/pack/ptc/tpm_encounter.json
@@ -52,77 +52,77 @@
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When The Gate to Hell is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and below The Gate to Hell.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03248",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "Ignore the text on unrevealed locations adjacent to Stone Archways.\n<b>Forced</b> - When Stone Archways is revealed: Put the topmost Catacombs in the Catacombs deck into play to the right of Stone Archways.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03249",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "Crypt of the Sepulchral Lamp is investigated using [willpower] instead of the skill indicated by the investigation attempt.\n<b>Forced</b> - When Crypt of the Sepulchral Lamp is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and to the right of Crypt of the Sepulchral Lamp.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03250",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "While you are investigating Bone-Filled Cavern, you have 1 fewer hand slot.\n<b>Forced</b> - When Bone-Filled Cavern is revealed: Put the top 2 Catacombs in the Catacombs deck into play below and to the right of Bone-Filled Cavern.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03251",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - After you end your turn at Well of Souls: You must either take 1 direct horror or discard 2 random cards from your hand.\n<b>Forced</b> - When Well of Souls is revealed: Put the topmost Catacombs in the Catacombs deck into play above, below, or to the right of Well of Souls.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03252",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "[action]: Test [intellect] (3) to read an ancient sign. If you succeed, look at the revealed side of any Catacombs location in play. (Group limit once per game.)\n<b>Forced</b> - When Candlelit Tunnels is revealed: Put the top 2 Catacombs in the Catacombs deck into play to the left and right of Candlelit Tunnels.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03253",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When Labyrinth of Bones is revealed: Put the top 3 Catacombs in the Catacombs deck into play above, below, and to the right of Labyrinth of Bones.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03254",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When you would move from Narrow Shaft to an unrevealed location: Test [agility] (3). If you fail, take 1 damage and cancel the effects of the move.\n<b>Forced</b> - When Narrow Shaft is revealed: Put the topmost Catacombs in the Catacombs deck into play above or to the right of Narrow Shaft.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03255",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - After you end your turn at Shivering Pools: You must either take 1 direct damage or lose 5 resources.\n<b>Forced</b> - When Shivering Pools is revealed: Put the topmost Catacombs in the Catacombs deck into play below or to the right of Shivering Pools.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03256",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When you reveal Blocked Passage: Take 2 damage. You cannot leave Blocked Passage this round.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03257",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
-        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per investigator] health and cannot be defeated by his [action] ability.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per_investigator] health and cannot be defeated by his [action] ability.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03258",

--- a/translations/it/pack/ptc/tuo.json
+++ b/translations/it/pack/ptc/tuo.json
@@ -17,7 +17,7 @@
         "code": "03149",
         "name": "Charles Ross, Esq.",
         "subname": "Acquisitions and Solicitation",
-        "text": "You may spend resources to pay for <b>Item</b> assets played by other investigators at your location.\n[lightning] Exhaust Charles Ross, Esq.: Reduce the cost of the next <b>Item</b> asset played by an investigator at your location by 1.",
+        "text": "You may spend resources to pay for <b>Item</b> assets played by other investigators at your location.\n[free] Exhaust Charles Ross, Esq.: Reduce the cost of the next <b>Item</b> asset played by an investigator at your location by 1.",
         "traits": "Ally. Patron.",
         "slot": "Ally"
     },

--- a/translations/pl/pack/dwl/dwl_encounter.json
+++ b/translations/pl/pack/dwl/dwl_encounter.json
@@ -151,7 +151,7 @@
         "code": "02058",
         "name": "The Experiment",
         "subname": "Something Went Terribly Wrong",
-        "text": "Massive.\nThe Experiment gets +3[per investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
+        "text": "Massive.\nThe Experiment gets +3[per_investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
         "traits": "Monster. Abomination. Elite."
     },
     {
@@ -228,7 +228,7 @@
         "code": "02068",
         "flavor": "With or without Dr. Morgan, you have to get out of here. Fast.",
         "name": "All In",
-        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "back_name": "Safe... For Now",
         "back_flavor": "You escape the club, doing your best to look inconspicuous as several cars pull up near the street. A handful of grim-faced men and women exit, running toward the restaurant's entrance to take control of the situation. One of them catches your eye, his hand on the grip of his .38, but thankfully he turns his attention back to the rest of his crew and follows them into the club. You breathe a sigh of relief...",
         "back_text": "— If an investigator resigned with Dr. Francis Morgan under his or her control, <b>(→R2)</b>\n— Otherwise, <b>(→R1)</b>"
@@ -237,7 +237,7 @@
         "code": "02069",
         "flavor": "\"Free drinks for whoever gets me the hell out of here!\" A man exclaims from the bar.",
         "name": "Fold",
-        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "back_name": "Escaping the Club",
         "back_flavor": "You make your way toward the rain-slicked streets of Arkham.",
         "back_text": "— If an investigator resigned with Peter Clover under his or her control, <b>(→R3)</b>\n— Otherwise, <b>(→R1)</b>"

--- a/translations/pl/pack/dwl/tmm_encounter.json
+++ b/translations/pl/pack/dwl/tmm_encounter.json
@@ -188,7 +188,7 @@
         "code": "02141",
         "name": "Hunting Horror",
         "subname": "Spawned from the Void",
-        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto-fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
+        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
         "traits": "Monster. Elite."
     },
     {

--- a/translations/pl/pack/dwl/wda_encounter.json
+++ b/translations/pl/pack/dwl/wda_encounter.json
@@ -55,7 +55,7 @@
         "text": "Clues cannot be placed on non-<i>Altered</i> locations.\n<b>Objective</b> - When an investigator enters Sentinel Peak, advance.",
         "back_name": "Will the Change",
         "back_flavor": "Approaching the peak of Sentinel Hill, you are confronted by several citizens of Dunwich. The man in the center of their circle is desperately trying to complete a Latin incantation. \"It's not working, Seth!\" one of the other men cries out. \"What're we gonna do?\" The man in the center stops his chant and pulls out a cobbler's knife. \"The father demands a blood sacrifice,\" he declares, and his face twists into a crazed expression. Before you can react, he slits his left wrist with the knife, dropping to his knees in agony. The headstone of the altar behind him splits open. A torrent of energy pours out of the stone, coalescing into the form of an open gate. Seth holds onto the stone in front of him to prevent himself from being sucked into the gate, but several of the others are startled and pulled through it. You barely manage to dig your heels in and grab hold of a nearby rock in time to resist the pull of the gate. Seth rises, wounded but alive. An expression of pride spreads across his pained face.",
-        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per investigator] damage on him."
+        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per_investigator] damage on him."
     },
     {
         "code": "02281",
@@ -88,7 +88,7 @@
         "text": "<b>Forced</b> - When an investigator at this location draws a <i>Hex</i> card: That investigator takes 1 damage.",
         "traits": "Dunwich. Sentinel Hill.",
         "back_flavor": "An arcane wall blocks the path further up the hill, leading towards the peak.",
-        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per investigator] clues, as a group"
+        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per_investigator] clues, as a group"
     },
     {
         "code": "02285",

--- a/translations/pl/pack/ptc/apot.json
+++ b/translations/pl/pack/ptc/apot.json
@@ -65,7 +65,7 @@
         "code": "03198",
         "name": "Madame Labranche",
         "subname": "Mysterious Benefactress",
-        "text": "[lightning] If you have no cards in your hand, exhaust Madame Labranche: Draw 1 card.\n[lightning] If you have no resources, exhaust Madame Labranche: Gain 1 resource.",
+        "text": "[free] If you have no cards in your hand, exhaust Madame Labranche: Draw 1 card.\n[free] If you have no resources, exhaust Madame Labranche: Gain 1 resource.",
         "traits": "Ally. Patron.",
         "slot": "Ally"
     },

--- a/translations/pl/pack/ptc/apot_encounter.json
+++ b/translations/pl/pack/ptc/apot_encounter.json
@@ -61,7 +61,7 @@
         "code": "03207",
         "flavor": "I knew that every time I met him brought him nearer to the accomplishment of his purpose and my fate. And still I tried to save myself.\n–Robert W. Chambers, \"In the Court of the Dragon,\" <u>The King in Yellow</u>",
         "name": "Stalked by Shadows",
-        "text": "[lightning] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
+        "text": "[free] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
         "back_name": "Shepherd's Crook",
         "back_flavor": "You lose track of yourself within the city as you flee for your life. Your feet move of their own accord. The beating of sinewy wings and screeching of creatures above you spurs you onward. Soon you find yourself running down a narrow avenue, passing a set of heavy iron gates. You are in a dead end - a court with tall, old houses on either side. You turn back toward the entrance and breathe a sigh of relief as you see the sun rising once more over the skyline of Paris. As though dispersed by the sunlight, the figure that had been chasing you folds into the shadows and vanishes. Just as you are about to leave, you spot a plaque next to a red-brown door atop a steep, narrow staircase. It reads: \"N. Engram.\"",
         "back_text": "Check Campaign Log.\n-<i>If you intruded on a secret meeting</i>, proceed to <b>(→R2)</b>.\n-Otherwise, proceed to <b>(→R1)</b>."
@@ -69,7 +69,7 @@
     {
         "code": "03208",
         "name": "Montparnasse",
-        "text": "[lightning] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
+        "text": "[free] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
         "traits": "Paris. Rail.",
         "back_flavor": "This area is known for its cafés and bars, and is often frequented by starving artists. Perhaps some of these creative types will become famous someday. Most, you assume, will fade into obscurity."
     },

--- a/translations/pl/pack/ptc/dca.json
+++ b/translations/pl/pack/ptc/dca.json
@@ -8,7 +8,7 @@
     {
         "code": "03307",
         "name": "No Stone Unturned",
-        "text": "Fast. Play during any [lightning] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
+        "text": "Fast. Play during any [free] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
         "traits": "Insight."
     },
     {

--- a/translations/pl/pack/ptc/ptc.json
+++ b/translations/pl/pack/ptc/ptc.json
@@ -53,7 +53,7 @@
         "flavor": "Perhaps this would be her big comeback.",
         "name": "Lola Hayes",
         "subname": "The Actress",
-        "text": "<b>Forced</b> - After you draw your opening hand: Choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\nYou can only play, commit, or trigger abilities on Neutral cards or cards of your role.\n[lightning]: Switch your role. (Limit once per round.)\n[elder_sign] effect: +2. You may switch roles.",
+        "text": "<b>Forced</b> - After you draw your opening hand: Choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\nYou can only play, commit, or trigger abilities on Neutral cards or cards of your role.\n[free]: Switch your role. (Limit once per round.)\n[elder_sign] effect: +2. You may switch roles.",
         "traits": "Performer.",
         "back_flavor": "Lola has performed to sold-out houses worldwide, but no play has been as haunting or as odd as The King in Yellow. Even during rehearsals, everything about it brought calamity and dread. When her co-star, Miriam, was found floating dead in the Seine, she decided she'd had enough, and penned a letter to the director explaining that her next performance would be her last. Now she heads home to Arkham for one final show, hoping she can finally be rid of this dreadful play.",
         "back_text": "<b>Deck size</b>: 35.\n<b>Deckbuilding Options</b>: Survivor, Guardian, Seeker, Rogue, and Mystic cards ([survivor], [guardian], [seeker], [rogue], and [mystic]) level 0-3, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): 2 copies of Improvisation, 2 copies of Crisis of Identity, 1 random basic weakness.\n<b>Additional Requirements</b>: Your deck must include at least 7 cards each from 3 different classes ([survivor], [guardian], [seeker], [rogue], or [mystic])."
@@ -76,7 +76,7 @@
         "code": "03009",
         "name": "Sophie",
         "subname": "In Loving Memory",
-        "text": "Mark Harrigan deck only.\nSophie cannot leave play.\n[lightning] Take 1 direct damage: You get +2 to your skill value for this skill test.\n<b>Forced</b> - If Mark Harrigan has 5 or more damage on him: Flip Sophie.",
+        "text": "Mark Harrigan deck only.\nSophie cannot leave play.\n[free] Take 1 direct damage: You get +2 to your skill value for this skill test.\n<b>Forced</b> - If Mark Harrigan has 5 or more damage on him: Flip Sophie.",
         "traits": "Item. Spirit",
         "back_text": "Sophie cannot leave play.\nYou get -1 to each of your skills.\n<b>Forced</b> - If Mark Harrigan has 4 or less damage on him: Flip Sophie."
     },
@@ -111,13 +111,13 @@
         "code": "03014",
         "name": "Spirit-Speaker",
         "subname": "Envoy of the Alusi",
-        "text": "Akachi Onyele deck only.\n[lightning] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
+        "text": "Akachi Onyele deck only.\n[free] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
         "traits": "Ritual."
     },
     {
         "code": "03015",
         "name": "Angered Spirits",
-        "text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[lightning] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
+        "text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[free] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
         "traits": "Task."
     },
     {
@@ -252,7 +252,7 @@
     {
         "code": "03035",
         "name": "Spirit Athame",
-        "text": "[lightning] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
+        "text": "[free] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
         "traits": "Item. Relic. Weapon. Melee.",
         "slot": "Hand"
     },

--- a/translations/pl/pack/ptc/ptc_encounter.json
+++ b/translations/pl/pack/ptc/ptc_encounter.json
@@ -407,7 +407,7 @@
     {
         "code": "03084c",
         "name": "Whispers in Your Head (Anxiety)",
-        "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [lightning] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
+        "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [free] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
         "traits": "Terror."
     },
     {

--- a/translations/pl/pack/ptc/tpm_encounter.json
+++ b/translations/pl/pack/ptc/tpm_encounter.json
@@ -52,77 +52,77 @@
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When The Gate to Hell is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and below The Gate to Hell.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03248",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "Ignore the text on unrevealed locations adjacent to Stone Archways.\n<b>Forced</b> - When Stone Archways is revealed: Put the topmost Catacombs in the Catacombs deck into play to the right of Stone Archways.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03249",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "Crypt of the Sepulchral Lamp is investigated using [willpower] instead of the skill indicated by the investigation attempt.\n<b>Forced</b> - When Crypt of the Sepulchral Lamp is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and to the right of Crypt of the Sepulchral Lamp.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03250",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "While you are investigating Bone-Filled Cavern, you have 1 fewer hand slot.\n<b>Forced</b> - When Bone-Filled Cavern is revealed: Put the top 2 Catacombs in the Catacombs deck into play below and to the right of Bone-Filled Cavern.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03251",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - After you end your turn at Well of Souls: You must either take 1 direct horror or discard 2 random cards from your hand.\n<b>Forced</b> - When Well of Souls is revealed: Put the topmost Catacombs in the Catacombs deck into play above, below, or to the right of Well of Souls.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03252",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "[action]: Test [intellect] (3) to read an ancient sign. If you succeed, look at the revealed side of any Catacombs location in play. (Group limit once per game.)\n<b>Forced</b> - When Candlelit Tunnels is revealed: Put the top 2 Catacombs in the Catacombs deck into play to the left and right of Candlelit Tunnels.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03253",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When Labyrinth of Bones is revealed: Put the top 3 Catacombs in the Catacombs deck into play above, below, and to the right of Labyrinth of Bones.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03254",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When you would move from Narrow Shaft to an unrevealed location: Test [agility] (3). If you fail, take 1 damage and cancel the effects of the move.\n<b>Forced</b> - When Narrow Shaft is revealed: Put the topmost Catacombs in the Catacombs deck into play above or to the right of Narrow Shaft.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03255",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - After you end your turn at Shivering Pools: You must either take 1 direct damage or lose 5 resources.\n<b>Forced</b> - When Shivering Pools is revealed: Put the topmost Catacombs in the Catacombs deck into play below or to the right of Shivering Pools.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03256",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When you reveal Blocked Passage: Take 2 damage. You cannot leave Blocked Passage this round.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03257",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
-        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per investigator] health and cannot be defeated by his [action] ability.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per_investigator] health and cannot be defeated by his [action] ability.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03258",

--- a/translations/pl/pack/ptc/tuo.json
+++ b/translations/pl/pack/ptc/tuo.json
@@ -17,7 +17,7 @@
         "code": "03149",
         "name": "Charles Ross, Esq.",
         "subname": "Acquisitions and Solicitation",
-        "text": "You may spend resources to pay for <b>Item</b> assets played by other investigators at your location.\n[lightning] Exhaust Charles Ross, Esq.: Reduce the cost of the next <b>Item</b> asset played by an investigator at your location by 1.",
+        "text": "You may spend resources to pay for <b>Item</b> assets played by other investigators at your location.\n[free] Exhaust Charles Ross, Esq.: Reduce the cost of the next <b>Item</b> asset played by an investigator at your location by 1.",
         "traits": "Ally. Patron.",
         "slot": "Ally"
     },

--- a/translations/ru/pack/dwl/dwl_encounter.json
+++ b/translations/ru/pack/dwl/dwl_encounter.json
@@ -151,7 +151,7 @@
         "code": "02058",
         "name": "The Experiment",
         "subname": "Something Went Terribly Wrong",
-        "text": "Massive.\nThe Experiment gets +3[per investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
+        "text": "Massive.\nThe Experiment gets +3[per_investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
         "traits": "Monster. Abomination. Elite."
     },
     {
@@ -228,7 +228,7 @@
         "code": "02068",
         "flavor": "With or without Dr. Morgan, you have to get out of here. Fast.",
         "name": "All In",
-        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "back_name": "Safe... For Now",
         "back_flavor": "You escape the club, doing your best to look inconspicuous as several cars pull up near the street. A handful of grim-faced men and women exit, running toward the restaurant's entrance to take control of the situation. One of them catches your eye, his hand on the grip of his .38, but thankfully he turns his attention back to the rest of his crew and follows them into the club. You breathe a sigh of relief...",
         "back_text": "— If an investigator resigned with Dr. Francis Morgan under his or her control, <b>(→R2)</b>\n— Otherwise, <b>(→R1)</b>"
@@ -237,7 +237,7 @@
         "code": "02069",
         "flavor": "\"Free drinks for whoever gets me the hell out of here!\" A man exclaims from the bar.",
         "name": "Fold",
-        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "back_name": "Escaping the Club",
         "back_flavor": "You make your way toward the rain-slicked streets of Arkham.",
         "back_text": "— If an investigator resigned with Peter Clover under his or her control, <b>(→R3)</b>\n— Otherwise, <b>(→R1)</b>"

--- a/translations/ru/pack/dwl/tmm_encounter.json
+++ b/translations/ru/pack/dwl/tmm_encounter.json
@@ -188,7 +188,7 @@
         "code": "02141",
         "name": "Hunting Horror",
         "subname": "Spawned from the Void",
-        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto-fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
+        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
         "traits": "Monster. Elite."
     },
     {

--- a/translations/ru/pack/dwl/wda_encounter.json
+++ b/translations/ru/pack/dwl/wda_encounter.json
@@ -55,7 +55,7 @@
         "text": "Clues cannot be placed on non-<i>Altered</i> locations.\n<b>Objective</b> - When an investigator enters Sentinel Peak, advance.",
         "back_name": "Will the Change",
         "back_flavor": "Approaching the peak of Sentinel Hill, you are confronted by several citizens of Dunwich. The man in the center of their circle is desperately trying to complete a Latin incantation. \"It's not working, Seth!\" one of the other men cries out. \"What're we gonna do?\" The man in the center stops his chant and pulls out a cobbler's knife. \"The father demands a blood sacrifice,\" he declares, and his face twists into a crazed expression. Before you can react, he slits his left wrist with the knife, dropping to his knees in agony. The headstone of the altar behind him splits open. A torrent of energy pours out of the stone, coalescing into the form of an open gate. Seth holds onto the stone in front of him to prevent himself from being sucked into the gate, but several of the others are startled and pulled through it. You barely manage to dig your heels in and grab hold of a nearby rock in time to resist the pull of the gate. Seth rises, wounded but alive. An expression of pride spreads across his pained face.",
-        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per investigator] damage on him."
+        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per_investigator] damage on him."
     },
     {
         "code": "02281",
@@ -88,7 +88,7 @@
         "text": "<b>Forced</b> - When an investigator at this location draws a <i>Hex</i> card: That investigator takes 1 damage.",
         "traits": "Dunwich. Sentinel Hill.",
         "back_flavor": "An arcane wall blocks the path further up the hill, leading towards the peak.",
-        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per investigator] clues, as a group"
+        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per_investigator] clues, as a group"
     },
     {
         "code": "02285",

--- a/translations/ru/pack/ptc/apot.json
+++ b/translations/ru/pack/ptc/apot.json
@@ -65,7 +65,7 @@
         "code": "03198",
         "name": "Madame Labranche",
         "subname": "Mysterious Benefactress",
-        "text": "[lightning] If you have no cards in your hand, exhaust Madame Labranche: Draw 1 card.\n[lightning] If you have no resources, exhaust Madame Labranche: Gain 1 resource.",
+        "text": "[free] If you have no cards in your hand, exhaust Madame Labranche: Draw 1 card.\n[free] If you have no resources, exhaust Madame Labranche: Gain 1 resource.",
         "traits": "Ally. Patron.",
         "slot": "Ally"
     },

--- a/translations/ru/pack/ptc/apot_encounter.json
+++ b/translations/ru/pack/ptc/apot_encounter.json
@@ -61,7 +61,7 @@
         "code": "03207",
         "flavor": "I knew that every time I met him brought him nearer to the accomplishment of his purpose and my fate. And still I tried to save myself.\n–Robert W. Chambers, \"In the Court of the Dragon,\" <u>The King in Yellow</u>",
         "name": "Stalked by Shadows",
-        "text": "[lightning] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
+        "text": "[free] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
         "back_name": "Shepherd's Crook",
         "back_flavor": "You lose track of yourself within the city as you flee for your life. Your feet move of their own accord. The beating of sinewy wings and screeching of creatures above you spurs you onward. Soon you find yourself running down a narrow avenue, passing a set of heavy iron gates. You are in a dead end - a court with tall, old houses on either side. You turn back toward the entrance and breathe a sigh of relief as you see the sun rising once more over the skyline of Paris. As though dispersed by the sunlight, the figure that had been chasing you folds into the shadows and vanishes. Just as you are about to leave, you spot a plaque next to a red-brown door atop a steep, narrow staircase. It reads: \"N. Engram.\"",
         "back_text": "Check Campaign Log.\n-<i>If you intruded on a secret meeting</i>, proceed to <b>(→R2)</b>.\n-Otherwise, proceed to <b>(→R1)</b>."
@@ -69,7 +69,7 @@
     {
         "code": "03208",
         "name": "Montparnasse",
-        "text": "[lightning] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
+        "text": "[free] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
         "traits": "Paris. Rail.",
         "back_flavor": "This area is known for its cafés and bars, and is often frequented by starving artists. Perhaps some of these creative types will become famous someday. Most, you assume, will fade into obscurity."
     },

--- a/translations/ru/pack/ptc/dca.json
+++ b/translations/ru/pack/ptc/dca.json
@@ -8,7 +8,7 @@
     {
         "code": "03307",
         "name": "No Stone Unturned",
-        "text": "Fast. Play during any [lightning] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
+        "text": "Fast. Play during any [free] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
         "traits": "Insight."
     },
     {

--- a/translations/ru/pack/ptc/ptc.json
+++ b/translations/ru/pack/ptc/ptc.json
@@ -53,7 +53,7 @@
         "flavor": "Perhaps this would be her big comeback.",
         "name": "Lola Hayes",
         "subname": "The Actress",
-        "text": "<b>Forced</b> - After you draw your opening hand: Choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\nYou can only play, commit, or trigger abilities on Neutral cards or cards of your role.\n[lightning]: Switch your role. (Limit once per round.)\n[elder_sign] effect: +2. You may switch roles.",
+        "text": "<b>Forced</b> - After you draw your opening hand: Choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\nYou can only play, commit, or trigger abilities on Neutral cards or cards of your role.\n[free]: Switch your role. (Limit once per round.)\n[elder_sign] effect: +2. You may switch roles.",
         "traits": "Performer.",
         "back_flavor": "Lola has performed to sold-out houses worldwide, but no play has been as haunting or as odd as The King in Yellow. Even during rehearsals, everything about it brought calamity and dread. When her co-star, Miriam, was found floating dead in the Seine, she decided she'd had enough, and penned a letter to the director explaining that her next performance would be her last. Now she heads home to Arkham for one final show, hoping she can finally be rid of this dreadful play.",
         "back_text": "<b>Deck size</b>: 35.\n<b>Deckbuilding Options</b>: Survivor, Guardian, Seeker, Rogue, and Mystic cards ([survivor], [guardian], [seeker], [rogue], and [mystic]) level 0-3, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): 2 copies of Improvisation, 2 copies of Crisis of Identity, 1 random basic weakness.\n<b>Additional Requirements</b>: Your deck must include at least 7 cards each from 3 different classes ([survivor], [guardian], [seeker], [rogue], or [mystic])."
@@ -76,7 +76,7 @@
         "code": "03009",
         "name": "Sophie",
         "subname": "In Loving Memory",
-        "text": "Mark Harrigan deck only.\nSophie cannot leave play.\n[lightning] Take 1 direct damage: You get +2 to your skill value for this skill test.\n<b>Forced</b> - If Mark Harrigan has 5 or more damage on him: Flip Sophie.",
+        "text": "Mark Harrigan deck only.\nSophie cannot leave play.\n[free] Take 1 direct damage: You get +2 to your skill value for this skill test.\n<b>Forced</b> - If Mark Harrigan has 5 or more damage on him: Flip Sophie.",
         "traits": "Item. Spirit",
         "back_text": "Sophie cannot leave play.\nYou get -1 to each of your skills.\n<b>Forced</b> - If Mark Harrigan has 4 or less damage on him: Flip Sophie."
     },
@@ -111,13 +111,13 @@
         "code": "03014",
         "name": "Spirit-Speaker",
         "subname": "Envoy of the Alusi",
-        "text": "Akachi Onyele deck only.\n[lightning] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
+        "text": "Akachi Onyele deck only.\n[free] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
         "traits": "Ritual."
     },
     {
         "code": "03015",
         "name": "Angered Spirits",
-        "text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[lightning] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
+        "text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[free] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
         "traits": "Task."
     },
     {
@@ -252,7 +252,7 @@
     {
         "code": "03035",
         "name": "Spirit Athame",
-        "text": "[lightning] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
+        "text": "[free] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
         "traits": "Item. Relic. Weapon. Melee.",
         "slot": "Hand"
     },

--- a/translations/ru/pack/ptc/ptc_encounter.json
+++ b/translations/ru/pack/ptc/ptc_encounter.json
@@ -407,7 +407,7 @@
     {
         "code": "03084c",
         "name": "Whispers in Your Head (Anxiety)",
-        "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [lightning] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
+        "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [free] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
         "traits": "Terror."
     },
     {

--- a/translations/ru/pack/ptc/tpm_encounter.json
+++ b/translations/ru/pack/ptc/tpm_encounter.json
@@ -52,77 +52,77 @@
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When The Gate to Hell is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and below The Gate to Hell.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03248",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "Ignore the text on unrevealed locations adjacent to Stone Archways.\n<b>Forced</b> - When Stone Archways is revealed: Put the topmost Catacombs in the Catacombs deck into play to the right of Stone Archways.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03249",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "Crypt of the Sepulchral Lamp is investigated using [willpower] instead of the skill indicated by the investigation attempt.\n<b>Forced</b> - When Crypt of the Sepulchral Lamp is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and to the right of Crypt of the Sepulchral Lamp.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03250",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "While you are investigating Bone-Filled Cavern, you have 1 fewer hand slot.\n<b>Forced</b> - When Bone-Filled Cavern is revealed: Put the top 2 Catacombs in the Catacombs deck into play below and to the right of Bone-Filled Cavern.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03251",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - After you end your turn at Well of Souls: You must either take 1 direct horror or discard 2 random cards from your hand.\n<b>Forced</b> - When Well of Souls is revealed: Put the topmost Catacombs in the Catacombs deck into play above, below, or to the right of Well of Souls.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03252",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "[action]: Test [intellect] (3) to read an ancient sign. If you succeed, look at the revealed side of any Catacombs location in play. (Group limit once per game.)\n<b>Forced</b> - When Candlelit Tunnels is revealed: Put the top 2 Catacombs in the Catacombs deck into play to the left and right of Candlelit Tunnels.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03253",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When Labyrinth of Bones is revealed: Put the top 3 Catacombs in the Catacombs deck into play above, below, and to the right of Labyrinth of Bones.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03254",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When you would move from Narrow Shaft to an unrevealed location: Test [agility] (3). If you fail, take 1 damage and cancel the effects of the move.\n<b>Forced</b> - When Narrow Shaft is revealed: Put the topmost Catacombs in the Catacombs deck into play above or to the right of Narrow Shaft.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03255",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - After you end your turn at Shivering Pools: You must either take 1 direct damage or lose 5 resources.\n<b>Forced</b> - When Shivering Pools is revealed: Put the topmost Catacombs in the Catacombs deck into play below or to the right of Shivering Pools.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03256",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When you reveal Blocked Passage: Take 2 damage. You cannot leave Blocked Passage this round.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03257",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
-        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per investigator] health and cannot be defeated by his [action] ability.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per_investigator] health and cannot be defeated by his [action] ability.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03258",

--- a/translations/ru/pack/ptc/tuo.json
+++ b/translations/ru/pack/ptc/tuo.json
@@ -17,7 +17,7 @@
         "code": "03149",
         "name": "Charles Ross, Esq.",
         "subname": "Acquisitions and Solicitation",
-        "text": "You may spend resources to pay for <b>Item</b> assets played by other investigators at your location.\n[lightning] Exhaust Charles Ross, Esq.: Reduce the cost of the next <b>Item</b> asset played by an investigator at your location by 1.",
+        "text": "You may spend resources to pay for <b>Item</b> assets played by other investigators at your location.\n[free] Exhaust Charles Ross, Esq.: Reduce the cost of the next <b>Item</b> asset played by an investigator at your location by 1.",
         "traits": "Ally. Patron.",
         "slot": "Ally"
     },

--- a/translations/zh/pack/dwl/dwl_encounter.json
+++ b/translations/zh/pack/dwl/dwl_encounter.json
@@ -151,7 +151,7 @@
         "code": "02058",
         "name": "The Experiment",
         "subname": "Something Went Terribly Wrong",
-        "text": "Massive.\nThe Experiment gets +3[per investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
+        "text": "Massive.\nThe Experiment gets +3[per_investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
         "traits": "Monster. Abomination. Elite."
     },
     {
@@ -228,7 +228,7 @@
         "code": "02068",
         "flavor": "With or without Dr. Morgan, you have to get out of here. Fast.",
         "name": "All In",
-        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "back_name": "Safe... For Now",
         "back_flavor": "You escape the club, doing your best to look inconspicuous as several cars pull up near the street. A handful of grim-faced men and women exit, running toward the restaurant's entrance to take control of the situation. One of them catches your eye, his hand on the grip of his .38, but thankfully he turns his attention back to the rest of his crew and follows them into the club. You breathe a sigh of relief...",
         "back_text": "— If an investigator resigned with Dr. Francis Morgan under his or her control, <b>(→R2)</b>\n— Otherwise, <b>(→R1)</b>"
@@ -237,7 +237,7 @@
         "code": "02069",
         "flavor": "\"Free drinks for whoever gets me the hell out of here!\" A man exclaims from the bar.",
         "name": "Fold",
-        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
+        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
         "back_name": "Escaping the Club",
         "back_flavor": "You make your way toward the rain-slicked streets of Arkham.",
         "back_text": "— If an investigator resigned with Peter Clover under his or her control, <b>(→R3)</b>\n— Otherwise, <b>(→R1)</b>"

--- a/translations/zh/pack/dwl/tmm_encounter.json
+++ b/translations/zh/pack/dwl/tmm_encounter.json
@@ -188,7 +188,7 @@
         "code": "02141",
         "name": "Hunting Horror",
         "subname": "Spawned from the Void",
-        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto-fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
+        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
         "traits": "Monster. Elite."
     },
     {

--- a/translations/zh/pack/dwl/wda_encounter.json
+++ b/translations/zh/pack/dwl/wda_encounter.json
@@ -55,7 +55,7 @@
         "text": "Clues cannot be placed on non-<i>Altered</i> locations.\n<b>Objective</b> - When an investigator enters Sentinel Peak, advance.",
         "back_name": "Will the Change",
         "back_flavor": "Approaching the peak of Sentinel Hill, you are confronted by several citizens of Dunwich. The man in the center of their circle is desperately trying to complete a Latin incantation. \"It's not working, Seth!\" one of the other men cries out. \"What're we gonna do?\" The man in the center stops his chant and pulls out a cobbler's knife. \"The father demands a blood sacrifice,\" he declares, and his face twists into a crazed expression. Before you can react, he slits his left wrist with the knife, dropping to his knees in agony. The headstone of the altar behind him splits open. A torrent of energy pours out of the stone, coalescing into the form of an open gate. Seth holds onto the stone in front of him to prevent himself from being sucked into the gate, but several of the others are startled and pulled through it. You barely manage to dig your heels in and grab hold of a nearby rock in time to resist the pull of the gate. Seth rises, wounded but alive. An expression of pride spreads across his pained face.",
-        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per investigator] damage on him."
+        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per_investigator] damage on him."
     },
     {
         "code": "02281",
@@ -88,7 +88,7 @@
         "text": "<b>Forced</b> - When an investigator at this location draws a <i>Hex</i> card: That investigator takes 1 damage.",
         "traits": "Dunwich. Sentinel Hill.",
         "back_flavor": "An arcane wall blocks the path further up the hill, leading towards the peak.",
-        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per investigator] clues, as a group"
+        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per_investigator] clues, as a group"
     },
     {
         "code": "02285",

--- a/translations/zh/pack/ptc/apot.json
+++ b/translations/zh/pack/ptc/apot.json
@@ -65,7 +65,7 @@
         "code": "03198",
         "name": "Madame Labranche",
         "subname": "Mysterious Benefactress",
-        "text": "[lightning] If you have no cards in your hand, exhaust Madame Labranche: Draw 1 card.\n[lightning] If you have no resources, exhaust Madame Labranche: Gain 1 resource.",
+        "text": "[free] If you have no cards in your hand, exhaust Madame Labranche: Draw 1 card.\n[free] If you have no resources, exhaust Madame Labranche: Gain 1 resource.",
         "traits": "Ally. Patron.",
         "slot": "Ally"
     },

--- a/translations/zh/pack/ptc/apot_encounter.json
+++ b/translations/zh/pack/ptc/apot_encounter.json
@@ -61,7 +61,7 @@
         "code": "03207",
         "flavor": "I knew that every time I met him brought him nearer to the accomplishment of his purpose and my fate. And still I tried to save myself.\n–Robert W. Chambers, \"In the Court of the Dragon,\" <u>The King in Yellow</u>",
         "name": "Stalked by Shadows",
-        "text": "[lightning] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
+        "text": "[free] Spend 1 [per_investigator] clues, as a group: Either place 1 doom on the current agenda, or automatically evade The Organist. (Group limit once per round.)\n<b>Objective</b> - Survive three nights. <i>(Do not advance until you are instructed.)</i>",
         "back_name": "Shepherd's Crook",
         "back_flavor": "You lose track of yourself within the city as you flee for your life. Your feet move of their own accord. The beating of sinewy wings and screeching of creatures above you spurs you onward. Soon you find yourself running down a narrow avenue, passing a set of heavy iron gates. You are in a dead end - a court with tall, old houses on either side. You turn back toward the entrance and breathe a sigh of relief as you see the sun rising once more over the skyline of Paris. As though dispersed by the sunlight, the figure that had been chasing you folds into the shadows and vanishes. Just as you are about to leave, you spot a plaque next to a red-brown door atop a steep, narrow staircase. It reads: \"N. Engram.\"",
         "back_text": "Check Campaign Log.\n-<i>If you intruded on a secret meeting</i>, proceed to <b>(→R2)</b>.\n-Otherwise, proceed to <b>(→R1)</b>."
@@ -69,7 +69,7 @@
     {
         "code": "03208",
         "name": "Montparnasse",
-        "text": "[lightning] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
+        "text": "[free] Discard a card from your hand: Gain resources equal to the number of [willpower] icons on the discarded card. (Limit once per round.)",
         "traits": "Paris. Rail.",
         "back_flavor": "This area is known for its cafés and bars, and is often frequented by starving artists. Perhaps some of these creative types will become famous someday. Most, you assume, will fade into obscurity."
     },

--- a/translations/zh/pack/ptc/dca.json
+++ b/translations/zh/pack/ptc/dca.json
@@ -8,7 +8,7 @@
     {
         "code": "03307",
         "name": "No Stone Unturned",
-        "text": "Fast. Play during any [lightning] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
+        "text": "Fast. Play during any [free] player window.\nChoose an investigator at your location. That investigator searches his or her deck for a card, draws it, and shuffles his or her deck.",
         "traits": "Insight."
     },
     {

--- a/translations/zh/pack/ptc/ptc.json
+++ b/translations/zh/pack/ptc/ptc.json
@@ -53,7 +53,7 @@
         "flavor": "Perhaps this would be her big comeback.",
         "name": "Lola Hayes",
         "subname": "The Actress",
-        "text": "<b>Forced</b> - After you draw your opening hand: Choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\nYou can only play, commit, or trigger abilities on Neutral cards or cards of your role.\n[lightning]: Switch your role. (Limit once per round.)\n[elder_sign] effect: +2. You may switch roles.",
+        "text": "<b>Forced</b> - After you draw your opening hand: Choose a role ([survivor], [guardian], [seeker], [rogue], [mystic], or Neutral).\nYou can only play, commit, or trigger abilities on Neutral cards or cards of your role.\n[free]: Switch your role. (Limit once per round.)\n[elder_sign] effect: +2. You may switch roles.",
         "traits": "Performer.",
         "back_flavor": "Lola has performed to sold-out houses worldwide, but no play has been as haunting or as odd as The King in Yellow. Even during rehearsals, everything about it brought calamity and dread. When her co-star, Miriam, was found floating dead in the Seine, she decided she'd had enough, and penned a letter to the director explaining that her next performance would be her last. Now she heads home to Arkham for one final show, hoping she can finally be rid of this dreadful play.",
         "back_text": "<b>Deck size</b>: 35.\n<b>Deckbuilding Options</b>: Survivor, Guardian, Seeker, Rogue, and Mystic cards ([survivor], [guardian], [seeker], [rogue], and [mystic]) level 0-3, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): 2 copies of Improvisation, 2 copies of Crisis of Identity, 1 random basic weakness.\n<b>Additional Requirements</b>: Your deck must include at least 7 cards each from 3 different classes ([survivor], [guardian], [seeker], [rogue], or [mystic])."
@@ -76,7 +76,7 @@
         "code": "03009",
         "name": "Sophie",
         "subname": "In Loving Memory",
-        "text": "Mark Harrigan deck only.\nSophie cannot leave play.\n[lightning] Take 1 direct damage: You get +2 to your skill value for this skill test.\n<b>Forced</b> - If Mark Harrigan has 5 or more damage on him: Flip Sophie.",
+        "text": "Mark Harrigan deck only.\nSophie cannot leave play.\n[free] Take 1 direct damage: You get +2 to your skill value for this skill test.\n<b>Forced</b> - If Mark Harrigan has 5 or more damage on him: Flip Sophie.",
         "traits": "Item. Spirit",
         "back_text": "Sophie cannot leave play.\nYou get -1 to each of your skills.\n<b>Forced</b> - If Mark Harrigan has 4 or less damage on him: Flip Sophie."
     },
@@ -111,13 +111,13 @@
         "code": "03014",
         "name": "Spirit-Speaker",
         "subname": "Envoy of the Alusi",
-        "text": "Akachi Onyele deck only.\n[lightning] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
+        "text": "Akachi Onyele deck only.\n[free] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
         "traits": "Ritual."
     },
     {
         "code": "03015",
         "name": "Angered Spirits",
-        "text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[lightning] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
+        "text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[free] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
         "traits": "Task."
     },
     {
@@ -252,7 +252,7 @@
     {
         "code": "03035",
         "name": "Spirit Athame",
-        "text": "[lightning] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
+        "text": "[free] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
         "traits": "Item. Relic. Weapon. Melee.",
         "slot": "Hand"
     },

--- a/translations/zh/pack/ptc/ptc_encounter.json
+++ b/translations/zh/pack/ptc/ptc_encounter.json
@@ -407,7 +407,7 @@
     {
         "code": "03084c",
         "name": "Whispers in Your Head (Anxiety)",
-        "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [lightning] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
+        "text": "Peril. Hidden.\n<b>Revelation</b> - Secretly add Whispers in Your Head (Anxiety) to your hand.\nYou cannot trigger [free] abilities.\n[action][action]: Discard Whispers in Your Head (Anxiety) from your hand.",
         "traits": "Terror."
     },
     {

--- a/translations/zh/pack/ptc/tpm_encounter.json
+++ b/translations/zh/pack/ptc/tpm_encounter.json
@@ -52,77 +52,77 @@
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When The Gate to Hell is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and below The Gate to Hell.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03248",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "Ignore the text on unrevealed locations adjacent to Stone Archways.\n<b>Forced</b> - When Stone Archways is revealed: Put the topmost Catacombs in the Catacombs deck into play to the right of Stone Archways.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03249",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "Crypt of the Sepulchral Lamp is investigated using [willpower] instead of the skill indicated by the investigation attempt.\n<b>Forced</b> - When Crypt of the Sepulchral Lamp is revealed: Put the top 2 Catacombs in the Catacombs deck into play above and to the right of Crypt of the Sepulchral Lamp.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03250",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "While you are investigating Bone-Filled Cavern, you have 1 fewer hand slot.\n<b>Forced</b> - When Bone-Filled Cavern is revealed: Put the top 2 Catacombs in the Catacombs deck into play below and to the right of Bone-Filled Cavern.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03251",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - After you end your turn at Well of Souls: You must either take 1 direct horror or discard 2 random cards from your hand.\n<b>Forced</b> - When Well of Souls is revealed: Put the topmost Catacombs in the Catacombs deck into play above, below, or to the right of Well of Souls.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03252",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "[action]: Test [intellect] (3) to read an ancient sign. If you succeed, look at the revealed side of any Catacombs location in play. (Group limit once per game.)\n<b>Forced</b> - When Candlelit Tunnels is revealed: Put the top 2 Catacombs in the Catacombs deck into play to the left and right of Candlelit Tunnels.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03253",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When Labyrinth of Bones is revealed: Put the top 3 Catacombs in the Catacombs deck into play above, below, and to the right of Labyrinth of Bones.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03254",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When you would move from Narrow Shaft to an unrevealed location: Test [agility] (3). If you fail, take 1 damage and cancel the effects of the move.\n<b>Forced</b> - When Narrow Shaft is revealed: Put the topmost Catacombs in the Catacombs deck into play above or to the right of Narrow Shaft.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03255",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - After you end your turn at Shivering Pools: You must either take 1 direct damage or lose 5 resources.\n<b>Forced</b> - When Shivering Pools is revealed: Put the topmost Catacombs in the Catacombs deck into play below or to the right of Shivering Pools.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03256",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
         "text": "<b>Forced</b> - When you reveal Blocked Passage: Take 2 damage. You cannot leave Blocked Passage this round.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03257",
         "flavor": "Skulls and bones decorate the walls of this wide hallway in a macabre fashion.",
         "name": "Catacombs",
-        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per investigator] health and cannot be defeated by his [action] ability.",
-        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per investigator] clues, as a group."
+        "text": "<b>Forced</b> - When Tomb of Shadows is revealed: Advance to act 1b.\nWhile The Man in the Pallid Mask is at the Tomb of Shadows, he gets +1[per_investigator] health and cannot be defeated by his [action] ability.",
+        "back_text": "As an additional cost for you to enter Catacombs, investigators at your location must spend 1[per_investigator] clues, as a group."
     },
     {
         "code": "03258",

--- a/translations/zh/pack/ptc/tuo.json
+++ b/translations/zh/pack/ptc/tuo.json
@@ -17,7 +17,7 @@
         "code": "03149",
         "name": "Charles Ross, Esq.",
         "subname": "Acquisitions and Solicitation",
-        "text": "You may spend resources to pay for <b>Item</b> assets played by other investigators at your location.\n[lightning] Exhaust Charles Ross, Esq.: Reduce the cost of the next <b>Item</b> asset played by an investigator at your location by 1.",
+        "text": "You may spend resources to pay for <b>Item</b> assets played by other investigators at your location.\n[free] Exhaust Charles Ross, Esq.: Reduce the cost of the next <b>Item</b> asset played by an investigator at your location by 1.",
         "traits": "Ally. Patron.",
         "slot": "Ally"
     },


### PR DESCRIPTION
[auto-fail] => [auto_fail]
[per investigator] => [per_investigator]
[lightning] => [fast]

Not sure about that last one, but [fast] seemed more prevalent in the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kamalisk/arkhamdb-json-data/198)
<!-- Reviewable:end -->
