### PR TITLE
German Translation of Dunwich

### DIFF
--- a/translations/de/pack/core/core.json
+++ b/translations/de/pack/core/core.json
@@ -101,7 +101,7 @@
         "subname": "Artefakt aus einem anderen Leben",
         "text": "Nur für das Deck von Agnes Baker.\n[reaction] Nachdem du eine <i>Zauber</i>-Karte gespielt hast: Ziehe 1 Karte.",
         "traits": "Gegenstand. Relikt.",
-        "slot": "Accessory"
+        "slot": "Zubehör"
     },
     {
         "code": "01013",
@@ -115,7 +115,7 @@
         "name": "Wendys Amulett",
         "text": "Nur für das Deck von Wendy Adams.\nDu darfst das oberste Ereignis in deinem Ablagestapel spielen, als ob es sich auf deiner Hand befände.\n<b>Erzwungen</b> - Nachdem du ein Ereignis gespielt hast: Platziere es unter dein Deck statt auf deinen Ablagestapel.",
         "traits": "Gegenstand. Relikt.",
-        "slot": "Accessory"
+        "slot": "Zubehör"
     },
     {
         "code": "01015",
@@ -142,7 +142,7 @@
         "name": "Streifenpolizist",
         "text": "Du bekommst +1 [combat].\n[free] Lege Streifenpolizist ab: Füge einem Gegner an deinem Ort 1 Schaden zu.",
         "traits": "Verbündeter. Polizei.",
-        "slot": "Ally"
+        "slot": "Verbündeter"
     },
     {
         "code": "01019",
@@ -164,7 +164,7 @@
         "name": "Wachհսnd",
         "text": "[reaction] Sobald ein Gegnerangriff Wachhund Schaden zufügt: Füge dem angreifenden Gegner 1 Schaden zu.",
         "traits": "Verbündeter. Kreatur.",
-        "slot": "Ally"
+        "slot": "Verbündeter"
     },
     {
         "code": "01022",
@@ -204,14 +204,14 @@
         "name": "Polizeimarke",
         "text": "Du bekommst +1 [willpower].\n[free] Solange ein Ermittler an deinem Ort seinen Zug nimmt, lege Polizeimarke ab: Dieser Ermittler darf in diesem Zug 2 zusätzliche Aktionen nehmen.",
         "traits": "Gegenstand.",
-        "slot": "Accessory"
+        "slot": "Zubehör"
     },
     {
         "code": "01028",
         "name": "Streifenpolizist",
         "text": "Du bekommst +1 [combat].\n[free] Erschöpfe Streifenpolizist und füge dieser Karte 1 Schaden zu: Füge einem Gegner an deinem Ort 1 Schaden zu.",
         "traits": "Verbündeter. Polizei.",
-        "slot": "Ally"
+        "slot": "Verbündeter"
     },
     {
         "code": "01029",
@@ -241,7 +241,7 @@
         "name": "Forschungsbibliothekar",
         "text": "[reaction] Nachdem Forschungsbibliothekar ins Spiel gekommen ist: Durchsuche dein Deck nach einer <i>Buch</i>-Vorteilskarte und füge sie deiner Hand hinzu. Mische dein Deck.",
         "traits": "Verbündeter. Miskatonic.",
-        "slot": "Ally"
+        "slot": "Verbündeter"
     },
     {
         "code": "01033",
@@ -250,7 +250,7 @@
         "subname": "Professor für Entomologie",
         "text": "Du bekommst +1 [intellect].\n[reaction] Nachdem du erfolgreich ermittelt hast: Erhalte 1 Ressource.",
         "traits": "Verbündeter. Miskatonic.",
-        "slot": "Ally"
+        "slot": "Verbündeter"
     },
     {
         "code": "01034",
@@ -305,7 +305,7 @@
         "subname": "Schutzamulett",
         "text": "[reaction] Sobald ein Nicht-<i>Elite</i>-Gegner an deinem Ort erscheint, lege Scheibe von Itzamna ab: Lege diesen Gegner ab.",
         "traits": "Gegenstand. Relikt.",
-        "slot": "Accessory"
+        "slot": "Zubehör"
     },
     {
         "code": "01042",
@@ -354,7 +354,7 @@
         "subname": "Der Löwe von Louisiana",
         "text": "Du darfst in deinem Zug eine zusätzliche Aktion nehmen.",
         "traits": "Verbündeter. Krimineller.",
-        "slot": "Ally"
+        "slot": "Verbündeter"
     },
     {
         "code": "01049",
@@ -393,14 +393,14 @@
         "subname": "Der Löwe von Louisiana",
         "text": "Du darfst in deinem Zug eine zusätzliche Aktion nehmen.",
         "traits": "Verbündeter. Krimineller.",
-        "slot": "Ally"
+        "slot": "Verbündeter"
     },
     {
         "code": "01055",
         "name": "Einbrecher",
         "text": "Du bekommst +1 [agility].\n[action] Erschöpfe Einbrecher: Löse dich von jedem Gegner, der mit dir in einen Kampf verwickelt ist, und bewege dich auf einen verbundenen Ort. Diese Aktion provoziert keine Gelegenheitsangriffe.",
         "traits": "Verbündeter. Krimineller.",
-        "slot": "Ally"
+        "slot": "Verbündeter"
     },
     {
         "code": "01056",
@@ -427,21 +427,21 @@
         "name": "Heiliger Rosenkranz",
         "text": "Du bekommst +1 [willpower].",
         "traits": "Gegenstand. Glücksbringer.",
-        "slot": "Accessory"
+        "slot": "Zubehör"
     },
     {
         "code": "01060",
         "name": "Vertrocknen",
         "text": "Anwendungen (4 Ladungen).\n[action] Gib 1 Ladung aus: <b>Kampf.</b> Dieser Angriff verwendet [willpower] statt [combat] und fügt +1 Schaden zu. Falls während dieses Angriffs ein [skull]-, [cultist]-, [tablet]-, [elder_thing]-, oder [auto_fail]-Symbol enthüllt wird, nimmst du 1 Horror.",
         "traits": "Zauber.",
-        "slot": "Arcane"
+        "slot": "Arkan"
     },
     {
         "code": "01061",
         "name": "Die Zukunft vorhersagen",
         "text": "Anwendungen (3 Ladungen).\n[action] Erschöpfe Die Zukunft vorhersagen und gib 1 Ladung aus: Sieh dir die obersten 3 Karten des Decks eines beliebigen Ermittlers oder des Begegnungsdecks an. Schicke diese Karten in beliebiger Reihenfolge oben auf das Deck zurück.",
         "traits": "Zauber.",
-        "slot": "Arcane"
+        "slot": "Arkan"
     },
     {
         "code": "01062",
@@ -454,7 +454,7 @@
         "name": "Eingeweihte der arkanen Künste",
         "text": "<b>Erzwungen</b> - Nachdem Eingeweihte der arkanen Künste ins Spiel gekommen ist: Platziere 1 Verderbensmarker auf sie.\n[free] Erschöpfe Eingeweihte der arkanen Künste: Durchsuche die obersten 3 Karten deines Decks nach einer <i>Zauber</i>-Karte und ziehe sie. Mische dein Deck.",
         "traits": "Verbündeter. Zauberer.",
-        "slot": "Ally"
+        "slot": "Verbündeter"
     },
     {
         "code": "01064",
@@ -513,7 +513,7 @@
         "flavor": "Der Mantel war nicht unbedingt die modischste Wahl, aber weil er so dick war, fühlte er sich warm und beruhigend an.",
         "name": "Ledermantel",
         "traits": "Gegenstand. Rüstung.",
-        "slot": "Body"
+        "slot": "Körper"
     },
     {
         "code": "01073",
@@ -534,7 +534,7 @@
         "name": "Hasenpfote",
         "text": "[reaction] Nachdem dir eine Fertigkeitsprobe misslingt, erschöpfe Hasenpfote: Ziehe 1 Karte.",
         "traits": "Gegenstand. Glücksbringer.",
-        "slot": "Accessory"
+        "slot": "Zubehör"
     },
     {
         "code": "01076",
@@ -542,7 +542,7 @@
         "name": "Streunende Katze",
         "text": "[free] Lege Streunende Katze ab: Du entkommst automatisch einem Nicht-<i>Elite</i>-Gegner an deinem Ort.",
         "traits": "Verbündeter. Kreatur.",
-        "slot": "Ally"
+        "slot": "Verbündeter"
     },
     {
         "code": "01077",
@@ -582,7 +582,7 @@
         "subname": "Die vergessene Tochter",
         "text": "[reaction] Sobald dich ein Gegner angreift, erschöpfe Aquinnah und füge ihr 1 Horror zu: Füge den Schaden des Gegners stattdessen einem anderen Gegner an deinem Ort zu. (Du nimmst immer noch den Horror, der durch diesen Angriff zugefügt wird.)",
         "traits": "Verbündeter.",
-        "slot": "Ally"
+        "slot": "Verbündeter"
     },
     {
         "code": "01083",
@@ -663,14 +663,14 @@
         "flavor": "Kugeln sind eine Sache ... 30 Zentimeter lange Fangzähne etwas ganz anderes.",
         "name": "Kugelsichere Weste",
         "traits": "Gegenstand. Rüstung.",
-        "slot": "Body"
+        "slot": "Körper"
     },
     {
         "code": "01095",
         "flavor": "Es befindet sich schon seit Jahren im Besitz meiner Familie. Pass gut darauf auf und es wird gut auf dich aufpassen.",
         "name": "Amulett des Älteren Zeichens",
         "traits": "Gegenstand. Relikt.",
-        "slot": "Accessory"
+        "slot": "Zubehör"
     },
     {
         "code": "01096",

--- a/translations/de/pack/core/core_encounter.json
+++ b/translations/de/pack/core/core_encounter.json
@@ -102,7 +102,7 @@
         "subname": "The Zealot",
         "text": "While you control Lita Chantler, she gains:\n\"Each investigator at your location gets +1 [combat].\n[reaction] When an investigator at your location successfully attacks a <i>Monster</i> enemy: That investigator deals +1 damage.\"",
         "traits": "Ally.",
-        "slot": "Ally"
+        "slot": "Verbündeter"
     },
     {
         "code": "01118",

--- a/translations/de/pack/dwl/bota.json
+++ b/translations/de/pack/dwl/bota.json
@@ -1,71 +1,71 @@
 [
     {
         "code": "02184",
-        "name": "Prepared for the Worst",
-        "text": "Search the top 9 cards of your deck for a <i>Weapon</i> asset and add it to your hand. Shuffle your deck.",
-        "traits": "Tactic."
+        "name": "Auf das Schlimmste vorbereitet",
+        "text": "Durchsuche die obersten 9 Karten deines Decks nach einer <i>Waffe</i>-Vorteilskarte und füge sie deiner Hand hinzu. Mische dein Deck.",
+        "traits": "Taktik."
     },
     {
         "code": "02185",
-        "name": "Keen Eye",
-        "text": "Permanent.\n[free] Spend 2 resources: You get +1 [intellect] until the end of the phase.\n[free] Spend 2 resources: You get +1 [combat] until the end of the phase.",
+        "name": "Scharfes Auge",
+        "text": "Dauerhaft.\n[free] Gib 2 Ressourcen aus: Du bekommst bis zum Ende der Phase +1 [intellect].\n[free] Gib 2 Ressourcen aus: Du bekommst bis zum Ende der Phase +1 [combat].",
         "traits": "Talent."
     },
     {
         "code": "02186",
-        "name": "Preposterous Sketches",
-        "text": "Play only if there is a clue on your location.\nDraw 3 cards.",
-        "traits": "Insight."
+        "name": "Absonderliche Zeichnungen",
+        "text": "Spiele diese Karte nur, falls sich ein Hinweis auf deinem Ort befindet.\nZiehe 3 Karten.",
+        "traits": "Erkenntnis."
     },
     {
         "code": "02187",
-        "name": "Higher Education",
-        "text": "Permanent.\nWhile you have 5 or more cards in your hand, Higher Education gains:\n\"[free] Spend 1 resource: You get +2 [willpower] for this skill test.\n[free] Spend 1 resource: You get +2 [intellect] for this skill test.\"",
+        "name": "Höhere Bildung",
+        "text": "Dauerhaft.\nSolange du 5 oder mehr Karten auf der Hand hast, erhält Höhere Bildung:\n\"[free] Gib 1 Ressource aus: Du bekommst für diese Fertigkeitsprobe +2 [willpower].\n[free] Gib 1 Ressource aus: Du bekommst für diese Fertigkeitsprobe +2 [intellect].\"",
         "traits": "Talent."
     },
     {
         "code": "02188",
-        "flavor": "“I never mind being on my own. That’s when I do my best work.”",
-        "name": "Lone Wolf",
-        "text": "Limit 1 per investigator.\n[reaction] When your turn begins, if there are no other investigators at your location: Gain 1 resource.",
+        "flavor": "“Es macht mir nichts aus, allein zu arbeiten. Allein arbeite ich am besten.”",
+        "name": "Einsamer Wolf",
+        "text": "Nur 1 pro Ermittler.\n[reaction] Sobald dein Zug beginnt, falls sich keine anderen Ermittler an deinem Ort befinden: Du erhälst 1 Ressource.",
         "traits": "Talent."
     },
     {
         "code": "02189",
-        "name": "Streetwise",
-        "text": "Permanent.\n[free] </b>Spend 2 resources: You get +3 [intellect] for this skill test.\n[free] Spend 2 resources: You get +3 [agility] for this skill test.",
+        "name": "Gewieft",
+        "text": "Dauerhaft.\n[free] </b>Gib 2 Ressourcen aus: Du bekommst für diese Fertigkeitenprobe +3 [intellect].\n[free] Gib 2 Ressourcen aus: Du bekommst für diese Fertigkeitenprobe +3 [agility].",
         "traits": "Talent."
     },
     {
         "code": "02190",
-        "flavor": "“No.”",
-        "name": "Defiance",
-        "text": "Before revealing chaos tokens for this test, choose one of the following symbols: ([skull], [cultist], [tablet], or [elder_thing]). Ignore the effects of the chosen symbol during this test (including its modifier).",
-        "traits": "Innate."
+        "flavor": "“Nein.”",
+        "name": "Widerstand",
+        "text": "Bevor Chaosmarker für diese Probe enthüllt werden, wähle eines der folgenden Symbole: ([skull], [cultist], [tablet], oder [elder_thing]). Ignoriere die Effekte des gewählten Symbols während dieser Probe (einschließlich des Modifikators).",
+        "traits": "Angeboren."
     },
     {
         "code": "02191",
-        "name": "Blood Pact",
-        "text": "Permanent.\n[free] Add 1 doom to Blood Pact: You get +3 [willpower] for this skill test. (Limit once per test.)\n[free] Add 1 doom to Blood Pact: You get +3 [combat] for this skill test. (Limit once per test.)",
-        "traits": "Spell. Pact."
+        "name": "Blutspakt",
+        "text": "Dauerhaft.\n[free] Füge Blutspakt 1 Verderben hinzu: Du bekommst für diese Fertigkeitsprobe +3 [willpower]. (Nur ein Mal pro Probe)\n[free] Füge Blutspakt 1 Verderben hinzu: Du bekommst für diese Fertigkeitsprobe +3 [combat]. (Nur ein Mal pro Probe.)",
+        "traits": "Zauber. Pakt."
     },
     {
         "code": "02192",
-        "name": "Rise to the Occasion",
-        "text": "Commit only to a skill test you are performing, and only if the difficulty of that test is at least 2 higher than your base skill value.",
-        "traits": "Innate."
+        "name": "Der Situation gewachsen",
+        "text": "Trage diese Karte nur zu einer Fertigkeitsprobe bei, die du durchführst, und nur, falls die Schwierigkeit dieser Probe mindestens um 2 höher als dein Grundfertigkeitswert ist.",
+        "traits": "Angeboren."
     },
     {
         "code": "02193",
-        "name": "Scrapper",
-        "text": "Permanent.\n[free] Spend 1 resource: You get +1 [combat] for this skill test.\n[free] Spend 1 resource: You get +1 [agility] for this skill test.",
+        "name": "Schläger",
+        "text": "Dauerhaft.\n[free] Gib 1 Ressource aus: Du bekommst für diese Fertigkeitsprobe +1 [combat].\n[free] Gib 1 Ressource aus: Du bekommst für diese Fertigkeitsprobe +1 [agility].",
         "traits": "Talent."
     },
     {
         "code": "02194",
-        "flavor": "You can never be too prepared.",
-        "name": "Emergency Cache",
-        "text": "Gain 3 resources and draw 1 card.",
-        "traits": "Supply."
+        "flavor": "Man kann niemals zu gut vorbereitet sein.",
+        "name": "Notfallausrüstung",
+        "text": "Erhalte 3 Ressourcen und ziehe 1 Karte.",
+        "traits": "Vorrat."
     }
 ]

--- a/translations/de/pack/dwl/bota_encounter.json
+++ b/translations/de/pack/dwl/bota_encounter.json
@@ -1,214 +1,214 @@
 [
     {
         "code": "02195",
-        "name": "Blood on the Altar",
-        "text": "[skull]: -1 for each location in play with no encounter card underneath it (max -4).\n[cultist]: -2. If you fail, add 1 clue from the token pool to your location.\n[tablet]: -2. If you are in the Hidden Chamber, reveal another token.\n[elder_thing]: -3. If you fail, place 1 doom on the current agenda.",
-        "back_text": "[skull]: -1 for each location in play with no encounter card underneath it.\n[cultist]: -4. If you fail, add 1 clue from the token pool to your location.\n[tablet]: -3. Reveal another token.\n[elder_thing]: -3. Place 1 doom on the current agenda."
+        "name": "Blut auf dem Altar",
+        "text": "[skull]: -1 für jeden Ort im Spiel ohne Begegnungskarten darunter (max. -4).\n[cultist]: -2. Falls die Probe misslingt, füge deinem Ort 1 Hinweis aus dem Markervorrat hinzu.\n[tablet]: -2. Falls du dich in Der verborgenen Kammer befindest, enthülle einen weiteren Marker.\n[elder_thing]: -3. Falls die Probe misslingt, platziere 1 Verderben auf die aktuelle Agenda.",
+        "back_text": "[skull]: -1 für jeden Ort im Spiel ohne Begegnungskarten darunter.\n[cultist]: -4. Falls die Probe misslingt, füge deinem Ort 1 Hinweis aus dem Markervorrat hinzu.\n[tablet]: -3. Enthülle einen weiteren Marker.\n[elder_thing]: -3. Platziere 1 Verderben auf die aktuelle Agenda."
     },
     {
         "code": "02196",
-        "flavor": "Your welcome in Dunwich has been cold. A string of disappearances has left the already aloof townsfolk on edge. Most of them look at you with distrust, and few are willing to help in your investigation. Who knows what will happen if you don’t find the location of the missing townsfolk soon...",
-        "name": "Strange Disappearances",
-        "back_flavor": "Whippoorwills gather along the gambrel roofs of Dunwich and begin to shriek in jubilation. The people of Dunwich believe that the presence of whippoorwills foreshadows somebody’s imminent death. Do they long for your death? Or is the victim someone else?",
-        "back_text": "If there are 3 or more potential sacrifices, choose one of them at random and place it underneath the agenda deck, without looking at it."
+        "flavor": "Dein Empfang in Dunwich war eher kühl. Kürzlich sind hier einige Menschen verschwunden und das macht die sowieso eher zurückhaltenden Dorfbewohner nervös. Die meisten betrachten dich misstrauisch und nur wenige von ihnen sind bereit bei deinen Ermittlungen zu helfen. Wer weiß, was noch passiert, falls du nicht bald den Ort findest, an dem die vermissten Dorfbewohner festgehalten werden...",
+        "name": "Merkwürdige Vermisstenfälle",
+        "back_flavor": "Ziegenmelker sammeln sich auf den Mansardendächern von Dunwich und kreischen vor Freude. Die Menschen in Dunwich glauben, dass die Gegenwart von Ziegenmelkern ein Vorbote eines direkt bevorstehenden Todesfalls ist. Wollen sie deinen Tod? Oder ist jemand anderes das Opfer?",
+        "back_text": "Falls es 3 oder mehr mögliche Opfer gibt, bestimme zufällig eines davon und platziere es unter dem Agendadeck, ohne es anzusehen."
     },
     {
         "code": "02197",
-        "flavor": "As the sun sets, the frightened townsfolk retreat into their homes and lock their doors. It is clear to you that many of them know more than they are letting on. A sickening feeling turns over in your stomach as the village’s true nature becomes clear.",
-        "name": "The Old Ones Hunger",
-        "back_flavor": "More whippoorwills flock to Dunwich village as the night progresses. The other townsfolk, notoriously superstitious, are terrified by the birds’ presence. With the doors around you shut and locked, you find yourself alone in the streets of Dunwich.",
-        "back_text": "\nIf there are 2 or more potential sacrifices, choose one of them at random and place it underneath the agenda deck, without looking at it."
+        "flavor": "Bei Sonnenuntergang ziehen sich die verängstigten Dorfbewohner in ihre Häuser zurück und verschließen die Türen. Dir ist klar, dass viele von ihnen mehr wissen, als sie zugeben. Ein Übelkeit erregendes Gefühl überkommt dich, als du allmählich die wahre Natur dieses Dorfes erkennst.",
+        "name": "Die Alten sind hungrig",
+        "back_flavor": "Im Verlauf der Nacht bevölkern mehr und mehr Ziegenmelker das Dorf Dunwich. Die abergläubischen Dorfbewohner sind durch die Anwesenheit dieser Vögel völlig verschreckt. Du bist allein auf den Straßen von Dunwich, alle Türen um dich herum sind verschlossen und verriegelt.",
+        "back_text": "\nFalls es 2 oder mehr mögliche Opfer gibt, bestimme zufällig eines davon und platziere es unter dem Agendadeck, ohne es anzusehen."
     },
     {
         "code": "02198",
-        "flavor": "The rhythmic screeching of the whippoorwills fills the night. If the superstitions of Dunwich are correct, their song portends impending death... But for whom?",
-        "name": "Feed the Beast",
-        "back_flavor": "The whippoorwills that have been cawing through the night scatter in unison, as if they are somehow satisfied with the turn of events.",
-        "back_text": "Each investigator must immediately resign."
+        "flavor": "Das rhytmische Kreischen der Ziegenmelker dringt durch die Nacht. Falls der Aberglaube der Menschen aus Dunwich stimmt, kündigen ihre Gesänge einen Todesfall an... aber wessen?",
+        "name": "Die Bestie füttern",
+        "back_flavor": "Die Ziegenmelker, deren Gekrächze du die ganze Nacht gehört hast, rufen jetzt im Gleichklang, als ob sie mit dem Verlauf der Ereignisse außerordentlich zufrieden wären.",
+        "back_text": "Jeder Ermittler muss sofort aufgeben."
     },
     {
         "code": "02199",
-        "flavor": "The disappearances in town may be related to the events in Arkham. You suspect that something awful is afoot. You must find where the missing townsfolk are being held in order to unveil this conspiracy.",
-        "name": "Searching for Answers",
-        "text": "<b>Objective</b> - When an investigator enters The Hidden Chamber, advance.",
-        "back_flavor": "You find your way into the hidden chamber where you believe the missing folk are being held, but the horrors that confront you there fray the edges of your sanity. Bound by chains in a secluded corner of the room is an unspeakable creature with the face of a man. It wheezes and wrestles to free itself as it notices your entrance. The many mouths covering the creature’s body are covered in blood and gristles of meat, as though it were feeding recently.",
-        "back_text": "Reveal each unrevealed location. \nMove all clues in play (including those on each investigator) to The Hidden Chamber.\nSpawn the set-aside Silas Bishop enemy in The Hidden Chamber."
+        "flavor": "Die Fälle von verschwundenen Dorfbewohnern könnten mit den Ereignissen in Arkham zusammenhängen. Du vermutest, dass hier etwas Fürchterliches vorgeht. Deshalb musst du den Ort finden, an dem die verschwundenen Dorfbewohnen gefangen gehalten werden, um die Verschwörung aufzudecken.",
+        "name": "Auf der Suche nach Antworten",
+        "text": "<b>Ermittlungsziel</b> - Sobald ein Ermittler Die verborgene Kammer betritt, rücke vor.",
+        "back_flavor": "Du findest den Weg in die verborgene Kammer, in der du die Vermissten vermutest, aber der Schrecken, mit dem du dort konfrontiert wirst, kostet dich fast deine geistige Gesundheit. In einer Ecke des Raumes ist eine unbeschreibliche Kreatur mit dem Gesicht eines Mannes angekettet. Sie keucht und versucht sich selbst zu befreien, als sie dich bemerkt. Die vielen Mäuler überall auf dem Körper der Kreatur sind blutverschmiert und Fleischfetzen zeugen davon, dass sie wohl gerade gefüttert worden ist.\nMit fürchterlich krächzender Stimme spricht die Kreatur aus ihren sieben Mündern. \"Ss...se...eth...?\" Dann kriecht sie vor, als ob sie dich ergreifen wollte, aber einige ihrer Ketten halten sie zurück.",
+        "back_text": "Enthülle jeden verhüllten Ort. \nBewege alle Hinweise im Spiel (einschließlich der Hinweise auf jedem Ermittler) in Die verborgene Kammer..\nDer beiseitegelegte Silas Bishop erscheint in Der verborgenen Kammer."
     },
     {
         "code": "02200",
-        "flavor": "The pitiful beast lunges to grab you with slimy arms, its many jaws snapping in hunger. Killing it would be merciful. But perhaps there is something else to discover about this creature…",
-        "name": "The Chamber of the Beast",
-        "text": "<b>Objective</b> - If Silas Bishop is defeated: <b>(→R1)\nObjective</b> - If there are no clues in the Hidden Chamber, advance.",
-        "back_flavor": "Despite the danger, you brave the beast's horrifying presence and investigate further before killing it. What you find confirms your worst suspicions. Several journal entries written by a \"Seth Bishop\" describe the process of feeding the creature in horrifying detail - tomatoes at first, then small game, then cattle, and then finally 'human sacrifices'. But the most disturbing part is that Seth calls the creature by name: 'Silas.'",
-        "back_text": "If The Necronomicon is in play: <b>(→R2)\n</b>Otherwise: <b>(→R3)</b>"
+        "flavor": "Die Mitleid erregende Kreatur stürmt vor, um mit ihren schleimigen Armen nach dir zu greifen und ihre vielen Kiefer schnappen hungrig nach dir. Sie zu töten wäre ein Akt der Gnade. Aber vielleicht kann man an dieser Kreatur noch etwas anderes entdecken…",
+        "name": "Die Kammer der Bestie",
+        "text": "<b>Ermittlungsziel</b> - Falls Silas Bishop besiegt ist: <b>(?A1)\nErmittlungsziel</b> - Falls sich keine Hinweise in Der verborgenen Kammer befinden, rücke vor.",
+        "back_flavor": "Aller gefahr zum Trotz hast du weiter ermittelt, ungeachtet der Anwesenheit der furchterregenden Bestie, bevor du sie getötet hast. Was du findest, bestätigt deine schlimmsten Befürchtungen. Einige Tagebucheinträge von \"Seth Bishop\" beschreiben in allen grässlichen Einzelheiten, wie die Kreatur gefüttert wird - zuerst mit Tomaten, später mit kleinen Tieren, dann mit Rindern und schließlich mit \"Menschenopfern\". Aber das Verstörendste ist, dass Seth die Kreatur mit einem Namen bezeichnet: \"Silas.\"",
+        "back_text": "Falls das Necronomicon (Übersetzung von Olaus Wormius) im Spiel ist : <b>(?A2)\n</b>Ansonsten: <b>(?A3)</b>"
     },
     {
         "code": "02201",
-        "flavor": "...the sparsely scattered houses wear a surprisingly uniform aspect of age, squalor, and dilapidation.\n–H. P. Lovecraft, \"The Dunwich Horror\"",
-        "name": "Village Commons",
-        "text": "[action] <b>Resign.</b> \"This is suicide! We're better off hiding out the night.\"",
-        "traits": "Dunwich. Central.",
-        "back_flavor": "...it is hard to prevent the impression of a faint, malign odour about the village street, as of the massed mould and decay of centuries.\n–H. P. Lovecraft, \"The Dunwich Horror\""
+        "flavor": "...während die verstreuten Häuser sich auf eine erstaunlische Weise in Alter, Verkommenheit und Verfall gleichen.\n–H. P. Lovecraft, \"Das Grauen von Dunwich\"",
+        "name": "Dorfplatz",
+        "text": "[action] <b>Aufgeben.</b> \"Das ist Selbstmord! Wir verstecken uns heute Nacht lieber.\"",
+        "traits": "Dunwich. Zentral.",
+        "back_flavor": "...fällt es schwer, den Eindruck von einem schwülen, üblen Gestank in der Dorfstraße angesichts des Morasts und des Verfalls von Jahrzehnten zu unterdrücken.\n–H. P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02202",
-        "name": "Bishop's Brook",
-        "text": "Each enemy at Bishop's Brook deals +1 horror while it is attacking.\n[free] If there are no clues here: Draw the encounter card underneath Bishop's Brook. (Group limit once per game).",
+        "name": "Bishops Bach",
+        "text": "Jeder Gegner auf Bishops Bach fügt +1 Horror zu, solange er angreift.\n[free] Falls sich hier keine Hinweis befinden: Ziehe die Begegnungskarte unter Bishops Bach. (Nur ein Mal pro Spiel für die gesamte Gruppe).",
         "traits": "Dunwich.",
-        "back_flavor": "One dreads to trust the tenebrous tunnel of the bridge, yet there is no way to avoid it.\n–H. P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "Man traut dem dunklen Tunnel der Brücke nicht, doch es gibt keinen anderen Weg.\n–H. P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02203",
-        "name": "Bishop's Brook",
-        "text": "If there is an investigator at Bishop's Brook, other investigators cannot enter Bishop's Brook.\n[free] If there are no clues here: Draw the encounter card underneath Bishop's Brook. (Group limit once per game).",
+        "name": "Bishops Bach",
+        "text": "Falls sich ein Ermittler auf Bishops Bach befindet, können andere Ermittler Bishops Bach nicht betreten.\n[free] Falls sich hier keine Hinweis befinden: Ziehe die Begegnungskarte unter Bishops Bach. (Nur ein Mal pro Spiel für die gesamte Gruppe).",
         "traits": "Dunwich.",
-        "back_flavor": "One dreads to trust the tenebrous tunnel of the bridge, yet there is no way to avoid it.\n–H. P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "Man traut dem dunklen Tunnel der Brücke nicht, doch es gibt keinen anderen Weg.\n–H. P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02204",
-        "flavor": "It is not reassuring to see, on a closer glance, that most of the houses are deserted and falling to ruin...\n–H. P. Lovecraft, \"The Dunwich Horror\"",
-        "name": "Burned Ruins",
-        "text": "Each enemy in the Burned Ruins gets +1 evade.\n[free] If there are no clues here: Draw the encounter card underneath Burned Ruins. (Group limit once per game).",
-        "traits": "Dunwich."
+        "name": "Verbrannte Ruinen",
+        "text": "Jeder Gegner in den Verbrannten Ruinen bekommt +1 Entkommen.\n[free] Falls sich hier keine Hinweis befinden: Ziehe die Begegnungskarte unter den Verbrannten Ruinen. (Nur ein Mal pro Spiel für die gesamte Gruppe).",
+        "traits": "Dunwich.",
+        "back_flavor": "Wenn man auf den zweiten Blick dann bemerkt, dass die meisten Häuser verlassen und nur noch Ruinen sind, dann trägt das nicht zur Beruhigung bei...\n–H. P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02205",
-        "name": "Burned Ruins",
-        "text": "[reaction] After you fail a skill test while investigating the Burned Ruins: Flip 1 clue token on the Burned Ruins to its doom side.\n[free] If there are no clues here: Draw the encounter card underneath Burned Ruins. (Group limit once per game).",
+        "name": "Verbrannte Ruinen",
+        "text": "[reaction] Nachdem dir eine Fertigkeitsprobe misslungen ist, während du in den Verbrannten Ruinen ermittelst: Drehe 1 Hinweis in den Verbrannten Ruinen auf seine Verderben-Seite.\n[free] Falls sich hier keine Hinweis befinden: Ziehe die Begegnungskarte unter den Verbrannten Ruinen. (Nur ein Mal pro Spiel für die gesamte Gruppe).",
         "traits": "Dunwich.",
-        "back_flavor": "It is not reassuring to see, on a closer glance, that most of the houses are deserted and falling to ruin...\n–H. P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "Wenn man auf den zweiten Blick dann bemerkt, dass die meisten Häuser verlassen und nur noch Ruinen sind, dann trägt das nicht zur Beruhigung bei...\n–H. P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02206",
-        "name": "Osborn's General Store",
-        "text": "You cannot gain resources while you are in Osborn's General Store.\n[free] If there are no clues here: Draw the encounter card underneath Osborn's General Store. (Group limit once per game).",
+        "name": "Osborns Laden",
+        "text": "Du kannst keine Ressourcen erhalten, solange du dich in Orborns Laden befindest.\n[free] Falls sich hier keine Hinweis befinden: Ziehe die Begegnungskarte unter Osborns Laden. (Nur ein Mal pro Spiel für die gesamte Gruppe).",
         "traits": "Dunwich.",
-        "back_flavor": "From the air of hushed fright at Osborn’s store they knew something hideous had happened...\n–H. P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "Aus der unterdrückten Furcht, die in Osborns Laden zu spüren war, schlossen die drei, dass etwas schreckliches passiert war...\n–H. P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02207",
-        "name": "Osborn's General Store",
-        "text": "[action]Spend 1 resource: Search the top 3 cards of your deck for an <i>Item</i> card and add it to your hand. Shuffle your deck.\n[free] If there are no clues here: Draw the encounter card underneath Osborn's General Store. (Group limit once per game).",
+        "name": "Osborns Laden",
+        "text": "[action]Gib 1 Ressource aus: Durchsuche die obersten 3 Karten deines Decks nach einer <i>Gegenstand</i>-Karte und füge sie deiner Hand hinzu. Mische dein Deck.\n[free] Falls sich hier keine Hinweis befinden: Ziehe die Begegnungskarte unter Osborns Laden. (Nur ein Mal pro Spiel für die gesamte Gruppe).",
         "traits": "Dunwich.",
-        "back_flavor": "From the air of hushed fright at Osborn’s store they knew something hideous had happened...\n–H. P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "Aus der unterdrückten Furcht, die in Osborns Laden zu spüren war, schlossen die drei, dass etwas schreckliches passiert war...\n–H. P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02208",
-        "name": "Congregational Church",
-        "text": "<b>Forced</b> - After Congregational Church is revealed: Search the encounter deck for a <i>Humanoid</i> enemy and spawn it at the Village Commons. Shuffle the encounter deck.\n[free] If there are no clues here: Draw the encounter card underneath Congregational Church. (Group limit once per game).",
+        "name": "Kongregationskirche",
+        "text": "<b>Erzwungen</b> - Nachdem die Kongregationskirche enthüllt worden ist: Durchsuche das Begegnungsdeck nach einem <i>Humanoid</i>-Gegner, der auf dem Dorfplatz erscheint. Mische das Begegnungsdeck.\n[free] Falls sich hier keine Hinweis befinden: Ziehe die Begegnungskarte unter der Kongregationskirche. (Nur ein Mal pro Spiel für die gesamte Gruppe).",
         "traits": "Dunwich.",
-        "back_flavor": "\"I my self did not more than a Fortnight ago catch a very plain Discourse of evill Powers in the Hill behind my House; wherein there were a Rattling and Rolling, Groaning, Screeching, and Hissing, such as no Things of this Earth cou’d raise up...\"\n–H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "\"Ich selbst stieß vor vierzehn Tagen auf eine deutliche Manifestation der bösen Kräfte an dem Berg hinter meinem Haus, wo es zu einem Rattern, Donnern, Grunzen, Schreien und Zischen kam, so wie es kein Ding auf Erden hervorbringen kann...\"\n–H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02209",
-        "name": "Congregational Church",
-        "text": "[action] Choose and discard a card from your hand: Gain 2 resources.\n[free] If there are no clues here: Draw the encounter card underneath Congregational Church. (Group limit once per game).",
+        "name": "Kongregationskirche",
+        "text": "[action] Wähle eine Karte von deiner Hand und lege sie ab: Du erhälst 2 Ressourcen.\n[free] Falls sich hier keine Hinweis befinden: Ziehe die Begegnungskarte unter der Kongregationskirche. (Nur ein Mal pro Spiel für die gesamte Gruppe).",
         "traits": "Dunwich.",
-        "back_flavor": "\"I my self did not more than a Fortnight ago catch a very plain Discourse of evill Powers in the Hill behind my House; wherein there were a Rattling and Rolling, Groaning, Screeching, and Hissing, such as no Things of this Earth cou’d raise up...\"\n–H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "\"Ich selbst stieß vor vierzehn Tagen auf eine deutliche Manifestation der bösen Kräfte an dem Berg hinter meinem Haus, wo es zu einem Rattern, Donnern, Grunzen, Schreien und Zischen kam, so wie es kein Ding auf Erden hervorbringen kann...\"\n–H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02210",
-        "name": "House in the Reeds",
-        "text": "While you are in the House in the Reeds, you cannot play events.\n[free] If there are no clues here: Draw the encounter card underneath House in the Reeds. (Group limit once per game).",
+        "name": "Haus im Schilf",
+        "text": "Solange du dich im Haus im Schilf befindest, kannst du keine Ereignisse spielen.\n[free] Falls sich hier keine Hinweis befinden: Ziehe die Begegnungskarte unter dem Haus im Schilf. (Nur ein Mal pro Spiel für die gesamte Gruppe).",
         "traits": "Dunwich.",
-        "back_flavor": "Even the locals stay away from this half-sunken hovel."
+        "back_flavor": "Selbst die Einheimischen halten sich von dieser halb versunkenen Hütte fern."
     },
     {
         "code": "02211",
-        "name": "House in the Reeds",
-        "text": "<b>Forced</b> - After House in the Reeds is revealed: Search the encounter deck for a <i>Nightgaunt</i> enemy and spawn it in the Village Commons. Shuffle the encounter deck.\n[free] If there are no clues here: Draw the encounter card underneath House in the Reeds. (Group limit once per game).",
+        "name": "Haus im Schilf",
+        "text": "<b>Erzwungen</b> - Nachdem das Haus im Schilf enthüllt worden ist: Durchsuche das Begegnungsdeck nach einem <i>Dunkeldürrer</i>-Gegner, der auf dem Dorfplatz erscheint. Mische das Begegnungsdeck.\n[free] Falls sich hier keine Hinweis befinden: Ziehe die Begegnungskarte unter dem Haus im Schilf. (Nur ein Mal pro Spiel für die gesamte Gruppe).",
         "traits": "Dunwich.",
-        "back_flavor": "Even the locals stay away from this half-sunken hovel."
+        "back_flavor": "Selbst die Einheimischen halten sich von dieser halb versunkenen Hütte fern."
     },
     {
         "code": "02212",
-        "name": "Schoolhouse",
-        "text": "While you are in the Schoolhouse, you cannot commit skill cards to skill tests.\n[free] If there are no clues here: Draw the encounter card underneath Schoolhouse. (Group limit once per game).",
+        "name": "Schulhaus",
+        "text": "Solange du dich im Schulhaus befindest, kannst du keine Fertigkeitskarten zu Fertigkeitsproben beitragen.\n[free] Falls sich hier keine Hinweis befinden: Ziehe die Begegnungskarte unter dem Schulhaus. (Nur ein Mal pro Spiel für die gesamte Gruppe).",
         "traits": "Dunwich.",
-        "back_flavor": "With its crumbling rooftop and rat-infested walls, this is hardly even a house, let alone a schoolhouse."
+        "back_flavor": "Man kann es mit seinem eingefallen Dach und rattenverseuchten Wänden kaum als Haus, geschweige denn als Schulhaus erkennen."
     },
     {
         "code": "02213",
-        "name": "Schoolhouse",
-        "text": "You cannot discover clues here except by investigating.\n[free] If there are no clues here: Draw the encounter card underneath Schoolhouse. (Group limit once per game).",
+        "name": "Schulhaus",
+        "text": "Du kannst hier keine Hinweise entdecken, außer durch Ermitteln.\n[free] Falls sich hier keine Hinweis befinden: Ziehe die Begegnungskarte unter dem Schulhaus. (Nur ein Mal pro Spiel für die gesamte Gruppe).",
         "traits": "Dunwich.",
-        "back_flavor": "With its crumbling rooftop and rat-infested walls, this is hardly even a house, let alone a schoolhouse."
+        "back_flavor": "Man kann es mit seinem eingefallen Dach und rattenverseuchten Wänden kaum als Haus, geschweige denn als Schulhaus erkennen."
     },
     {
         "code": "02214",
-        "name": "The Hidden Chamber",
-        "subname": "Prison of the Beast",
-        "text": "<b>Revelation</b> - Put The Hidden Chamber into play.\nThe Hidden Chamber and the location from which it was drawn are connected to one another.\nThe door to The Hidden Chamber is locked. You cannot enter The Hidden Chamber unless Key to the Chamber is attached to The Hidden Chamber.",
+        "name": "Die verborgene Kammer",
+        "subname": "Gefängnis der Bestie",
+        "text": "<b>Enthüllung</b> - Bringe Die verborgene Kammer ins Spiel.\nDie verborgene Kammer und der Ort, an dem sie gezogen worden ist, sind miteinander verbunden.\nDie Tür zur verborgenen Kammer ist verschlossen. Du kannst Die verborgene Kammer nicht betreten, bis Schlüssel zur Kammer an Die verborgene Kammer angehängt ist.",
         "traits": "Dunwich."
     },
     {
         "code": "02215",
-        "flavor": "This tarnished silver key was hidden and kept safe out of sight. It must lead somewhere important.",
-        "name": "Key to the Chamber",
-        "text": "<b>Revelation</b> - Take control of Key to the Chamber.\n[free] If The Hidden Chamber is connected to your location: Attach Key to the Chamber to The Hidden Chamber.",
-        "traits": "Item. Key."
+        "flavor": "Jemand hat den angelaufenen Silberschlüssel versteckt und vor den Blicken anderer geschützt. Er muss zu einem sehr wichtigen Ort gehören.",
+        "name": "Schlüssel zur Kammer",
+        "text": "<b>Enthüllung</b> - Übernimm die Kontrolle über Schlüssel zur Kammer.\n[free] Falls Die verborgene Kammer mit deinem Ort verbunden ist: Hänge Schlüssel zur Kammer an Die verborgene Kammer an.",
+        "traits": "Gegenstand. Schlüssel."
     },
     {
         "code": "02216",
-        "flavor": "What walked on the mountains that May-Night?\nWhat Roodmas horror fastened itself on the world in half human flesh and blood?\n—H. P. Lovecraft, \"The Dunwich Horror\"",
+        "flavor": "Was wandelte in dieser Mainacht über die Berge?\nWelcher Schrecken Roodmas hat sich hier in halb humanoider Form auf der Erde manifestiert?\n—H. P. Lovecraft, \"Das Grauen von Dunwich\"",
         "name": "Silas Bishop",
-        "subname": "Infused With Evil",
-        "text": "Massive.\nSilas Bishop cannot make attacks of opportunity.",
-        "traits": "Monster. Abomination. Elite."
+        "subname": "Vom Bösen durchdrungen",
+        "text": "Gewaltig.\nSilas Bishop kann keine Gelegenheitsangriffe durchführen.",
+        "traits": "Monster. Abscheulichkeit. Elite."
     },
     {
         "code": "02217",
-        "flavor": "...His memories of chantings in the great stone circles were not altogether connected with Wilbur and his grandfather.\n–H. P. Lovecraft, \"The Dunwich Horror\"",
+        "flavor": "...seine Erinnerungen von Beschwörungen in den großen Steinkreisen bezogen sich nicht nur auf Wilbur und seinen Großvater.\n–H. P. Lovecraft, \"Das Grauen von Dunwich\"",
         "name": "Zebulon Whateley",
-        "subname": "Recalling Ancient Things",
-        "text": "You get +1 [willpower].\n[reaction] After you succeed at a [willpower] test on a treachery card, exhaust Zebulon Whateley: Draw 1 card.",
-        "traits": "Ally. Dunwich.",
+        "subname": "Erinnerungen an uralte Dinge",
+        "text": "Du bekommst +1 [willpower].\n[reaction] Nachdem dir eine [willpower]-Probe auf einer Verratskarte gelungen ist, erschöpfe Zebulon Whatley: Ziehe 1 Karte.",
+        "traits": "Verbündeter. Dunwich.",
         "slot": "Ally"
     },
     {
         "code": "02218",
-        "flavor": "Earl Sawyer, who tended the horse and cattle during Wilbur’s absence, had developed a woefully acute case of nerves.\n-H. P. Lovecraft, \"The Dunwich Horror\"",
+        "flavor": "Earl Sawyer, der sich während Wilburs Abwesenheit um das Vieh und das Pferd gekümmert hatte, war mit den Nerven fertig.\n-H. P. Lovecraft, \"Das Grauen von Dunwich\"",
         "name": "Earl Sawyer",
-        "subname": "Smarter Than He Lets On",
-        "text": "You get +1 [agility].\n[reaction] After you evade an enemy, exhaust Earl Sawyer: Draw 1 card.",
-        "traits": "Ally. Dunwich.",
+        "subname": "Schlauer als er vorgibt",
+        "text": "Du bekommst +1 [agility].\n[reaction] Nachdem du einem Gegner entkommen bist: Ziehe 1 Karte.",
+        "traits": "Verbündeter. Dunwich.",
         "slot": "Ally"
     },
     {
         "code": "02219",
-        "name": "Powder of Ibn Ghazi",
-        "subname": "Seeing Things Unseen",
-        "text": "Powder of Ibn Ghazi enters play with X clues on it, where X is the number of characters who \"survived the Dunwich Legacy\" in your Campaign Log.\n[free]: Move 1 clue from Powder of Ibn Ghazi to an exhausted Brood of Yog-Sothoth at your location.",
-        "traits": "Item."
+        "name": "Pulver von Ibn-Ghazi",
+        "subname": "Dinge sehen, die ungesehen bleiben sollten",
+        "text": "Pulver von Ibn-Ghazi kommt mit X Hinweisen darauf ins Spiel, wobei X die Anzahl der Charaktere ist, die laut deinem Kampagnenlogbuch \"Das Vermächtnis von Dunwich\" überlebt haben.\n[free]: Bewege 1 Hinweis von Pulver von Ibn-Ghazi auf eine erschöpfte Brut von Yog-Sothoth an deinem Ort.",
+        "traits": "Gegenstand."
     },
     {
         "code": "02220",
-        "name": "Kidnapped!",
-        "text": "<b>Revelation</b> - Test [willpower] (4) or [agility] (4). If you fail, add an <i>Ally</i> asset you control to the pool of potential sacrifices. Then, attach Kidnapped! to the current agenda. If you have no <i>Ally</i> assets, take 2 damage and discard Kidnapped! instead.\n<b>Forced</b> - When attached agenda advances: Choose a potential sacrifice at random and place it underneath the agenda deck."
+        "name": "Entführt!",
+        "text": "<b>Enthüllung</b> - Lege eine [willpower]-Probe (4) oder eine [agility]-Probe (4) ab. Falls die Probe misslingt, füge eine <i>Verbündeter</i>-Vorteilskarte, die du kontrollierst, dem Vorrat möglicher Opfer hinzu. Hänge dann Entführt! an die aktuelle Agenda an. Falls du keine <i>Verbündeter</i>-Vorteilskarte hast, nimm stattdessen 2 Schaden und lege Entführt! ab.\n<b>Erzwungen</b> - Sobald von der aktuellen Agenda mit dieser Verstärkung vorgerückt wird: Bestimme zufällig ein mögliches Opfer und platziere es unter das Agendadeck."
     },
     {
         "code": "02221",
-        "name": "Psychopomp's Song",
-        "text": "Surge. Peril.\n<b>Revelation</b> - Add Psychopomp's Song to any investigator's threat area.\n<b>Forced</b> - When you would take 1 or more damage: Take 2 additional damage and discard Psychopomp's Song.",
+        "name": "Lied des Psychopompos",
+        "text": "Nachrüsten. Wagnis.\n<b>Enthüllung</b> - Füge Lied des Psychopompos der Bedrohungszone eines beliebigen Ermittlers hinzu.\n<b>Erzwungen</b> - Sobald du 1 oder mehr Schaden nehmen würdest: Nimm 2 Schaden zusätzlich und lege Lied des Psychopompos ab.",
         "traits": "Omen."
     },
     {
         "code": "02222",
-        "name": "Strange Signs",
-        "text": "<b>Revelation</b> - Test [intellect] (3). If you fail, add 1 clue from the token pool to your location (2 clues instead if there are 3 or 4 investigators in the game).",
+        "name": "Seltsame Zeichen",
+        "text": "<b>Enthüllung</b> - Lege eine [intellect]-Probe (3) ab. Falls die Probe misslingt, füge deinem Ort 1 Hinweis aus dem Markervorrat hinzu (stattdessen 2 Hinweise, falls 3 oder 4 Ermittler im Spiel sind).",
         "traits": "Omen."
     },
     {
         "code": "02223",
-        "flavor": "A sickening display of gore causes you to retch. You’re glad this wasn’t you.",
-        "name": "Rotting Remains",
-        "text": "<b>Revelation</b> - Test [willpower] (3). For each point you fail by, take 1 horror.\n",
-        "traits": "Terror."
+        "flavor": "Der abstoßende Anblick der Überreste lässt dich würgen. Du bist dankbar, dass es nicht dich getroffen hat.",
+        "name": "Verrottende Überreste",
+        "text": "<b>Enthüllung</b> - Lege eine [willpower]-Probe (3) ab. Für jeden Punkt, um den die Probe misslingt, nimmst du 1 Horror.\n",
+        "traits": "Schrecken."
     },
     {
         "code": "02224",
-        "name": "Servant of Many Mouths",
-        "text": "<b>Spawn</b> - Any empty location.\nRetaliate.\n[reaction] </b>After you defeat Servant of Many Mouths: Discover 1 clue at any location.",
+        "name": "Diener vieler Münder",
+        "text": "<b>Erscheinen </b> - Beliebiger leerer Ort.\nZurückschlagen.\n[reaction] </b>Nachdem du Diener vieler Münder besiegt hast: Entdecke 1 Hinweis an einem beliebigen Ort.",
         "traits": "Humanoid."
     }
 ]

--- a/translations/de/pack/dwl/dwl.json
+++ b/translations/de/pack/dwl/dwl.json
@@ -1,192 +1,192 @@
 [
     {
         "code": "02001",
-        "flavor": "\"God has spoken. I will do His work without hesitation.\"",
+        "flavor": "\"Gott hat gesprochen. Ich werde sein Werk ohne Zögern ausführen.\"",
         "name": "Zoey Samaras",
-        "subname": "The Chef",
-        "text": "[reaction] After you become engaged with an enemy: Gain 1 resource.\n[elder_sign] effect: +1. If this skill test is successful during an attack, that attack deals +1 damage.",
-        "traits": "Believer. Hunter.",
-        "back_flavor": "Zoey had known that she was special ever since God spoke to her one night when she was six years old... the night that terrible fire took away her parents. He told her that He had chosen her from among all the people of the world to be His agent. She would protect the innocent and punish the wicked. Since then, He comes to her in times of trouble, offering guidance and comfort. Zoey now travels from city to city, taking work as a chef to support herself. When she isn't working, she stalks the night, guided by the Lord's voice. Wherever she finds wickedness, she strikes it down without remorse or hesitation.",
-        "back_text": "<b>Deck size</b>: 30.\n<b>Deckbuilding options</b>: Guardian cards ([guardian]) level 0-5, Neutral cards level 0-5, up to five level 0 cards from any other class.\n<b>Deckbuilding requirements</b> (do not count toward deck size): Zoey's Cross, Smite the Wicked, 1 random basic weakness."
+        "subname": "Die Köchin",
+        "text": "[reaction] Nachdem du mit einem Gegner in einem Kampf verwickelt worden bist: Erhalte 1 Ressource.\n[elder_sign]-Effekt: +1. Falls diese Fertigkeitsprobe während eines Angriffs gelingt, fügt dieser Angriff +1 Schaden zu.",
+        "traits": "Glaubender. Jäger.",
+        "back_flavor": "Seit ihrem sechsten Lebensjahr wusste Zoey, dass sie etwas Besonderes war, denn damals hatte eines Nachts Gott zu ihr gesprochen... in derselben Nacht, in der dieses fürchterliche Feuer ihr die Eltern nahm. Er hatte ihr gesagt, dass Er sie unter allen Menschen auf dieser Welt auserwählt hätte seine Dienerin zu sein. Sie würde die Unschuldigen schützen und die Bösen bestrafen. Seitdem kam Er immer zu ihr, wenn sie Probleme hatte, und gab ihr Führung und Trost. Heute reist Zoey von Stadt zu Stadt und verdient ihren Lebensunterhalt als Köchin. Wenn sie nicht arbeitet, streift sie, geleitet von der Stimme des Herrn, durch die Nacht. Und wenn sie auf etwas Böses trifft, vernichtet sie es ohne Reue und Zögern.",
+        "back_text": "<b>Deckgröße</b>: 30.\n<b>Deckbau-Optionen</b>: Wächterkarten ([guardian]) Stufe 0-5, Neutrale Karten Stufe 0-5, bis zu fünf Karten der Stufe 0 beliebiger anderer Klassen.\n<b>Deckbau-Voraussetzungen</b> (zählen nicht gegen die Deckgröße): Zoeys Kreuz, Zerschmettere die Gottlosen, 1 zufällige Grundschwäche."
     },
     {
         "code": "02002",
-        "flavor": "\"This time, nothing will stop me from getting at the truth!\"",
+        "flavor": "\"Dieses Mal wird mich nichts davon abhalten, die Wahrheit aufzudecken.\"",
         "name": "Rex Murphy",
-        "subname": "The Reporter",
-        "text": "[reaction] After you succeed at a skill test by 2 or more while investigating: Discover 1 clue at your location.\n[elder_sign] effect: +2. You may instead choose to automatically fail this skill test to draw 3 cards.",
+        "subname": "Der Reporter",
+        "text": "[reaction] Nachdem dir eine Fertigkeitsprobe um 2 oder mehr gelungen ist, solange du ermittelst: Entdecke 1 Hinweis an deinem Ort.\n[elder_sign]-Effekt: +2. Du darfst stattdessen entscheiden, dass diese Probe automatisch misslingt, um 3 Karten zu ziehen.",
         "traits": "Reporter.",
-        "back_flavor": "When disaster strikes, Rex Murphy is usually on hand, suffering the consequences. After spending a day with Rex, even the most hardened skeptic will concede that the man is cursed. Anytime he had a lead on a good story, something would go wrong. That business in Innsmouth with the photographs that had blown out to sea. The tracks in Dunwich that had washed away in the rain just before he'd brought the sheriff. His terrible fortune has more than once exposed him to gruesome beasts and occult conspiracies. To survive, Rex has developed an inquisitive mind, keeping one step ahead of the next disaster.",
-        "back_text": "<b>Deck size</b>: 30.\n<b>Deckbuilding options</b>: Seeker cards ([seeker]) level 0-5, Neutral cards level 0-5, up to five level 0 cards from any other class.\n<b>Deckbuilding requirements</b> (do not count toward deck size): Search for the Truth, Rex's Curse, 1 random basic weakness.\n<b>Deckbuilding requirements</b>: No <i>Fortune</i> cards."
+        "back_flavor": "Wenn etwas Schreckliches passiert, ist Rex Murphy in der Regel sofort zur Stelle und nimmt dabei sämtliche Konsequenzen in Kauf. Nach einem Tag mit Rex gibt es selbst der größte Skeptiker zu, dass dieser Mann verflucht ist. Immer wenn er einer großen Geschichte auf der Spur ist, geht etwas schief. Diese Sache in Innsmouth mit den Fotografien, die aufs Meer hinaus geweht wurden. Die Spuren in Dunwich, die der Regen fortgewaschen hatte, kurz bevor der Sheriff eingetroffen war. Sein fürchterliches Pech hat ihn mehr als ein Mal in Berührung mit scheußlichen Kreaturen und okkulten Verschwörungen gebracht. Um zu überleben, hat Rex eine Wissbegier entwickelt, mit der er hofft der nächsten Katastrophe einen Schritt voraus sein zu können.",
+        "back_text": "<b>Deckgröße</b>: 30.\n<b>Deckbau-Optionen</b>: Sucherkarten ([seeker]) Stufe 0-5, Neutrale Karten Stufe 0-5, bis zu fünf Karten der Stufe 0 beliebiger anderer Klassen.\n<b>Deckbau-Voraussetzungen</b> (zählen nicht gegen die Deckgröße): Suche nach der Wahrheit, Rex´ Fluch, 1 zufällige Grundschwäche.\n<b>Deckbau-Einschränkungen</b>: Keine <i>Glücksfall</i>-Karten."
     },
     {
         "code": "02003",
-        "flavor": "\"No more 'Miss Barnes' from you. My friends call me Jenny.\"",
+        "flavor": "\"Nennen Sie mich nicht mehr 'Miss Barnes'. Meine Freunde nennen mich Jenny.\"",
         "name": "Jenny Barnes",
-        "subname": "The Dilettante",
-        "text": "You collect 1 additional resource during each upkeep phase.\n[elder_sign] effect: +1 for each resource you have.",
-        "traits": "Drifter.",
-        "back_flavor": "Jenny Barnes has spent the majority of her young life in pursuit of creature comforts, fine dining, and the latest fashions. That all changed when she received a letter from her sister, Isabelle. In this letter, Isabelle confessed that mysterious forces were aligning against her and that she feared she may fall victim to some paranormal threat. It was the last letter Jenny received from her beloved sister. Jenny has since returned to the States to track down and investigate all occult occurrences she can find. Hardly a wilting flower, she has proven herself a crack shot as well as a fearless and clever investigator of the unknown. Until Isabelle's disappearance is explained, Jenny will never relent in her search.",
-        "back_text": "<b>Deck size</b>: 30.\n<b>Deckbuilding options</b>: Rogue cards ([rogue]) level 0-5, Neutral cards level 0-5, up to five level 0 cards from any other class.\n<b>Deckbuilding requirements</b> (do not count toward deck size): Jenny's Twin .45s, Searching for Izzie, 1 random basic weakness."
+        "subname": "Die Dilettantin",
+        "text": "Du sammelst in der Unterhaltsphase 1 zusätzliche Ressource.\n[elder_sign]-Effekt: +1 für jede Ressource, die du hast.",
+        "traits": "Herumtreiber.",
+        "back_flavor": "Jenny Barnes hatte den größten Teil ihres jungen Lebens nach leiblichen Genüssen, edlen Speisen und der neusten Mode gestrebt. Dies änderte sich aber grundlegend, als sie einen Brief ihrer Schwester Isabelle erhielt. In diesem Brief vertraute Isabelle ihr an, dass sich mysteriöse Kräfte gegen sie verbündet hatten und sie fürchtete Opfer einer paranormalen Bedrohung zu werden. Das war der letzte Brief, den Jenny von ihrer geliebten Schwester erhalten hatte. Seitdem ist Jenny in die Staaten zurückgekehrt, wo sie auf der Suche nach okkulten Vorfällen ist, deren Hintergrund sie zu ermitteln versucht. Sie hat bewiesen, dass sie keine alternde Schönheit, sondern eine Meisterschützin und intelligente Ermittlerin des Unbekannten ist. Bis Isabellas Verschwinden aufgeklärt ist, wird Jenny ihre Suche nicht aufgeben.",
+        "back_text": "<b>Deckgröße</b>: 30.\n<b>Deckbau-Optionen</b>: Schurkenkarten ([rogue]) Stufe 0-5, Neutrale Karten Stufe 0-5, bis zu fünf Karten der Stufe 0 beliebiger anderer Klassen.\n<b>Deckbau-Voraussetzungen</b> (zählen nicht gegen die Deckgröße): Jennys Zwillings-45er, Auf der Suche nach Izzie, 1 zufällige Grundschwäche."
     },
     {
         "code": "02004",
-        "flavor": "\"No, not quiet at all. Dead folks get downright rambunctious when I play my horn.\"",
+        "flavor": "\"Nein, überhaupt nicht still. Die Toten werden regelrecht ausgelassen, wenn ich auf meiner Trompete spiele.\"",
         "name": "Jim Culver",
-        "subname": "The Musician",
-        "text": "Treat the modifier on [skull] tokens you reveal as \"0.\"\nAnytime you reveal a [elder_sign] token, you may choose to instead treat it as a [skull] token.\n[elder_sign] effect: +1.",
+        "subname": "Der Musiker",
+        "text": "Behandel den Modifikator auf [skull]-Markern, die du enthüllst, als eine \"0.\"\nImmer wenn du einen [elder_sign]-Marker enthüllst, darfst du ihn stattdessen als [skull]-Marker behandeln.\n[elder_sign]-Effekt: +1.",
         "traits": "Performer.",
-        "back_flavor": "Jazz has been nothing but trouble for Jim since the day he picked up his daddy's trumpet. There was something weird and otherworldly about the writing on the inside of the bell, but the tones from it were smooth and dark, like good coffee. That trumpet landed Jim a lot of gigs until the time it made Widow Jenkins get up and dance, the day he played at her funeral. After that, it was kind of hard to find work. Since then, Jim has learned a lot about jazz — and the things the graveyard ghouls talk about on cold autumn nights. Lately, they've been talking about The End, as in the end of everything that is and could be. The Final Rhapsody. The fact is, Jim isn't too keen on that idea.",
-        "back_text": "<b>Deck size</b>: 30.\n<b>Deckbuilding options</b>: Mystic cards ([mystic]) level 0-5, Neutral cards level 0-5, up to five level 0 cards from any other class.\n<b>Deckbuilding requirements</b> (do not count toward deck size): Jim's Trumpet, Final Rhapsody, 1 random basic weakness."
+        "back_flavor": "Jazz bereitet Jim seit dem Tag, an dem er zum ersten Mal nach der Trompete seines Vaters gegriffen hatte, immer nur Probleme. Irgendetwas war merkwürdig, beinahe uniridsich an den Gravierungen im Schallstück, aber ihr Klang war glatt und dunkel, wie guter Kaffee. Diese Trompete brachte Jim eine Menge Konzerte ein, bis die Witwe Jenkins aufstand und tanzte, als er auf ihrer Beerdigung spielte. Danach war es schwer, neue Engagements zu finden. Seitdem hat Jim eine Menge über Jazz gelernt - und über die Dinge, über welche die Ghule auf Friedhöfen in kalten Herbstnächten sprechen. In letzter Zeit sprachen sie über das Ende, wie in das Ende von allem, was ist und sein könnte. Die Letzte Rhapsodie. Um die Wahrheit zu sagen, Jim ist nicht unbedingt begeistert von dieser Idee.",
+        "back_text": "<b>Deckgröße</b>: 30.\n<b>Deckbau-Optionen</b>: Magierkarten ([mystic]) Stufe 0-5, Neutrale Karten Stufe 0-5, bis zu fünf Karten der Stufe 0 beliebiger anderer Klassen.\n<b>Deckbau-Voraussetzungen</b> (zählen nicht gegen die Deckgröße): Jims Trompete, Letzte Rhapsodie, 1 zufällige Grundschwäche."
     },
     {
         "code": "02005",
-        "flavor": "\"C'mere, boy. We got work to do.\"",
+        "flavor": "\"Komm her, Junge. Wir haben etwas zu erledigen.\"",
         "name": "\"Ashcan\" Pete",
-        "subname": "The Drifter",
-        "text": "You begin the game with Duke in play.\n[free] Discard a card from your hand: Ready an asset you control. (Limit once per round.)\n[elder_sign] effect: +2. Ready Duke.",
-        "traits": "Drifter.",
-        "back_flavor": "At night, \"Ashcan\" Pete sleeps wherever his travels take him: in a field, on a train, or maybe, if he's lucky, in a barn. He bunks with his loyal hound dog, Duke, on one side and his beat-up guitar on the other. And sometimes when Pete sleeps, he dreams. He dreams of haunted, tortured places and of horrible creatures. When he wakes up, he knows that someone needs his help, because his dreams are true. He could not say how long he has been on the road, living by his wits, but he can say for certain no place is too far to go to help someone in need. And as long as Pete can help people, he is not likely to stop wandering any time soon.",
-        "back_text": "<b>Deck size</b>: 30.\n<b>Deckbuilding options</b>: Survivor cards ([survivor]) level 0-5, Neutral cards level 0-5, up to five level 0 cards from any other class.\n<b>Deckbuilding requirements</b> (do not count toward deck size): Duke, Wracked by Nightmares, 1 random basic weakness."
+        "subname": "Der Herumtreiber",
+        "text": "Du beginnst das Spiel mit Duke im Spiel.\n[free] Lege eine Karte von deiner Hand ab: Mache eine Vorteilskarte, die du kontrollierst, spielbereit. (Nur ein Mal pro Runde.)\n[elder_sign]-Effekt: +2. Mache Duke spielbereit.",
+        "traits": "Herumtreiber.",
+        "back_flavor": "\"Ashcan\" Pete verbringt die Nächte dort, wohin ihn seine Reisen verschlagen: auf einem Feld, in einem Zug oder, wenn er Glück hat, in einer Scheune. Neben sich hat er dabei seinen treuen Jagdhund Duke auf der einen und seine verbeulte Gitarre auf der anderen Seite. Und manchmal träumt Pete dann. Er träumt von heimgesuchten, gequälten Orten und schrecklichen Kreaturen. Wenn er aufwacht, weiß er, dass jemand Hilfe braucht, denn seine Träume zeigen ihm die Wahrheit. Er weiß nicht mehr, wie lange er sich schon auf der Straße durchschlägt, aber er weiß sicher, dass kein Ort zu weit entfernt für ihn ist, wenn jemand seine Hilfe braucht. Und so lange Pete anderen Menschen helfen kann, wird er seine Wanderung nicht aufgeben.",
+        "back_text": "<b>Deckgröße</b>: 30.\n<b>Deckbau-Optionen</b>: Überlebenderkarten ([survivor]) Stufe 0-5, Neutrale Karten Stufe 0-5, bis zu fünf Karten der Stufe 0 beliebiger anderer Klassen.\n<b>Deckbau-Voraussetzungen</b> (zählen nicht gegen die Deckgröße): Duke, Von Albträumen gequält, 1 zufällige Grundschwäche."
     },
     {
         "code": "02006",
-        "name": "Zoey's Cross",
-        "subname": "Symbol of Righteousness",
-        "text": "Zoey Samaras deck only.\n[reaction] After an enemy becomes engaged with you, exhaust Zoey's Cross and spend 1 resource: Deal 1 damage to that enemy.",
-        "traits": "Item. Charm.",
+        "name": "Zoeys Kreuz",
+        "subname": "Symbol der Rechtschaffenheit",
+        "text": "Nur für das Deck von Zoey Samaras.\n[reaction] Nachdem ein Gegner mit dir in einem Kampf verwickelt worden ist, erschöpfe Zoeys Kreuz und gib 1 Ressource aus: Füge diesem Gegner 1 Schaden zu.",
+        "traits": "Gegenstand. Glücksbringer.",
         "slot": "Accessory"
     },
     {
         "code": "02007",
-        "name": "Smite the Wicked",
-        "text": "<b>Revelation</b> – Discard cards from the top of the encounter deck until an enemy is discarded. Attach Smite the Wicked to that enemy and spawn it at the location farthest from you.\n<b>Forced</b> – When the game ends, if attached enemy is in play: You suffer 1 mental trauma.",
-        "traits": "Task."
+        "name": "Zerschmettere die Gottlosen",
+        "text": "<b>Enthüllung</b> – Lege Karten oben vom Begegnungsdeck ab, bis ein Gegner abgelegt worden ist. Hänge Zerschmettere die Gottlosen an diesen Gegner an und lasse ihn an dem Ort erscheinen, der am weitesten von dir entfernt ist.\n<b>Erzwungen</b> – Sobald das Spiel endet, falls der Gegner mit dieser Verstärkung im Spiel ist: Du erleidest 1 seelisches Trauma.",
+        "traits": "Aufgabe."
     },
     {
         "code": "02008",
-        "flavor": "When things went his way, which wasn't often these days, Rex was a good reporter, with a nose for a story and an eye for detail... <cite>Graham McNeill, Ghouls of the Miskatonic,</cite>",
-        "name": "Search for the Truth",
-        "text": "Rex Murphy deck only.\nDraw X cards, where X is the number of clues on Rex Murphy (to a maximum of 5).",
-        "traits": "Insight."
+        "flavor": "Wenn es für ihn gut lief, was heutzutage nicht oft vorkam, war Rex ein guter Reporter mit einer Nase für eine gute Geschichte und scharfem Blick für Details ... <cite>Graham McNeill, Ghule von Miskatonic,</cite>",
+        "name": "Suche nach der Wahrheit",
+        "text": "Nur für das Deck von Rex Murphy.\nZiehe X Karten, wobei X die Anzahl der Hinweise auf Rex Murphy ist (bis zu einem Maximum von 5).",
+        "traits": "Erkenntnis."
     },
     {
         "code": "02009",
-        "name": "Rex's Curse",
-        "text": "<b>Revelation</b> - Put Rex's Curse into play in your threat area.\n<b>Forced</b> - When you would succeed at a skill test: Return the revealed chaos token to the bag and reveal a new chaos token. If this effect causes you to fail the test, shuffle Rex's Curse into your deck. (Limit once per test.)",
-        "traits": "Curse."
+        "name": "Rex` Fluch",
+        "text": "<b>Enthüllung</b> - Bringe Rex` Fluch in deiner Bedrohungszone ins Spiel.\n<b>Erzwungen</b> - Sobald dir eine Fertigkeitsprobe gelingen würde: Schicke den enthüllten Chaosmarker zurück in den Beutel und enthülle einen neuen Chaosmarker. Falls die Probe durch diesen Effekt misslingt, mische Rex` Fluch in dein Deck (Nur ein Mal pro Probe).",
+        "traits": "Fluch."
     },
     {
         "code": "02010",
-        "flavor": "\"...Say, are those Mr. Donohue's guns?\" Jenny held a pistol over her shoulder and struck a pose. \"I think they suit me better than him. Don't you agree?\"",
-        "name": "Jenny's Twin .45s",
-        "subname": "A Perfect Fit",
-        "text": "Jenny Barnes deck only. Uses (X ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +2 [combat] for this attack. This attack deals +1 damage.",
-        "traits": "Item. Weapon. Firearm.",
+        "flavor": "\"...Sag mal, sind das die Waffen von Mr. Donohue?\" Jenny posierte mit einer Pistole über ihrer Schulter. \"Ich denke, die stehen mir besser als ihm. Findest du nicht auch?\"",
+        "name": "Jennys Zwillings-45er",
+        "subname": "Passen perfekt",
+        "text": "Nur für das Deck von Jenny Barnes. Anwendungen (X Munition).\n[action] Gib 1 Munition aus: <b>Kampf.</b> Du bekommst für diesen Angriff +2 [combat]. Dieser Angriff fügt +1 Schaden zu.",
+        "traits": "Gegenstand. Waffe. Feuerwaffe.",
         "slot": "Hand x2"
     },
     {
         "code": "02011",
-        "name": "Searching for Izzie",
-        "text": "<b>Revelation</b> - Attach Searching for Izzie to the location farthest from you.\n[action][action]: <b>Investigate</b>. If you succeed, instead of discovering clues, discard Searching for Izzie.\n<b>Forced</b> - When the game ends, if Searching for Izzie is in play: You suffer 1 mental trauma.",
-        "traits": "Task."
+        "name": "Auf der Suche nach Izzie",
+        "text": "<b>Enthüllung</b> - Hänge Auf der Suche nach Izzie an den Ort an, der am weitesten von dir entfernt ist.\n[action][action]: <b>Ermitteln</b>. Falls die Probe gelingt, lege Auf der Suche nach Izzie ab, statt Hinweise zu entdecken.\n<b>Erzwungen</b> - Sobald das Spiel endet, falls Auf der Suche nach Izzie im Spiel ist: Du erleidest 1 seelisches Trauma.",
+        "traits": "Aufgabe."
     },
     {
         "code": "02012",
-        "flavor": "Daddy used to say, \"Jazz is a lot like liquor, it makes everything go down a little smoother.\" Daddy used to say a lot of stupid things.",
-        "name": "Jim's Trumpet",
-        "subname": "The Dead Listen",
-        "text": "Jim Culver deck only.\n[reaction] When a [skull] token is revealed during a skill test, exhaust Jim's Trumpet: Heal 1 horror from an investigator at your location or a connecting location.",
-        "traits": "Item. Instrument. Relic.",
+        "flavor": "Daddy sagte immer: \"Jazz ist ähnlich wie Schnaps, er sorgt dafür, dass alles etwas leichter zu schlucken ist.\" Daddy redete häufig dummr Zeug.",
+        "name": "Jims Trompete",
+        "subname": "Die Toten hören zu",
+        "text": "Nur für das Deck für Jim Culver.\n[reaction] Sobald ein [skull]-Marker während einer Fertigkeitsprobe enthüllt wird, erschöpfe Jims Trompete: Heile 1 Horror von einem Ermittler an deinem oder einem verbundenen Ort.",
+        "traits": "Gegenstand. Instrument. Relikt.",
         "slot": "Hand"
     },
     {
         "code": "02013",
-        "flavor": "When the dead start talking about what scares them, that's when it's time to listen.",
-        "name": "Final Rhapsody",
-        "text": "<b>Revelation</b> - Reveal 5 chaos tokens from the chaos bag. For each [skull] and [auto_fail] token revealed, take 1 damage and 1 horror.",
-        "traits": "Endtimes."
+        "flavor": "Wenn die Toten davon zu reden beginnen, was ihnen Angst macht, ist es an der Zeit, ihnen gut zuzuhören.",
+        "name": "Letzte Rhapsodie",
+        "text": "<b>Enthüllung</b> - Enthülle 5 Chaosmarker aus dem Chaosbeutel. Für jeden enthüllten [skull]- oder [auto_fail]-Marker nimm 1 Schaden und 1 Horror.",
+        "traits": "Endzeit."
     },
     {
         "code": "02014",
         "name": "Duke",
-        "subname": "Loyal Hound",
-        "text": "\"Ashcan\" Pete deck only.\n[action] Exhaust Duke: <b>Fight.</b> You attack with a base [combat] skill of 4. This attack deals +1 damage.\n[action] Exhaust Duke: <b>Investigate.</b> You investigate with a base [intellect] skill of 4. You may move to a connecting location immediately before investigating with this effect.",
-        "traits": "Ally. Creature."
+        "subname": "Loyaler Jagdhund",
+        "text": "Nur für das Deck von \"Ashcan\" Pete.\n[action] Erschöpfe Duke: <b>Kampf.</b> Du greifst mit einem Grund-[combat]-Fertigkeitswert von 4 an. Dieser Angriff fügt +1 Schaden zu.\n[action] Erschöpfe Duke: <b>Ermitteln.</b> Du ermittelst mit einem Grund-[intellect]-Fertigkeitswert von 4. Du darfst dich sofort auf einen verbundenen Ort bewegen, bevor du mit diesem Effekt ermittelst.",
+        "traits": "Verbündeter. Kreatur."
     },
     {
         "code": "02015",
-        "name": "Wracked by Nightmares",
-        "text": "<b>Revelation</b> - Exhaust all assets you control and put Wracked by Nightmares into play in your threat area.\nAssets you control cannot ready.\n[action][action]: Discard Wracked by Nightmares.",
-        "traits": "Madness."
+        "name": "Von Albträumen gequält",
+        "text": "<b>Enthüllung</b> - Erschöpfe alle Vorteilskarten, die du kontrollierst, und bringe Von Albträumen gequält in deiner Bedrohungszone ins Spiel. \nVorteilskarten, die du kontrollierst, können nicht spielbereit gemacht werden.\n[action][action]: Lege Von Albträumen gequält ab.",
+        "traits": "Wahnsinn."
     },
     {
         "code": "02016",
-        "name": "Blackjack",
-        "text": "[action]: <b>Fight.</b> You get +1 [combat] for this attack. If you perform this attack against an enemy engaged with another investigator and you fail, you deal no damage.",
-        "traits": "Item. Weapon. Melee.",
+        "name": "Totschläger",
+        "text": "[action]: <b>Kampf.</b> Du bekommst für diesen Angriff +1 [combat]. Falls du diesen Angriff gegen einen Gegner durchführst, der mit einem anderen Ermittler in einen Kampf verwickelt ist, und dir die Probe gelingt, fügst du keinen Schaden zu.",
+        "traits": "Gegenstand. Waffe. Nahkampf.",
         "slot": "Hand"
     },
     {
         "code": "02017",
-        "flavor": "You steel your nerves and shout into the darkness. \"Come and get me!\"",
-        "name": "Taunt",
-        "text": "Fast. Play only during your turn.\nEngage any number of enemies at your location.",
-        "traits": "Tactic."
+        "flavor": "Du nimmst deinen ganzen Mut zusammen und rufst in die Dunkelheit: \"Kommt und holt mich!\"",
+        "name": "Verspotten",
+        "text": "Schnell. Spiele diese Karte nur während deines Zuges.\nVerwickel eine beliebige Anzahl Gegner an deinem Ort in einen Kampf.",
+        "traits": "Taktik."
     },
     {
         "code": "02018",
-        "flavor": "It's dangerous to go alone.",
-        "name": "Teamwork",
-        "text": "Investigators at your location may give or trade any number of <b>Item</b> assets, <b>Ally</b> assets, or resources among one another.",
-        "traits": "Tactic."
+        "flavor": "Alleingänge sind gefährlich.",
+        "name": "Zusammenarbeit",
+        "text": "Ermittler an deinem Ort dürfen einander eine beliebige Anzahl von <b>Gegenstand</b>-Vorteilskarten, <b>Verbündeter</b>-Vorteilskarten oder Ressourcen geben oder untereinander tauschen.",
+        "traits": "Taktik."
     },
     {
         "code": "02019",
-        "flavor": "You steel your nerves and shout into the darkness. \"Come and get me!\"",
-        "name": "Taunt",
-        "text": "Fast. Play only during your turn.\nEngage any number of enemies at your location. Draw 1 card for each enemy engaged in this way.",
-        "traits": "Tactic."
+        "flavor": "Du nimmst deinen ganzen Mut zusammen und rufst in die Dunkelheit: \"Kommt und holt mich!\"",
+        "name": "Verspotten",
+        "text": "Schnell. Spiele diese Karte nur während deines Zuges.\nVerwickel eine beliebige Anzahl Gegner an deinem Ort in einen Kampf. Ziehe 1 Karte für jeden so in einen Kampf verwickelten Gegner.",
+        "traits": "Taktik."
     },
     {
         "code": "02020",
-        "name": "Laboratory Assistant",
-        "text": "Your maximum hand size is increased by 2 while checking your hand size during the upkeep phase.\n[reaction] After Laboratory Assistant enters play: Draw 2 cards.",
-        "traits": "Ally. Miskatonic. Science.",
+        "name": "Laborassistentin",
+        "text": "Dein Handkartenlimit wird um 2 erhöht, solange dein Handkartenlimit während der Unterhaltsphase überprüft wird.\n[reaction] Nachdem Laborassistentin ins Spiel gekommen ist: Ziehe 2 Karten.",
+        "traits": "Verbündeter. Miskatonic. Wissenschaft.",
         "slot": "Ally"
     },
     {
         "code": "02021",
-        "flavor": "By all accounts, it should not even exist.",
-        "name": "Strange Solution",
-        "subname": "Unidentified",
-        "text": "[action] Test [intellect] (4). If you succeed, discard Strange Solution and draw 2 cards. Record in your Campaign Log that \"you have identified the solution.\"",
-        "traits": "Item. Science."
+        "flavor": "Egal welche Quelle man zu Rate zieht, dieses Zeug sollte es überhaupt nicht geben.",
+        "name": "Seltsame Lösung",
+        "subname": "Nicht identifiziert",
+        "text": "[action] Lege eine [intellect]-Probe (4) ab. Falls die Probe gelingt, lege Seltsame Lösung ab und ziehe 2 Karten. Notiere in deinem Kampagnenlogbuch: \"Du hast die Lösung identifiziert.\"",
+        "traits": "Gegenstand. Wissenschaft."
     },
     {
         "code": "02022",
-        "flavor": "You know this town like the back of your hand.",
-        "name": "Shortcut",
-        "text": "Fast. Play only during your turn.\nChoose an investigator at your location. Move that investigator to a connecting location.",
-        "traits": "Insight. Tactic."
+        "flavor": "Du kennst diese Stadt wie deine Westentasche.",
+        "name": "Abkürzung",
+        "text": "Schnell. Spiele diese Karte nur in deinem Zug.\nWähle einen Ermittler an deinem Ort. Bewege diesen Ermittler an einen verbundenen Ort.",
+        "traits": "Erkenntnis. Taktik."
     },
     {
         "code": "02023",
-        "flavor": "Some people need to know the truth at any cost. Some truths can cut like knives.",
-        "name": "Seeking Answers",
-        "text": "<b>Investigate.</b> If you succeed, instead of discovering a clue at your location, discover a clue at a connecting location.",
-        "traits": "Insight."
+        "flavor": "Einige Menschen wollen die Wahrheit um jeden Preis erfahren. Einige Wahrheiten sind extrem schmerzhaft.",
+        "name": "Auf der Suche nach Antworten",
+        "text": "<b>Ermitteln.</b> Falls die Probe gelingt, entdeckst du statt eines Hinweises an deinem Ort einen Hinweis an einem verbundenen Ort.",
+        "traits": "Erkenntnis."
     },
     {
         "code": "02024",
-        "name": "Liquid Courage",
-        "text": "Uses (4 supplies).\n[action] Spend 1 supply: Choose an investigator at your location to heal 1 horror. Then, that investigator tests [willpower] (2). If the test succeeds, he or she heals 1 additional horror. If the test fails, he or she discards 1 card at random from his or her hand.",
-        "traits": "Item. Illicit."
+        "name": "Flüssiger Mut",
+        "text": "Anwendungen (4 Vorräte).\n[action] Gib 1 Vorrat aus: Wähle einen Ermittler an deinem Ort, um 1 Horror von ihm zu heilen. Dann legt dieser Ermittler eine [willpower]-Probe (2) ab. Falls die Probe gelingt, heilt er 1 weiteren Horror. Falls die Probe misslingt, legt er 1 zufällige Karte von seiner Hand ab.",
+        "traits": "Gegenstand. Illegal."
     },
     {
         "code": "02025",
-        "name": "Think on Your Feet",
-        "text": "Fast. Play when an enemy would spawn at your location.\nImmediately move to a connecting location. (The enemy still spawns at your previous location.)",
+        "name": "Eine schnelle Entscheidung",
+        "text": "Schnell. Spiele diese Karte nur, sobald ein Gegner an deinem Ort erscheinen würde.\nBewege dich sofort zu einem verbundenen Ort. (Der Gegner erscheint immer noch an deinem vorherigen Ort.)",
         "traits": "Trick."
     },
     {
@@ -197,95 +197,95 @@
     },
     {
         "code": "02027",
-        "name": "Hired Muscle",
-        "text": "You get +1 [combat].\n<b>Forced</b> – At the end of the upkeep phase: You must either pay 1 resource or discard Hired Muscle.",
-        "traits": "Ally. Criminal.",
+        "name": "Angeheuerter Schläger",
+        "text": "Du bekommtst +1 [combat].\n<b>Erzwungen</b> – Am Ende der Unterhaltsphase: Du musst entweder 1 Ressource zahlen oder Angeheuerter Schläger ablegen.",
+        "traits": "Verbündeter. Krimineller.",
         "slot": "Ally"
     },
     {
         "code": "02028",
-        "name": "Rite of Seeking",
-        "text": "Uses (3 charges).\n[action] Spend 1 charge: <b>Investigate.</b> Investigate using [willpower] instead of [intellect]. If you succeed, discover 1 additional clue at this location. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this test, after this test resolves lose all remaining actions and immediately end your turn.",
-        "traits": "Spell.",
+        "name": "Suchritual",
+        "text": "Anwendung (3 Ladungen).\n[action] Gib 1 Ladung aus: <b>Ermitteln.</b> Verwende beim Ermitteln [willpower] statt [intellect]. Falls die Probe gelingt, entdecke 1 zusätzlichen Hinweis an diesem Ort. Wenn ein [skull]-, [cultist]-, [tablet]-, [elder_thing]-, oder [auto_fail]-Symbol während dieser Probe enthüllt wird, verlierst du nach dieser Probe alle verbliebenen Aktionen und beendest sofort deinen Zug.",
+        "traits": "Zauber.",
         "slot": "Arcane"
     },
     {
         "code": "02029",
-        "flavor": "The wax tapers give off an eerie glow, and the flames move as if they are alive.",
-        "name": "Ritual Candles",
-        "text": "[reaction] After a [skull], [cultist], [tablet], or [elder_thing] symbol is revealed during a test you are performing: You get +1 skill value for this test.",
-        "traits": "Item.",
+        "flavor": "Die Wachskerzen glühen unheimlich und die Flammen zucken, als ob sie lebendig wären.",
+        "name": "Ritualkerzen",
+        "text": "[reaction] Nachdem ein [skull]-, [cultist]-, [tablet]-, oder [elder_thing]-Symbol während einer Probe enthüllt worden ist, die du ablegst: Du bekommst für diese Probe +1 auf den Fertigkeitswert.",
+        "traits": "Gegenstand.",
         "slot": "Hand"
     },
     {
         "code": "02030",
-        "flavor": "From the unreal lead me to the real<br>From the darkness lead me to the light<br>From the dead lead me to the immortal",
-        "name": "Clarity of Mind",
-        "text": "Uses (3 charges).\n[action] Spend 1 charge: Heal 1 horror from an investigator at your location.",
-        "traits": "Spell.",
+        "flavor": "Aus dem Irrealen führe mich zum realen<br>Aus der Dunkelheit führe mich ins Licht<br>Aus dem Reich der Toten führe mich in die Unsterblichkeit",
+        "name": "Klarheit des Geistes",
+        "text": "Anwendung (3 Ladungen).\n[action] Gib 1 Ladung aus: Heile 1 Horror von einem Ermittler an deinem Ort.",
+        "traits": "Zauber.",
         "slot": "Arcane"
     },
     {
         "code": "02031",
-        "name": "Bind Monster",
-        "text": "<b>Evade.</b> This evasion attempt uses [willpower] instead of [agility]. If you succeed and the enemy is non‑<i>Elite</i>, evade it and attach Bind Monster to it.\n[reaction] When attached enemy would ready: Test [willpower] (3). If you succeed, attached enemy does not ready. If you fail, discard Bind Monster.",
-        "traits": "Spell."
+        "name": "Monster binden",
+        "text": "<b>Entkommen.</b> Dieser Entkommen-Versuch verwendet [willpower] statt [agility]. Falls die Probe gelingt und es ein Nicht-<i>Elite</i>-Gegner ist, entkomme ihm und hänge Monster binden an ihn an.\n[reaction] Sobald der Gegner mit dieser Verstärkung spielbereit gemacht werden würde: Lege eine [willpower]-probe (3) ab. Falls die Probe gelingt, wird der Gegner mit dieser Verstärkung nicht spielbereit gemacht. Falls die Probe misslingt, lege Monster binden ab.",
+        "traits": "Zauber."
     },
     {
         "code": "02032",
-        "name": "Fire Axe",
-        "text": "[action]: <b>Fight.</b> If you have no resources in your resource pool, this attack deals +1 damage.\n[free] During an attack using Fire Axe, spend 1 resource: You get +2 [combat] for this skill test. (Limit three times per attack.)",
-        "traits": "Item. Weapon. Melee.",
+        "name": "Brandaxt",
+        "text": "[action]: <b>Kampf.</b> Falls du keine Ressourcen in deinem Ressourcenvorrat hast, fügt dieser Angriff +1 Schaden zu.\n[free] Gib während eines Angriffs, in dem du die Brandaxt verwendest, 1 Ressource aus: Du bekommst für diese Fertigkeitsprobe +2 [combat]. (Nur drei Mal pro Angriff.)",
+        "traits": "Gegenstand. Waffe. Nahkampf.",
         "slot": "Hand"
     },
     {
         "code": "02033",
-        "flavor": "The broad-shouldered young man exudes the sort of confidence one only finds in youth.",
+        "flavor": "Der breitschultrige junge Mann strahlt die Art Selbstbewusstsein aus, die nur jungen Menschen zu eigen ist.",
         "name": "Peter Sylvestre",
-        "subname": "Big Man on Campus",
-        "text": "You get +1 [agility].\n[reaction] After your turn ends: Heal 1 horror from Peter Sylvestre.",
-        "traits": "Ally. Miskatonic.",
+        "subname": "Große Nummer auf dem Campus",
+        "text": "Du bekommst +1 [agility].\n[reaction] Nachdem dein Zug beendet ist: Heile 1 Horror von Peter Sylvestre.",
+        "traits": "Verbündeter. Miskatonic.",
         "slot": "Ally"
     },
     {
         "code": "02034",
-        "name": "Bait and Switch",
-        "text": "<b>Evade.</b> If you succeed, if the enemy is non-<i>Elite</i>, evade the enemy and move it to a connecting location.",
+        "name": "Lockvogeltaktik",
+        "text": "<b>Entkommen.</b> Falls die Probe gelingt, falls es ein Nicht-<i>Elite</i>-Gegner ist, entkomme diesem Gegner und bewege ihn auf einen verbundenen Ort.",
         "traits": "Trick."
     },
     {
         "code": "02035",
-        "flavor": "The broad-shouldered young man exudes the sort of confidence one only finds in youth.",
+        "flavor": "Der breitschultrige junge Mann strahlt die Art Selbstbewusstsein aus, die nur jungen Menschen zu eigen ist.",
         "name": "Peter Sylvestre",
-        "subname": "Big Man on Campus",
-        "text": "You get +1 [agility] and +1 [willpower].\n[reaction] After your turn ends: Heal 1 horror from Peter Sylvestre.",
-        "traits": "Ally. Miskatonic.",
+        "subname": "Große Nummer auf dem Campus",
+        "text": "Du bekommst +1 [agility] und +1 [willpower].\n[reaction] Nachdem dein Zug beendet ist: Heile 1 Horror von Peter Sylvestre.",
+        "traits": "Verbündeter. Miskatonic.",
         "slot": "Ally"
     },
     {
         "code": "02036",
         "name": "Kukri",
-        "text": "[action]: <b>Fight.</b> You get +1 [combat] for this attack. If you succeed, you may spend 1 additional action to deal +1 damage for this attack.",
-        "traits": "Item. Weapon. Melee.",
+        "text": "[action]: <b>Kampf.</b> Du bekommst für diesen Angriff +1 [combat]. Falls die Probe gelingt, darfst du 1 zusätzliche Aktion ausgeben, um mit diesem Angriff +1 Schaden zuzfügen.",
+        "traits": "Gegenstand. Waffe. Nahkampf.",
         "slot": "Hand"
     },
     {
         "code": "02037",
-        "flavor": "One man's loan is another man's treasure.",
-        "name": "Indebted",
-        "text": "Permanent.\nYou start each game with 2 fewer resources.",
-        "traits": "Flaw."
+        "flavor": "Die Schulden des einen, der Reichtum des anderen.",
+        "name": "Verschuldet",
+        "text": "Dauerhaft.\nDu beginnst das Spiel mit 2 Ressourcen weniger.",
+        "traits": "Makel."
     },
     {
         "code": "02038",
-        "name": "Internal Injury",
-        "text": "<b>Revelation</b> - Place Internal Injury into play in your threat area.\n<b>Forced</b> - At the end of your turn: Take 1 direct damage.\n[action][action]: Discard Internal Injury.",
-        "traits": "Injury."
+        "name": "Innere Verletzung",
+        "text": "<b>Enthüllung</b> - Bringe Innere Verletzung in deiner Bedrohungszone ins Spiel.\n<b>Erzwungen</b> - Am Ende deines Zuges: Nimm 1 direkten Schaden.\n[action][action]: Lege Innere Verletzung ab.",
+        "traits": "Verletzung."
     },
     {
         "code": "02039",
-        "name": "Chronophobia",
-        "text": "<b>Revelation</b> - Place Chronophobia into play in your threat area.\n<b>Forced</b> - At the end of your turn: Take 1 direct horror.\n[action][action]: Discard Chronophobia.",
-        "traits": "Madness."
+        "name": "Chronophobie",
+        "text": "<b>Enthüllung</b> - Bringe Chronophobie in deiner Bedrohungszone ins Spiel.\n<b>Erzwungen</b> - Am Ende deines Zuges: Nimme 1 direkten Horror.\n[action][action]: Lege Chronophobie ab.",
+        "traits": "Wahnsinn."
     }
 ]

--- a/translations/de/pack/dwl/dwl_encounter.json
+++ b/translations/de/pack/dwl/dwl_encounter.json
@@ -2,480 +2,480 @@
     {
         "code": "02040",
         "name": "Dr. Henry Armitage",
-        "subname": "The Head Librarian",
-        "text": "[reaction] After you draw a card, discard that card and exhaust Dr. Henry Armitage: Gain 3 resources.",
-        "traits": "Ally. Miskatonic.",
+        "subname": "Leiter der Bibliothek",
+        "text": "[reaction] Nachdem du eine Karte gezogen hast, lege jene Karte ab und erschöpfe Dr. Henry Armitage: Du erhälst 3 Ressourcen.",
+        "traits": "Verbündeter. Miskatonic.",
         "slot": "Ally"
     },
     {
         "code": "02041",
-        "name": "Extracurricular Activity",
-        "text": "<b>Easy / Standard</b>\n[skull]: -1. If you fail, discard the top 3 cards of your deck.\n[cultist]: -1 (-3 instead if there are 10 or more cards in your discard pile).\n[elder_thing]: -X. Discard the top 2 cards of your deck. X is the total printed cost of those discarded cards.",
-        "back_text": "<b>Hard / Expert</b>\n[skull]: -2. If you fail, discard the top 5 cards of your deck.\n[cultist]: -1 (-5 instead if there are 10 or more cards in your discard pile).\n[elder_thing]: -X. Discard the top 3 cards of your deck. X is the total printed cost of those discarded cards."
+        "name": "Aktivitäten außerhalb des Lehrplans",
+        "text": "<b>Einfach / Normal</b>\n[skull]: -1. Falls die Probe misslingt, lege die obersten 3 Karten deines Decks ab.\n[cultist]: -1 (-3 stattdessen, falls sich 10 oder mehr Karten in deinem Ablagestapel befinden).\n[elder_thing]: -X. Lege die obersten 2 Karten deines Decks ab. X ist die Gesamtsumme der aufgedruckten Kosten der abgelegten Karten.",
+        "back_text": "<b>Schwer / Experte</b>\n[skull]: -2. Falls die Probe misslingt, lege die obersten 5 Karten deines Decks ab.\n[cultist]: -1 (-5 stattdessen, falls sich 10 oder mehr Karten in deinem Ablagestapel befinden).\n[elder_thing]: -X. Lege die obersten 3 Karten deines Decks ab. X ist die Gesamtsumme der aufgedruckten Kosten der abgelegten Karten."
     },
     {
         "code": "02042",
-        "flavor": "You have arrived at the Miskatonic University campus in search of Professor Warren Rice. Classes are over, and a mysterious silence hangs in the air over the quad.",
-        "name": "Quiet Halls",
-        "back_name": "Something Stirs",
-        "back_flavor": "The university is dead silent. The shadows coil about your feet as you walk, and you swear there is something following you with each step you take. Is it just your imagination? Or is there really someone — or something — stalking you?",
-        "back_text": "Each investigator with 5 or more cards in his or her discard pile takes 1 horror. Each investigator with 10 or more cards in his or her discard pile takes 2 horror, instead.\nIf the players have completed The House Always Wins, advance directly to agenda 2b. If Extracurricular Activity is the first scenario in the campaign, advance to agenda 2a."
+        "flavor": "Auf der Suche nach Professor Warren Rice bist du auf dem Campus der Miskatonic Universität angekommen. Der Unterricht ist für heute vorbei und eine geheimnisvolle Stille legt sich über das Freigelände der Universität.",
+        "name": "Stille Flure",
+        "back_name": "Etwas regt sich",
+        "back_flavor": "Die Universität ist totenstill. Die Schatten winden sich beim gehen um die Füße und du hast das sichere Gefühl, verfolgt zu werden. Bildest du dir das nur ein? Oder ist wirklich jemand - oder etwas - hinter dir her?",
+        "back_text": "Jeder Ermittler mit 5 oder mehr Karten in seinem Ablagestapel nimmt 1 Horror. Jeder Ermittler mit 10 oder mehr Karten in seinem Ablagestapel nimmt stattdessen 2 Horror.\nFalls die Spieler Das Haus gewinnt immer bereits abgeschlossen haben, rücke direkt zu Agenda 2b vor. Falls Aktivitäten außerhalb des Lehrplans das erste Szenario der Kampagne ist, rücke zu Agenda 2a vor."
     },
     {
         "code": "02043",
-        "flavor": "Professor Rice's disappearance isn't the only thing amiss at the university. You're unsure exactly what is going on, but you're starting to believe Armitage was right in asking for your help.",
-        "name": "Dead of Night",
-        "text": "Each investigator's maximum hand size is reduced by 3 while checking his or her hand size during the upkeep phase.",
-        "back_name": "An Experiment Gone Wrong",
-        "back_flavor": "A cry of fear echoes through the campus, and several students flee from the eastern side of the university, where the Science building can be found. Could this commotion be linked to Professor Rice's disappearance?",
-        "back_text": "If the Dormitories location is not in play, put it into play.\nIf The Experiment is in play, move it 1 location towards the Dormitories.\nIf The Experiment is not in play, spawn it in the Science Building."
+        "flavor": "Das Verschwinden von Professor Rice ist nicht das einzige Merkwürdige an dieser Universität. Du bist dir nicht sicher, was genau vor sich geht, aber langsam glaubst du, dass Armitage Recht hatte, als er dich um Hilfe gebeten hat.",
+        "name": "Tiefste Nacht",
+        "text": "Das Handkartenlimit jedes Ermittlers wird um 3 gesenkt, solange das Handkartenlimit in der Unterhaltsphase überprüüft wird.",
+        "back_name": "Ein fehlgeschlagenes Experiment",
+        "back_flavor": "Ein Angstschrei hallt auf dem Campus wider und einige Studenten fliehen aus dem östlichen Teil der Universität, wo sich das naturwissenschaftliche Gebäude befindet. Könnte dieser Tumult mit dem Verschwinden von Professor Rice im Zusammenhang stehen?",
+        "back_text": "Falls der Ort Studentenwohnheime nicht im Spiel ist, bringe ihn ins Spiel.\nFalls Das Experiment im Spiel ist, bewege es 1 Ort in Richtung Studentenwohnheime.\nFalls Das Experiment nicht im Spiel ist, erscheint es im Naturwissenschaftlichen Gebäude."
     },
     {
         "code": "02044",
-        "flavor": "Some kind of wild creature is on the loose. Whatever it is, it appears to be headed toward the university dormitories.",
-        "name": "The Beast Unleashed",
-        "text": "<b>Forced</b> - When this agenda would advance by reaching its doom threshold: Instead, remove all doom in play and move The Experiment 1 location toward the Dormitories.\n<b>Objective</b> - If The Experiment enters the Dormitories, advance.",
-        "back_name": "Not Fast Enough",
-        "back_flavor": "Before you are able to act, you hear screaming from the northern side of the campus. You begin to make your way toward the screaming, your vision darkening with each step. As soon as the creature enters sight, you feel the darkness overtake you, and a force pulls you out of your consciousness. Everything goes black, and you pass out.",
-        "back_text": "Each investigator immediately takes 3 horror. Then, proceed to <b>(→R4)</b>."
+        "flavor": "Eine wilde Kreatur läuft frei herum. Was es auch ist, es scheint sich auf die Studentenwohnheime der Universität zuzubewegen.",
+        "name": "Die entfesselte Bestie",
+        "text": "<b>Erzwungen</b> - Sobald von dieser Agenda vorgerückt werden würde, weil ihr Schwellenwert für das Verderben erreicht worden ist: Entferne stattdessen alle Verderbensmarker im Spiel und bewege Das Experiment 1 Ort in Richtung Studentenwohnheime.\n<b>Ermittlungsziel</b> - Falls Das Experiment die Studentenwohnheime betritt, rücke vor.",
+        "back_name": "Nicht schnell genug",
+        "back_flavor": "Bevor du etwas tun kannst, hörst du Schreie aus dem nördlichen Teil des Campus. Du eilst in die Richtung, aus der die Schreie gekommen sind, aber mit jedem Schritt verdunkelt sich deine Sicht. Als du die Kreatur erblickst, fühlst du, wie die Dunkelheit von dir Besitz ergreift und eine Kraft an deinem Bewusstsein zerrt. Alles wird schwarz und du wirst bewusstlos.",
+        "back_text": "Jeder Ermittler nimmt sofort 3 Horror. Fahre dann mit <b>(→A4)</b> fort."
     },
     {
         "code": "02045",
-        "flavor": "Professor Rice was last seen several hours ago by one of Armitage's students, in the Humanities building.",
-        "name": "After Hours",
-        "back_name": "The Head Janitor",
-        "back_flavor": "You were unable to find Professor Rice, but one of the students you spoke with mentioned a strange man entering Rice's office. Unfortunately, the door leading to the faculty offices is locked at this late hour. The student says that the head janitor, \"Jazz\", might be able to let you in, if you can find him.",
-        "back_text": "Shuffle the encounter discard pile and the set-aside \"Jazz\" Mulligan into the encounter deck."
+        "flavor": "Professor Rice wurde zuletzt vor einigen Stunden von einem Studenten von Armitage im geisteswissenschaftlichen Gebäude gesehen.",
+        "name": "Nach Feierabend",
+        "back_name": "Chefhausmeister",
+        "back_flavor": "Du konntest Professor Rice nicht finden, aber einer der Studenten, mit denen du gesprochen hast, erwähnte einen merkwürdigen Mann, der das Büro von Rice betreten hat. Leider ist die Tür zu den Büros der Lehrkräfte so spät in der Nacht verschlossen. Der Student meint, dass der Chefhausmeister \"Jazz\" dich vielleicht hineinlässt, falls du ihn finden kannst.",
+        "back_text": "Mische den Begegnungs-Ablagestapel und den beiseitegelegten \"Jazz\" Mulligan in das Begegnungsdeck."
     },
     {
         "code": "02046",
-        "flavor": "Concerned for Professor Rice's safety, you seek out the head janitor, who can let you into the locked sections of the campus.",
-        "name": "Rice's Whereabouts",
-        "text": "[action] Spend 1 clue: Discard the top 5 cards of the encounter deck (top 10 instead if there is only 1 player in the game).\n<b>Forced</b> - If you discard \"Jazz\" Mulligan for any reason, resolve his revelation effect.\n<b>Objective</b> - When you take control of \"Jazz\" Mulligan, advance.",
-        "back_name": "The Experiment Is Loose!",
-        "back_flavor": "You convince \"Jazz\" that something strange is going on, and that Professor Rice may be in danger. He doesn't trust you enough to hand you his keys, but agrees to come with you.\nAll of a sudden, you hear a crash coming from the Science building, and a student rushes toward you. \"Help!\" he cries. \"There's some kind of animal loose in the chem labs! I only barely caught a glimpse of it, but...\" He shudders. \"I think it's heading to the dorms! You've got to do something!\"",
-        "back_text": "If the Alchemy Labs location is not in play, put it into play. If you are at Agenda 1 or 2, spawn The Experiment in the Alchemy Labs.\nIf you have completed The House Always Wins, put the set-aside Alchemical Concoction into play underneath the Alchemy Labs. If Extracurricular Activity is the first scenario of the campaign, remove the set-aside Alchemical Concoction from the game, instead."
+        "flavor": "Besorgt um die Sicherheit von Professor Rice suchst du den Chefhausmeister, der dich in die verschlossenen Bereiche des Campus lassen könnte.",
+        "name": "Wo ist Rice?",
+        "text": "[action] Gib 1 Hinweis aus: Lege die obersten 5 Karten des Begegnungsdecks ab (falls 1 Spieler im Spiel ist, stattdessen die obersten 10).\n<b>Erzwungen</b> - Falls du \"Jazz\" Mulligan aus irgendeinem Grund ablegst, handle seinen Enthüllungseffekt ab.\n<b>Ermittlungsziel</b> - Sobald du die Kontrolle über \"Jazz\" Mulligan übernimmst, rücke vor.",
+        "back_name": "Das Experiment läuft frei herum!",
+        "back_flavor": "Du überzeugst \"Jazz\", dass irgendetwas Merkwürdiges vorgeht und das Professor Rice Möglicherweise in Schwierigkeiten ist. Er traut dir nicht genug, um dir die Schlüssel auszuhändigen, ist aber bereit dich zu begleiten \nPlötzlich hörst du ein lautes Krachen aus dem Naturwissenschaftlichen Gebäude und ein Student rennt auf dich zu. \"Hilfe!\", schreit er. \"Da ist irgendein Tier im Chemielabor! Ich konnte es nur ganz kurz sehen, aber...\" Er schauder. \"Ich glaube es ist auf den Weg zu den Studentenwohnheimen! Sie müssen etwas unternehmen!\"",
+        "back_text": "Falls das Alchemistenlabor nicht im Spiel ist, bringe es ins Spiel. Falls du bei Agenda 1 oder 2 bist, erscheint das beiseitegelegte Das Experiment im Alchemistenlabor.\nFalls Das Haus gewinnt immer bereits abgeschlossen ist, bringe die beiseitegelegte Karte Alchemistisches Gebräu unter dem Alchemistenlabor ins Spiel. Falls Aktivitäten außerhalb des Lehrplans das erste Szenario der Kampagne ist, entferne die die beiseiteglegte Karte Alchemistisches Gebräu stattdessen aus dem Spiel."
     },
     {
         "code": "02047",
-        "flavor": "You have only moments to react. You could warn the students in the dormitories and escort them to safety, or continue your task of searching the faculty offices for Professor Rice. Or, perhaps you could try to slay the beast that threatens the campus.",
-        "name": "Campus Safety",
-        "text": "<b>Objective</b> - Find and complete an objective on another encounter card.",
-        "back_name": "The Beast's Death",
-        "back_flavor": "The monstrous creature lets out a terrible shriek as it succumbs to its wounds and collapses onto the ground. A foul odor emanates from the corpse as its flesh begins to bubble and froth. Your relief turns to disgust as the body begins to shrink and disintegrate. Minutes later, the body has almost entirely evaporated into a sticky mass, and the awful odor has vanished. Inside the remnants of the creature's body, all you can find is a set of bones – the skeletal structure of a canine.",
-        "back_text": "<b>(→R3)</b>"
+        "flavor": "Dir bleibt nur wenig Zeit, um zu reagieren. Du könntest die Studenten in den Studentwohnheimen warnen und in Sicherheit bringen oder deine Aufgabe erfüllen und in den Büros der Lehrkräfte nach Professor Rice suchen. Vielleicht könntest du auch versuchen die Bestie, die den Campus terrorisiert, zu überwältigen.",
+        "name": "Campussicherheit",
+        "text": "<b>Ermittlungsziel</b> - Finde ein Ermittlungsziel auf einer anderen Begegnungskarte und schließe es ab.",
+        "back_name": "Der Tod der Bestie",
+        "back_flavor": "Die monströse Kreatur kreischt schrill auf, als sie ihren Wunden erliegt und zusammenbricht. Ein fauliger Gestank steigt von dem Kadaver auf, als das Fleisch zu blubbern und zu schäumen beginnt. Deine Erleichterung hält nicht lange an, als du angewidert siehst, dass der Körper zunächst schrumpft und sich dann auflöst. Kurz darauf ist er nur noch eine klebrige Masse und der fürchterliche Gestank ist verschwunden. In den Überresten befindet sich aber nur ein Skelett - das eines Hundes.",
+        "back_text": "<b>(→A3)</b>"
     },
     {
         "code": "02048",
-        "flavor": "Surrounded by fences and gates of wrought iron, you can't help but feel as much a prisoner here as a guest.",
-        "name": "Miskatonic Quad",
-        "text": "[action]: <b>Resign</b>. \"We can't find Rice anywhere...\" You leave the campus, hoping Armitage will forgive you.",
+        "flavor": "Umgeben von Zäunen und schmiedeeisernen Toren fühlst du dich eher wie ein Gefangener als wir ein Gast ...",
+        "name": "Miskatonic-Freigelände",
+        "text": "[action]: <b>Aufgeben</b>. \"Ich kann Rice nirgendwwo finden...\" Du verlässt das Gelände und hoffst, dass Armitage dir verzeihen wird.",
         "traits": "Miskatonic.",
-        "back_flavor": "A too-early winter has stripped the trees bare. Their dead branches whistle as a sharp, cold wind cuts across the empty quad."
+        "back_flavor": "Ein viel zu früher Wintereinbruch hat dafür gesorgt, dass die Bäume bereits kahl sind. Ihre toten Äste pfeifen im scharfen, kalten Wind, der über das leere Freigelände weht."
     },
     {
         "code": "02049",
-        "flavor": "The power is out, plunging the building's halls into heavy darkness. There is no sign of Professor Rice.",
-        "name": "Humanities Building",
-        "text": "<b>Forced</b> - At the end of your turn, if you are in the Humanities Building: Discard the top X cards of your deck, where X is the amount of horror on you.",
+        "flavor": "Der ausgefallene Strom taucht das Innere des Gebäudes in tiefste Finsternis. Es gibt keine Spur von Professor Rice.",
+        "name": "Geisteswissenschaftliches Gebäude",
+        "text": "<b>Erzwungen</b> - Falls du dich am Ende deines Zuges im geisteswissenschaftlichen Gebäude befindest: Lege die obersten X Karten deines Decks ab, wobei X die Menge an Horror auf dir ist.",
         "traits": "Miskatonic.",
-        "back_flavor": "Professor Rice was last seen in the humanities building, teaching one of his Latin classes. The murky windows of the weatherworn structure emit no light, and the night is silent around you."
+        "back_flavor": "Professor Rice wurde zuletzt im geisteswissenschatlichen Gebäude gesehen, wo er Latein unterrichtet. Die trüben Fenster des verwitterten Gebäudes sind dunkel und um dich herum gerrscht nächtliche Stille."
     },
     {
         "code": "02050",
-        "flavor": "The Orne Library is a labyrinth of dusty bookshelves and poorly lit halls.",
-        "name": "Orne Library",
-        "text": "You must spend 1 additional action to investigate the Orne Library.",
+        "flavor": "Die Orne-Bibliothek ist ein Labyrinth aus staubigen Bücherregalen und schlecht beleuchteten Hallen.",
+        "name": "Orne-Bibliothek",
+        "text": "Du musst 1 zusätzliche Aktion ausgeben, um in der Orne-Bibliothek zu ermitteln.",
         "traits": "Miskatonic.",
-        "back_flavor": "Three floors of weathered grey granite, the library looks more like a reliquary than a place of learning. Stone gargoyles snarl down from above arched windows, and Latin script winds around the double doors at the top of a wide set of stone steps."
+        "back_flavor": "Das dreistöckige Gebäude aus grauem Granit ähnelt eher einem Reliquienschrein als einem Ort zum Lernen. Steinerne Wasserspeier fletschen über den Bogenfenstern die Zähne und über breite Steinstufen erreicht man die Doppeltür, um die sich ein lateinischer Shriftzug rankt."
     },
     {
         "code": "02051",
-        "name": "Student Union",
-        "text": "<b>Forced</b> - After Student Union is revealed: Put the set-aside Dormitories into play.\n[action][action]: Heal 1 damage and 1 horror.",
+        "name": "Studentenvereinigung",
+        "text": "<b>Erzwungen</b> - Nachdem Studentenvereinigung enthüllt worden ist: Bringe die beiseitegelegten Studentenwohnheime ins Spiel.\n[action][action]: Heile 1 Schaden und 1 Horror.",
         "traits": "Miskatonic.",
-        "back_flavor": "Even at this late hour, you can hear a muffled chatter from inside the student union. Perhaps one of the students will know where Professor Rice is."
+        "back_flavor": "Selbst zu so später Stunde kann man den gedämpften Klang von Gesprächen aus dem Inneren der Studentenvereinigung hören. Vielleicht weiß einer der Studenten, wo Professor Rice ist."
     },
     {
         "code": "02052",
-        "flavor": "As you explore these old, well-kept buildings, you find yourself wondering whether the beds are comfortable...",
-        "name": "Dormitories",
-        "text": "<b>Objective</b> - If investigators in the Dormitories spend 3[per_investigator] clues, as a group: <b>(→R2)</b>",
+        "flavor": "Beim Durchsuchen der alten, aber gut in Schuss gehaltenen Gebäude, stellt sich die Frage, ob die Betten wohl bequem sind.",
+        "name": "Studentenwohnheime",
+        "text": "<b>Ermittlungsziel</b> - Falls die Ermittler in Studentenwohnheime als Gruppe 3[per_investigator] Hinweise ausgeben: <b>(→A2)</b>",
         "traits": "Miskatonic.",
-        "back_flavor": "The red brick form of the west dormitory could be seen through the trees...<br><cite>Graham McNeill, Ghouls of the Miskatonic</cite>",
-        "back_text": "The door leading into the Dormitories is locked. You cannot move into the Dormitories."
+        "back_flavor": "Durch die Blätter der Bäume seht ihr die roten Ziegelsteinmauern des westlichen Studentenwohnheims.<br><cite>Graham McNeill, Die Guhle von Miskatonic</cite>",
+        "back_text": "Die Tür, die in die Studentenwohnheime führt, ist verschlossen. Du kannst dich nicht in die Studentenwohnheime bewegen."
     },
     {
         "code": "02053",
-        "name": "Administration",
-        "text": "<b>Forced</b> - After Administration is revealed: Put the set-aside Faculty Offices into play.\n<b>Forced</b> - At the end of your turn, if you are in Administration: Discard the top card of your deck.",
+        "name": "Verwaltungsgebäude",
+        "text": "<b>Erzwungen</b> - Nachdem Verwaltungsgebäude enthüllt worden ist: Bringe die beiseitegelegten Büros der Lehrkräfte ins Spiel.\n<b>Erzwungen</b> - Falls du dich am Ende deines Zuges im Verwaltujngsgebäude befindest: Lege die oberste Karte deines Decks ab.",
         "traits": "Miskatonic.",
-        "back_flavor": "Around the aged administration building, creepers of ivy climb from the ground in an effort to claim it. The old hall stands alone in an isolated section of the campus, apart from the day-to-day bustle of students."
+        "back_flavor": "Das alte Verwaltungsgebäude ist fast vollständig von Efeuranken umschlungen, die den Eindruck machen, als wollten sie das Gebäude übernehmen. Das alte Gemäuer steht allein in einem vom täglichen Trubel des Universitätslebens etwas abgeschiedenen Bereich des Campus."
     },
     {
         "code": "02054",
-        "name": "Faculty Offices",
-        "subname": "The Night is Still Young",
-        "text": "<b>Forced</b> - After Faculty Offices is revealed: Search the encounter deck and discard pile for a <i>Humanoid</i> enemy and spawn it here. Shuffle the encounter deck.\n<b>Objective</b> - If investigators in the Faculty Offices spend 2[per_investigator] clues, as a group: <b>(→R1)</b>",
+        "name": "Büros der Lehrkräfte",
+        "subname": "Die Nacht ist noch jung",
+        "text": "<b>Erzwungen</b> - Nachdem Büros der Lehrkräfte enthüllt worden ist: Durchsuche das Begegnungsdeck und den Ablagestapel nach einem <i>Humanoid</i>-Gegner, der hier erscheit. Mische das Begegnungsdeck.\n<b>Ermittlungsziel</b> - Falls die Ermittler in den Büros der Lehrkräfte als Gruppe 2[per_investigator] Hinweise ausgeben: <b>(→A1)</b>",
         "traits": "Miskatonic.",
-        "back_flavor": "You come to a locked door at the top of the stairs leading to the third floor of the administration building. Through its frosted window, you glimpse a shadow darting across the hall.",
-        "back_text": "The door leading into the Faculty Offices is locked. You cannot move into the Faculty Offices."
+        "back_flavor": "Am oberen Ende der Treppe in den dritten Stock des Verwaltungsgebäudes befindet sich eine verschlossene Tür. Durch das Milchglasfenster ist ein Schatten zu sehen, der durch den Flur eilt.",
+        "back_text": "Die Tür, die zu den Büros der Lehrkräfte führt, ist verschlossen. Du kannst dich nicht in die Büros der Lehrkräfte bewegen."
     },
     {
         "code": "02055",
-        "flavor": "There is no sign of Professor Rice in his office. You call his name, and it echoes fruitlessly through the hall.",
-        "name": "Faculty Offices",
-        "subname": "The Hour is Late",
+        "flavor": "In seinem Büro gibt es keine Spur von Professor Rice. Du rufst seinen Namen, aber die einzige Antwort ist der Widerhall deiner Stimme im Flur.",
+        "name": "Büros der Lehrkräfte",
+        "subname": "Es wird spät",
         "traits": "Miskatonic.",
-        "back_flavor": "You come to a locked door at the top of the stairs leading to the third floor of the administration building. Through its frosted window, you glimpse a shadow darting across the hall... or maybe it's just your imagination.",
-        "back_text": "The door leading into the Faculty Offices is locked. You cannot move into the Faculty Offices."
+        "back_flavor": "Am oberen Ende der Treppe in den dritten Stock des Verwaltungsgebäudes befindet sich eine verschlossene Tür. Durch das Milchglasfenster glaubst du einen Schatten zu sehen, der durch den Flur eilt... vielleicht spielt dir aber auch deine Fantasie einen Streich.",
+        "back_text": "Die Tür, die zu den Büros der Lehrkräfte führt, ist verschlossen. Du kannst dich nicht in die Büros der Lehrkräfte bewegen."
     },
     {
         "code": "02056",
-        "flavor": "A trail of viscous ooze snakes through the halls of the Science building's first floor, leading down into the basement.",
-        "name": "Science Building",
-        "text": "<b>Forced</b> - After Science Building is revealed: Put the set-aside Alchemy Labs into play.\n<b>Forced</b> - When you fail a [willpower] test in the Science Building: Take 1 damage.",
+        "flavor": "Durch die Flure im ersten Stock des naturwissenschaftlichen Gebäudes zieht sich eine Spur aus zähflüssigem Schleim, die ins Untergeschoss führt.",
+        "name": "Naturwissenschaftliches Gebäude",
+        "text": "<b>Erzwungen</b> - Nachdem naturwissenschaftlichen Gebäude enthüllt worden ist: Bringe das beiseitegelegte Alchemistenlabor ins Spiel.\n<b>Erzwungen</b> - Sobald dir eine [willpower]-Probe im naturwissenschaftlichen Gebäude misslingt: Nimm 1 Schaden.",
         "traits": "Miskatonic.",
-        "back_flavor": "The Science building dominates the eastern side of the campus. Its windows are dark, save for a lone window shining faintly in the corner of the basement."
+        "back_flavor": "Das naturwissenschaftliche Gebäude nimmt den östlichen Teil des Campus ein. Seine Fenster sind dunkel, bis auf ein einzelnes Fenster im Untergeschoss, von dem ein schwacher Lichtschein ausgeht."
     },
     {
         "code": "02057",
-        "flavor": "Peculiar concoctions and obscure reagents line the shelves of the laboratory. What manner of science is going on down here?",
-        "name": "Alchemy Labs",
-        "text": "[action]: <b>Investigate.</b> If you are successful, instead of discovering clues, take the Alchemical Concoction from underneath this location if able.",
+        "flavor": "Auf den Regalen des Labors stehen merkwürdige Gebräue und obskure Reagenzien. Welche Art von Wissenschaft wird hier betrieben?",
+        "name": "Alchemistenlabor",
+        "text": "[action]: <b>Ermitteln.</b> Falls die Probe gelingt, nimm statt Hinweise zu entdecken das Alchemistische Gebräu unter diesem Ort, falls möglich.",
         "traits": "Miskatonic.",
-        "back_flavor": "A pungent stench rises from the laboratory downstairs. The silence of the hall is broken by the unmistakable hiss of a burner.",
-        "back_text": "The door leading into the Alchemy Labs is locked. You cannot move into the Alchemy Labs."
+        "back_flavor": "Ein stechender Geruch kommt aus dem unteren Laborbereich. Die Stille der Halle wird durch das unverkennbare Zischen eines Brenners unterbrochen.",
+        "back_text": "Die Tür, die ins Alchemistenlabor führt, ist verschlossen. Du kannst dich nicht ins Alchemistenlabor bewegen."
     },
     {
         "code": "02058",
-        "name": "The Experiment",
-        "subname": "Something Went Terribly Wrong",
-        "text": "Massive.\nThe Experiment gets +3[per_investigator] health.\n<b>Forced</b> - When the enemy phase begins: Ready The Experiment.\n<b>Objective</b> - If The Experiment is defeated, advance to act 3b.",
-        "traits": "Monster. Abomination. Elite."
+        "name": "Das Experiment",
+        "subname": "Irgendwas ist fürchterlich schiefgegangen",
+        "text": "Gewaltig.\nDas Experiment bekommt +3[per_investigator] Ausdauer.\n<b>Erzwungen</b> – Sobald die Gegnerphase beginnt: Mache Das Experiment spielbereit.\n<b>Ermittlungsziel</b> - Wenn Das Experiment besiegt wird, rücke zu Szene 3b vor.",
+        "traits": "Monster. Abscheulichkeit. Elite."
     },
     {
         "code": "02059",
-        "name": "Alchemical Concoction",
-        "text": "[action]: <b>Fight</b>. This attack uses [intellect] instead of [combat]. If used to attack The Experiment, this attack deals +6 damage. If you succeed, remove Alchemical Concoction from the game.",
-        "traits": "Item. Science."
+        "name": "Alchemistisches Gebräu",
+        "text": "[action]: <b>Kampf</b>. Dieser Angriff verwendet [intellect] statt [combat]. Falls dieser Vorteil verwendet wird, um Das Experiment anzugreifen, fügt dieser Angriff +6 Schaden zu. Falls die Probe gelingt, entferne Alchemistisches Gebräu aus dem Spiel.",
+        "traits": "Gegenstand. Wissenschaft."
     },
     {
         "code": "02060",
         "name": "\"Jazz\" Mulligan",
-        "subname": "The Head Janitor",
-        "text": "<b>Revelation</b> - Put \"Jazz\" Mulligan into play at your location.\nWhile \"Jazz\" Mulligan is not controlled by a player, he gains: \"[action]: <b>Parley</b>. Test [intellect] (3). If successful, take control of \"Jazz\" Mulligan.\"\nWhile you control \"Jazz\" Mulligan, you ignore the text on each unrevealed <i>Miskatonic</i> location.",
+        "subname": "Chefhausmeister",
+        "text": "<b>Enthüllung</b> - Bringe \"Jazz\" Mulligan an deinem Ort ins Spiel.\nSolange \"Jazz\" Mulligan nicht von einem Ermittler kontrolliert wird, erhält er: \"[action]: <b>Verhandlung</b>. Lege eine [intellect] (3) ab. Falls die Probe gelingt, übernimm die Kontrolle über \"Jazz\" Mulligan.\"\nSolange du \"Jazz\" Mulligan kontrollierst, ignoriere den Text auf jedem unverhüllten <i>Miskatonic</i>-Ort.",
         "traits": "Ally. Miskatonic."
     },
     {
         "code": "02061",
         "name": "Professor Warren Rice",
-        "subname": "Professor of Languages",
-        "text": "You get +1 [intellect].\n[reaction] After you discover the last remaining clue in your location, exhaust Professor Warren Rice: Draw 1 card.",
-        "traits": "Ally. Miskatonic.",
+        "subname": "Professor für Linguistik",
+        "text": "Du bekommst +1 [intellect].\n[reaction] Nachdem du den letzten verbliebenen Hinweis an deinem Ort entdeckt hast, erschöpfe Professor Warren Rice: Ziehe 1 Karte.",
+        "traits": "Verbündeter. Miskatonic.",
         "slot": "Ally"
     },
     {
         "code": "02062",
-        "name": "The House Always Wins",
-        "text": "<b>Easy / Standard</b>\n[skull]: -2. You may spend 2 resources to treat this token as a 0, instead.\n[cultist]: -3. If you succeed, gain 3 resources.\n[tablet]: -2. If you fail, discard 3 resources.",
-        "back_text": "<b>Hard / Expert</b>\n[skull]: -3. You may spend 3 resources to treat this token as a 0, instead.\n[cultist]: -3. If you fail, discard 3 resources.\n[tablet]: -2. Discard 3 resources."
+        "name": "Das Haus gewinnt immer",
+        "text": "<b>Einfach / Normal</b>\n[skull]: -2. Du darfst 2 Ressourcen ausgeben, um diesen Marker stattdessen als 0 zu behandeln.\n[cultist]: -3. Falls die Probe gelingt, erhalte 3 Ressourcen.\n[tablet]: -2. Falls die Probe misslingt, lege 3 Ressourcen ab.",
+        "back_text": "<b>Schwer / Experte</b>\n[skull]: -3. Du darfst 3 Ressourcen ausgeben, um diesen Marker stattdessen als 0 zu behandeln.\n[cultist]: -3. Falls die Probe misslingt, lege 3 Ressourcen ab.\n[tablet]: -2. Lege 3 Ressourcen ab."
     },
     {
         "code": "02063",
-        "flavor": "You have entered the Clover Club Casino in search of Dr. Morgan. The club is bustling at this late hour, filled with patrons looking to relax and drink, or make it big. You don't appear to be in much danger.",
-        "name": "The Clover Club",
-        "text": "Each <i>Criminal</i> enemy gains Aloof.\nIf an investigator deals damage to a <i>Criminal</i> enemy: Immediately advance.",
-        "back_name": "On the Right Track",
-        "back_flavor": "Your questioning has drawn the attention of several men – hired thugs, by the look of them. \"Francis doesn't want to be bothered,\" one of them says. \"We suggest you leave the premises before we force you to leave.\"",
-        "back_text": "Shuffle the encounter discard pile into the encounter deck.\nIf the players have completed Extracurricular Activity, advance directly to agenda 2b. If The House Always Wins is the first scenario in the campaign, advance to agenda 2a."
+        "flavor": "Die Suche nach Dr. Morgan hat dich in den Clover Club geführt. Zu dieser späten Stunde ist der Club voller Gäste, die Entspannung suchen, etwas trinken wollen oder auf den großen Gewinn hoffen. Es scheint keine Gefahr zu drohen.",
+        "name": "Der Clover Club",
+        "text": "Jeder <i>Krimineller</i>-Gegner erhält Zurückhaltend.\n<b>Erzwungen</b> – Falls ein Ermittler einem <i>Krimineller</i>-Gegner Schaden zufügt: Rücke sofort vor.",
+        "back_name": "Auf der richtigen Spur",
+        "back_flavor": "Deine Befragungen haben die Aufmerksamkeit einiger Männer auf dich gelenkt – ihrem Aussehen nach sind es angeheuerte Schläger. \"Francis möchte nicht gestört werden,\" sagt einer von ihnen. \"Wir würden vorschlagen, du gehst einfach, bevor wir dich dazu zwingen müssen.\"",
+        "back_text": "Mische den Begegnungs-Ablagestapel in des Begegnungsdeck.\nFalls Aktivitäten außerhalb des Lehrplans bereits abgeschlossen ist, rücke direkt zu Agenda 2b vor. Falls Das Haus gewinnt immer das erste Szenario der Kampagne ist, rücke zu Agenda 2a vor."
     },
     {
         "code": "02064",
-        "flavor": "Most of the other patrons seem oblivious to the mobsters and goons closing in around you. But you recognize this for what it really is – you're about to get roughed up.",
-        "name": "Underground Muscle",
-        "back_name": "Sudden Chaos",
-        "back_flavor": "You hear a crash from somewhere outside and screams of pain in the lounge. A terrible monstrosity smashes through the entrance to the club, crushing the stairwell and knocking over gangsters and patrons alike.",
-        "back_text": "Spawn a random enemy from the set-aside <em>Hideous Abominations</em> encounter set in Clover Club Lounge. Shuffle the rest of that encounter set, the set-aside <em>Striking Fear</em> encounter set, and the encounter discard pile into the encounter deck.\nMove all investigators and unengaged enemies from La Bella Luna to the Clover Club Lounge. Remove La Bella Luna from the game."
+        "flavor": "Die meisten anderen Gäste scheinen gar nicht zu bemerken, wie sich die Mafiosi und Schläger um dich herum sammeln. Aber du erkennst deutlich, was vor sich geht – man will dich aufmischen.",
+        "name": "Krimineller Schläger",
+        "back_name": "Plötzliches Chaos",
+        "back_flavor": "Von draußen hört man ein Krachen und Schmerzensschreie ertönen aus der Lounge. Ein fürchterliches Monster bricht durch den Eingang in den Club, zerstört das Treppenhaus und schlägt Gangster und Gäste gleichermaßen nieder.",
+        "back_text": "Ein zufälliger Gegner aus dem beiseitegelegten Begegnungsset <em>Grässliche Abscheulichkeiten</em> erscheint in der Lounge des Clover Clubs. Mischen den Rest des Begegnungssets, das beiseitelegete Begegnungsset <em>Lähmende Angst</em> und den Begegnungs-Ablagstapel in des Begegnungsdeck.\nBewege alle Ermittler und nicht in einen Kampf verwickelte Gegner von La Bella Luna in die Lounge des Clover Clubs. Entferne La Bella Luna aus dem Spiel."
     },
     {
         "code": "02065",
-        "flavor": "Amidst the chaos and confusion, the strange abominations attack everyone in the club. Screams echo through the halls as the blood begins to spray.",
-        "name": "Chaos in the Clover Club",
-        "text": "<b>Forced</b> - At the start of the enemy phase: Discard each <i>Criminal</i> enemy in the same location as an <i>Abomination</i> enemy.",
-        "back_name": "The Building Collapses",
-        "back_flavor": "As the strange abominations continue to rampage through the club, the building's foundations shake and tremble. You flee toward the exit, but you are caught in the collapsing rubble as the club is destroyed.",
-        "back_text": "<b>(→R4)</b>"
+        "flavor": "Im Club herrschen Chaos und Verwirrung, als die seltsamen Abscheulichkeiten jeden Einzelnen angreifen. Schreie hallen durch die Flure und Blut spritzt.",
+        "name": "Chaos im Clover Club",
+        "text": "<b>Erzwungen</b> - Zu Beginn der Gegnerphase: Lege jeden <i>Krimineller</i>-Gegner ab, der sich auf demselben Ort wie ein <i>Abscheulichkeit</i>-Gegner befindet.",
+        "back_name": "Das Gebäude stürzt ein",
+        "back_flavor": "Während die seltsamen Abscheulichkeiten weiter im Club toben, erzittern die Grundmauern des Gebäudes. Deine Flucht zum Ausgang wird durch das niederprasselnde Geröll des zusammenstürzenden Clubs verhindert. Du sitzt in der Falle.",
+        "back_text": "<b>(→A4)</b>"
     },
     {
         "code": "02066",
-        "flavor": "You need to find Dr. Morgan. The club is packed; perhaps somebody knows where he is.",
-        "name": "Beginner's Luck",
-        "text": "[reaction] When you reveal a chaos token: You may treat that token as if it were any other token in the chaos bag. If you do, remember that you have \"cheated.\" (Group limit once per round.)\n<b>Objective</b> - When the investigators have collected the requisite number of clues, they must immediately spend them and advance.",
+        "flavor": "Du musste Dr. Morgan finden. Der Club ist voll, vielleicht weiß jemand, wo er sich aufhält.",
+        "name": "Anfängerglück",
+        "text": "[reaction] Sobald du einen Chaosmarker enthüllst: Du darfst diesen Marker behandeln, als ob er ein beliebiger anderer Marker aus dem Chaosbeutel wäre. Falls du dies tust, merke dir, dass du \"falsch gespielt\" hast. (Nur ein mal pro Runde für die gesamte Gruppe.)\n<b>Ermittlungsziel</b> - Sobald die Ermittler die geforderte Anzahl Hinweise gesammelt haben, müssen sie diese sofort ausgeben und vorrücken.",
         "back_name": "High Roller",
-        "back_flavor": "After speaking to a number of gamblers and servers, it seems as though Dr. Morgan has had quite the run lately. Instead of cashing out his winnings, he was convinced to double down. He was last seen entering the guarded hall near the back of the cardroom.",
-        "back_text": "Put the set-aside Darkened Hall into play.\nIf it is Agenda 1, discard cards from the top of the encounter deck until a <i>Criminal</i> enemy is discarded, and spawn that enemy in the Darkened Hall."
+        "back_flavor": "Nach Gesprächen mit einigen Spielern und Kellnern scheint es, als hätte Dr. Morgan in letzter Zeit ungewöhnlich viel Glück gehabt. Statt sich seine Gewinne auszahlen zu lassen, wurde er überredet seine Einsätze zu verdoppeln. Zuletzt wurde er beim Betreten des bewachten Flures im hinteren Bereich des Spielzimmers gesehen.",
+        "back_text": "Bringe den beiseitegelegten Ort Dunkler Flur ins Spiel.\nFalls Agenda 1 aktuell ist, lege Karten oben vom Begegnungsdeck ab, bis ein <i>Krimineller</i>-Gegner enthüllt worden ist, dieser Gegner erscheint im Dunklen Flur."
     },
     {
         "code": "02067",
-        "flavor": "Dr. Morgan is somewhere in the private section of the club, where only VIPs and the club's managers are allowed. If you are to find him, you're going to have to sneak or even fight your way in.",
-        "name": "Skin Game",
-        "text": "<b>Objective</b> - Only investigators in the VIP Area may spend the requisite number of clues, as a group, to advance.",
-        "back_name": "Dr. Morgan's Fate",
-        "back_text": "<b>If the players have not yet completed Extracurricular Activity:</b><blockquote><i>You find Dr. Morgan gambling in one of the VIP rooms... but he appears to be playing cards with two unconscious bodies, his pupils dilated as though in a trance. He can't seem to stop laughing, smiling, and chatting with the other \"players.\"</i></blockquote>Put the set-aside Dr. Morgan into play in the VIP Area. Advance to Act 3a - \"All In.\"\n<hr><b>If the players have completed Extracurricular Activity:</b><blockquote><em>The VIP rooms are filled with the mangled and bloody bodies of unfortunate patrons. There doesn't appear to be any trace of Dr. Morgan. You hear screaming and gunfire from the main area of the club.</em></blockquote></b>Put the set-aside Peter Clover into play in the Clover Club Bar. Search the encounter deck (or out of play) for an <i>Abomination</i> enemy, and spawn it in the Clover Club Bar. Advance to Act 3a - \"Fold.\""
+        "flavor": "Dr. Morgan befindet sich irgendwo im privaten Bereich des Clubs, zu dem nur VIPs und diee Manager des Clubs Zutritt haben. Falls du ihn finden willst, musst du dich hineinschleichen oder den Weg hinein erkämpfen.",
+        "name": "Falsches Spiel",
+        "text": "<b>Ermittlungsziel</b> - Nur Ermittler im VIP-Bereich können als Gruppe die geforderten Hinweise ausgeben, um vorzurücken.",
+        "back_name": "Das Schicksal von Dr. Morgan",
+        "back_text": "<b>Falls die Spieler Aktivitäten außerhalb des Lehrplans noch nicht abgeschlossen haben:</b><blockquote><i>Du findest Dr. Morgan beim Spielen in einem der VIP-Räume... aber seine beiden Mitspieler scheinen nicht bei Bewusstsein zu sein und seine Pupillen sind wie in einer Trance erweitert. Er scheint nicht damit aufhören zu können schrill zu lachen, zu lächeln und sich mit den anderen \"Spielern\" zu unterhalten.</i></blockquote>Bringe den beiseitegelegten Dr. Morgan im VIP-Bereich ins Spiel. Rücke zu Szene 3a - \"All In\" vor.\n<hr><b>Falls die Spieler Aktivitäten außerhalb des Lehrplans abgeschlossen haben:</b><blockquote><em>Die VIP-Räume sind voll zerfleischter, blutender Leichen unglückseeliger Gäste. Es scheint keine Spur von Dr. Morgan zu geben. Aus denm öffentlichen Bereich des Clubs sind Schreie und Schüsse zu hören.</em></blockquote></b>Bringe den beiseitegelegten Peter Clover in der Bar des Clover Clubs ins Spiel. Durchsuche das Begegnungsdeck (oder die Zone außerhalb des Spiels) nach einem <i>Abscheulichkeit</i>-Gegner, der in der Bar des Clover Clubs erscheint. Rücke zu Szene 3a - \"Fold\" vor."
     },
     {
         "code": "02068",
-        "flavor": "With or without Dr. Morgan, you have to get out of here. Fast.",
+        "flavor": "Du musst hier raus - mit oder ohne Dr. Morgan. Und zwar schnell.",
         "name": "All In",
-        "text": "While Dr. Morgan is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to shake Dr. Morgan out of his daze. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Dr. Morgan, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
-        "back_name": "Safe... For Now",
-        "back_flavor": "You escape the club, doing your best to look inconspicuous as several cars pull up near the street. A handful of grim-faced men and women exit, running toward the restaurant's entrance to take control of the situation. One of them catches your eye, his hand on the grip of his .38, but thankfully he turns his attention back to the rest of his crew and follows them into the club. You breathe a sigh of relief...",
-        "back_text": "— If an investigator resigned with Dr. Francis Morgan under his or her control, <b>(→R2)</b>\n— Otherwise, <b>(→R1)</b>"
+        "text": "Solange Dr. Francis Morgan nicht von einem Spieler kontrolliert wird, erhält er: \"[action]: <b>Verhandlung</b>. Lege eine [willpower]-Probe (3) ab, um Dr. Francis Morgan aus seiner Benommenheit zu wecken. Falls die Probe gelingt, platziere 1 Hinweis aus dem Markervorrat auf ihn. Falls sich 1[per_investigator] Hinweise auf Dr. Francis Morgan befinden, übernimm die Kontrolle über ihn.\"\n<b>Ermittlungsziel</b> - Falls jeder unbesiegte Ermittler aufgegeben hat, rücke vor.",
+        "back_name": "Sicher... zumindest im Moment",
+        "back_flavor": "Du entkommst aus dem Club und bemühst dich unverdächtig auszusehen, als mehrere Wagen am Straßenrand anhalten. Einige grimmig wirkende Männer und Frauen steigen aus und rennen zum Eingang des Restaurants, um die Situation dort unter Kontrolle zu bringen. Einer von ihnen blickt in deine Richtung und seine Hand wandert zum Griff seiner 38er, aber dann wendet er zum Glück seine Aufmerksamkeit wieder dem Rest der Truppe zu und folgt ihnen in den Club. Du atmest erleichtert auf.",
+        "back_text": "— Falls ein Ermittler mit Dr. Francis Morgan unter seiner Kontrolle aufgegeben hat <b>(→A2)</b>\n— Ansonsten <b>(→A1)</b>"
     },
     {
         "code": "02069",
-        "flavor": "\"Free drinks for whoever gets me the hell out of here!\" A man exclaims from the bar.",
+        "flavor": "\"Freigetränke für denjenigen, der mich hier rausbringt!\", ruft ein Mann an der Bar.",
         "name": "Fold",
-        "text": "While Peter Clover is not controlled by a player, he gains \"[action]: <b>Parley</b>. Test [willpower] (3) to convince Peter to follow you. If you succeed, place 1 clue from the token bank on him. If there are 1[per_investigator] clues on Peter Clover, take control of him.\"\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
-        "back_name": "Escaping the Club",
-        "back_flavor": "You make your way toward the rain-slicked streets of Arkham.",
-        "back_text": "— If an investigator resigned with Peter Clover under his or her control, <b>(→R3)</b>\n— Otherwise, <b>(→R1)</b>"
+        "text": "Solange Peter Clover nicht von einem Spieler kontrolliert wird, erhält er: \"[action]: <b>Verhandlung</b>. Lege eine [willpower]-Probe (3) ab, um Peter davon zu überzeugen, dir zu folgen. Falls die Probe gelingt, platziere 1 Hinweis aus dem Markervorrat auf ihn. Falls sich 1[per_investigator] Hinweise auf Peter Clover befinden, übernimm die Kontrolle über ihn.\"\n<b>Ermittlungsziel</b> - Falls jeder unbesiegte Ermittler aufgegeben hat, rücke vor.",
+        "back_name": "Flucht aus dem Club",
+        "back_flavor": "Du rennst durch die vom Regen rutschigen Straßen von Arkham.",
+        "back_text": "— Falls ein Ermittler mit Peter Clover unter seiner Kontrolle aufgegeben hat <b>(→A3)</b>\n— Ansonsten <b>(→A1)</b>"
     },
     {
         "code": "02070",
-        "flavor": "The music is cliché and they only serve spaghetti. As far as covers for underground speakeasies go, it's not particularly creative.",
+        "flavor": "Die Musik ist klischeehaft und es werden nur Spaghetti serviert. Keine besonders kreative Tarnung für eine illegale Kneipe.",
         "name": "La Bella Luna",
-        "text": "[action]: <b>Resign.</b> This was a bust.",
+        "text": "[action]: <b>Aufgeben.</b> Das war ein Reinfall.",
         "traits": "Arkham.",
-        "back_flavor": "La Bella Luna was a \"multi-purpose\" establishment."
+        "back_flavor": "Das La Bella Luna ist ein \"Mehrzweck\"-Etablissement."
     },
     {
         "code": "02071",
-        "name": "Clover Club Lounge",
-        "text": "While it is Act 1, Clover Club Lounge gains:\n\"[action] Discard an <i>Ally</i> asset from your hand: Gain 2 clues from the token pool. (Limit once per game.)\"",
+        "name": "Lounge des Clover Clubs",
+        "text": "Solange Szene 1 aktuell ist, erhält Lounge des Clover Clubs:\n\"[action] Lege eine <i>Verbündeter</i>-Vorteilskarte von deiner Hand ab: Erhalte 2 Hinweise aus dem Markervorrat. (Nur einmal pro Spiel.)\"",
         "traits": "Clover Club.",
-        "back_flavor": "Comfortable leather couches, mahogany furniture, and an array of beautiful art greets gamblers, tempting them into the life of the would-be affluent."
+        "back_flavor": "Bequeme Ledersofas, Mahagonimöbel und ein Arrangement wunderschöner Kunstwerke begrüßen die Spieler und locken sie in das Leben der Möchtegern-Reichen."
     },
     {
         "code": "02072",
-        "name": "Clover Club Bar",
-        "text": "While it is Act 1, Clover Club Bar gains:\n\"[action] Spend 2 resources: Gain 2 clues from the token pool and draw 2 cards. Remember that you have 'had a drink.' (Limit once per game.)\"",
+        "name": "Bar des Clover Clubs",
+        "text": "Solange Szene 1 aktuell ist, erhält Bar des Clover Clubs:\n\"[action] Gib 2 Ressourcen aus: Erhalte 2 Hinweise aus dem Markervorrat und ziehe 2 Karten. Merke dir, dass du 'einen Drink hattest.' (Nur einmal pro Spiel.)\"",
         "traits": "Clover Club.",
-        "back_flavor": "The shelves behind the bar sag beneath the weight of all manner of bootlegged drinks: cheap ales, moonshine, expensive bottles of wine, aged whiskey. If only you had a couple hours to kill..."
+        "back_flavor": "Die Regale hinter der Bar biegen sich unter dem Gewicht geschmuggelter Getränke aller Art: billige Biere, schwarzgebrannter Schnaps, teure Weinflaschen, alte Whiskeys. Hättest du doch nur ein paar Stunden zum totschlagen..."
     },
     {
         "code": "02073",
-        "name": "Clover Club Cardroom",
-        "text": "While it is Act 1, Clover Club Cardroom gains:\n\"[action] Spend 2 resources: Reveal a random chaos token.\nIf it is a [elder_sign] symbol, gain 2 clues and 2 resources from the token bank.\nIf it is an even number, gain 2 clues from the token bank.\nIf it is an odd number or a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, nothing happens.\"",
+        "name": "Spielzimmer des Clover Clubs",
+        "text": "Solange Szene 1 aktuell ist, erhält Spielzimmer des Clover Clubs:\n\"[action] Gib 2 Ressourcen aus: Enthülle einen zufälligen Chaosmarker.\nFalls es ein [elder_sign]-Symbol ist, erhalte 2 Hinweise und 2 Ressourcen aus dem Markervorrat.\nFalls es eine gerade Zahl ist, erhalte 2 Hinweise aus dem Markervorrat.\nFalls es eine ungerade Zahl oder ein [skull], [cultist], [tablet], [elder_thing], or [auto_fail]-Symbol it, passiert nichts.\"",
         "traits": "Clover Club.",
-        "back_flavor": "As you approach the cardroom, the clinking of poker chips and the shuffling of cards is punctuated by shouts of revelry and frustration. Your thoughts are nearly drowned out by the racket."
+        "back_flavor": "Als du dich dem Spielzimmer näherst, hörst du das Klackern von Pokerchips und das Geräusch von Karten, die gemischt werden, durchsetzt mit Aurufen der Freude und der Frustration. Der Lärm macht es beinahe unmöglich, einen klaren Gedanken zu fassen."
     },
     {
         "code": "02074",
-        "flavor": "The door slams shut behind you, and you stand in sudden silence. This area of the club is lonesome and devoid of warmth and color. Somehow, the spotless floor and walls seem more sinister than inviting.",
-        "name": "Darkened Hall",
-        "text": "<b>Forced</b> - When Darkened Hall is revealed: Put into play the 3 set-aside Back Hall Doorway locations.",
+        "flavor": "Hinter dir fällt die Tür mit einem Knall ins Schloss und plötzlich umgibt dich Stille. Dieser Bereich des Clubs ist verlassen, kalt und farblos. Die fleckenlosen Böden und Wände wirken eher unheimlich als einladend.",
+        "name": "Dunkler Flur",
+        "text": "<b>Erzwungen</b> - Sobald Dunkler Flur enthüllt wird: Bringe die 3 beiseitegelegten Orte Tür zum hinteren Bereich ins Spiel.",
         "traits": "Clover Club.",
-        "back_flavor": "A heavy oak door stands in a secluded corner of the club. As you approach it, the air grows heavy and the clamor of the cardroom fades behind you."
+        "back_flavor": "In einer abgelegenen Ecke des Clubs befindet sich eine schwere Eichentür. Je näher du ihr kommst, desto dicker wird die Luft während der Lärm aus dem Spielzimmer hinter dir leiser wird."
     },
     {
         "code": "02075",
-        "flavor": "Exotic art and antiques adorn the walls of Peter Clover's private gallery. An evening breeze rustles the worn pages of a ledger back and forth.",
-        "name": "Art Gallery",
-        "text": "<b>Forced</b> - After you fail a skill test while investigating the Art Gallery: Lose 2 resources.",
+        "flavor": "Exotische Kunstwerke und Antiquitäten säumen die Wände von Peter Clovers Privatgalerie. Im lauen Abendwind bewegen sich die abgenutzten Blätter eines Hauptbuches.",
+        "name": "Kunstgalerie",
+        "text": "<b>Erzwungen</b> - Nachdem dir eine Fertigkeitsprobe misslungen ist, solange du in der Kunsgalerie ermittelst: Verliere 2 Ressourcen.",
         "traits": "Clover Club.",
-        "back_name": "Back Hall Doorway",
-        "back_flavor": "You approach an unmarked door toward the back of the Clover Club."
+        "back_name": "Tür zum hinteren Bereich",
+        "back_flavor": "Du näherst dich einer nicht beschrifteten Tür zum hinteren Bereich des Clover Clubs."
     },
     {
         "code": "02076",
-        "flavor": "The coppery smell of blood assaults your senses. The floor is littered with broken glass, and the upholstery has been torn to shreds. Where is Dr. Morgan?",
-        "name": "VIP Area",
-        "text": "While you are in the VIP Area, you cannot draw cards or gain resources during the upkeep phase.",
+        "flavor": "Der an Kupfer erinnernde Geruch von Blut steigt in deine Nase. Der Boden ist bedeckt mit Glasscherben und die Polstermöbel sind völlig zerfetzt. Wo ist Dr. Morgan?",
+        "name": "VIP-Bereich",
+        "text": "Solange du dich im VIP-Bereich befindets, kannst du während deiner Unterhaltsphase keine Karten ziehen und keine Ressourcen erhalten.",
         "traits": "Clover Club.",
-        "back_name": "Back Hall Doorway",
-        "back_flavor": "You approach an unmarked door toward the back of the Clover Club."
+        "back_name": "Tür zum hinteren Bereich",
+        "back_flavor": "Du näherst dich einer nicht beschrifteten Tür zum hinteren Bereich des Clover Clubs."
     },
     {
         "code": "02077",
-        "flavor": "A steep, narrow staircase ascends to a second unmarked door. To your surprise, it leads into a back alley behind La Bella Luna. This must be where they smuggle in their \"goods.\"",
-        "name": "Back Alley",
-        "text": "[action]: <b>Resign.</b> We can get out this way!",
+        "flavor": "Eine steile, schmale Treppe führt zu einer zweiten Tür ohne Aufschrift. Zu deiner Überraschung führt sie auf eine kleine Gasse hinter dem La Bella Luna. Wahrscheinlich werden hier die \"Waren\" geschmuggelt.",
+        "name": "Gasse hinter dem Haus",
+        "text": "[action]: <b>Aufgeben.</b> Wir können hier raus!",
         "traits": "Clover Club.",
-        "back_name": "Back Hall Doorway",
-        "back_flavor": "You approach an unmarked door toward the back of the Clover Club."
+        "back_name": "Tür zum hinteren Bereich",
+        "back_flavor": "Du näherst dich einer nicht beschrifteten Tür zum hinteren Bereich des Clover Clubs."
     },
     {
         "code": "02078",
-        "name": "Clover Club Pit Boss",
-        "text": "<b>Prey</b> - Highest [intellect].\nHunter.\n<b>Forced</b> - After an investigator at Clover Club Pit Boss's location gains any number of clues: Clover Club Pit Boss readies, engages that investigator, and makes an immediate attack.",
-        "traits": "Criminal. Elite."
+        "name": "Pit Boss des Clover Clubs",
+        "text": "<b>Beute</b> - Höchster [intellect]-Wert.\nJäger.\n<b>Erzwungen</b> - Nachdem ein Ermittler am Ort des Pit Boss des Clover Clubs eine beliebige Anzahl Hinweise erhält: Pit Boss des Clover Clubs wird spielbereit gemacht, er verwickelt den Ermittler in einen Kampf und führt sofort einen Angriff durch.",
+        "traits": "Krimineller. Elite."
     },
     {
         "code": "02079",
         "name": "Peter Clover",
-        "subname": "Holding All the Cards",
-        "text": "<b>Forced</b> - At the start of the enemy phase, if no investigator controls Peter Clover: Deal 1 damage to him.\n[free]Exhaust Peter Clover: Automatically evade a <i>Criminal</i> enemy in your location.",
+        "subname": "Alle Trümpfe in der Hand",
+        "text": "<b>Erzwungen</b> - Zu Beginn der Gegnerphase, falls kein Ermittler Peter Clover kontrolliert: Füge ihm 1 Schden zu.\n[free]Erschöpfe Peter Clover: Entkomme automatisch einem <i>Krimineller</i>-Gegner an deinem Ort.",
         "traits": "Human. Criminal."
     },
     {
         "code": "02080",
         "name": "Dr. Francis Morgan",
-        "subname": "Professor of Archaeology",
-        "text": "You get +1 [combat].\n[reaction] After you defeat an enemy, exhaust Dr. Francis Morgan: Draw 1 card.",
-        "traits": "Ally. Miskatonic.",
+        "subname": "Professor der Archäologie",
+        "text": "Du bekommst +1 [combat].\n[reaction] nachdem du einen Gegner besiegt hast, erschöpfe Dr. Francis Morgan: Ziehe 1 Karte.",
+        "traits": "Verbündeter. Miskatonic.",
         "slot": "Ally"
     },
     {
         "code": "02081",
-        "flavor": "An unpleasant warmth fills your body, and you sluggishly look at your empty glass.",
-        "name": "Something in the Drinks",
-        "text": "Surge.\n<b>Revelation</b> - Each player who has \"had a drink\" loses 1 action.",
-        "traits": "Poison. Illicit."
+        "flavor": "Eine unangenehme Wärme durchströmt deinen Körper und du schaust träge in dein leeres Glas.",
+        "name": "Etwas ist in den Drinks",
+        "text": "Nachrüsten.\n<b>Enthüllung</b> - Jeder Spieler, der \"einen Drink hatte\" verliert 1 Aktion.",
+        "traits": "Gift. Illegal."
     },
     {
         "code": "02082",
-        "flavor": "Eyes are all around you, watching your every move.",
-        "name": "Arousing Suspicions",
-        "text": "<b>Revelation</b> - Place 1 doom on each <i>Criminal</i> enemy at your location. If no doom was placed by this effect, lose 2 resources."
+        "flavor": "Um dich herum sind lauter Augen, die jede deiner Bewegungen beobachten.",
+        "name": "Verdacht erregen",
+        "text": "<b>Enthüllung</b> - Platziere 1 Verderbensmarker auf jeden <i>Krimineller</i>-Gegner an deinem Ort. Falls durch diesen Effekt kein Verderbensmarker platziert worden ist, verlierst du 2 Ressourcen."
     },
     {
         "code": "02083",
-        "flavor": "Are these visions of things to be, or things as they might be? Or could these horrors have already happened?",
-        "name": "Visions of Futures Past",
-        "text": "<b>Revelation</b> - Test [willpower] (5). For each point you fail by, discard the top card of your deck.",
-        "traits": "Hex."
+        "flavor": "Zeigen diese Visionen die Zukunft oder etwas, das in der Gegenwart sein könnte? Oder ist dieser Schrecken vielleicht schon Vergangenheit?",
+        "name": "Visionen vergangener Zukünfte",
+        "text": "<b>Enthüllung</b> - Lege eine [willpower]-Probe (5) ab. Für jeden Punkt, um den die Probe misslingt, lege die oberste Karte deines Decks ab.",
+        "traits": "Verwünschung."
     },
     {
         "code": "02084",
-        "name": "Beyond the Veil",
-        "text": "Surge.\n<b>Revelation</b> - Put Beyond the Veil into play in your threat area if there is no copy of Beyond the Veil in your threat area.\n<b>Forced</b> - If your deck has no cards in it: Take 10 damage and discard Beyond the Veil.",
-        "traits": "Hex."
+        "name": "Hinter dem Schleier",
+        "text": "Nachrüsten.\n<b>Enthüllung</b> - Bringe Hinter dem Schleier in deiner Bedrohungszone ins Spiel, falls sich keine Kopie von Hinter dem Schleier in deiner Bedrohungszone befindet.\n<b>Erzwungen</b> - Falls dein Deck keine Karten hat: Nimm 10 Schaden und lege Hinter dem Schleier ab.",
+        "traits": "Verwünschung."
     },
     {
         "code": "02085",
-        "flavor": "",
-        "name": "Light of Aforgomon",
-        "text": "Peril.\n<b>Revelation</b> - You must attach Light of Aforgomon to either the current agenda or the current act.\nLimit 1 per agenda/act. Treat all damage as direct damage and all horror as direct horror.",
-        "traits": "Pact. Power."
+        "name": "Licht von Aforgomon",
+        "text": "Wagnis.\n<b>Enthüllung</b> - Du musst Licht von Aforgomon entweder an die aktuelle Agenda oder die aktuelle Szene anhängen.\nNur 1 pro Agenda/Szene. Behandle allen Schaden als direkten Schaden und allen Horror als direkten Horror.",
+        "traits": "Pakt. Macht."
     },
     {
         "code": "02086",
-        "flavor": "A malevolence has overtaken their minds, turning them into soulless puppets.",
-        "name": "Thrall",
-        "text": "<b>Spawn</b> - Location with the most clues.\nRetaliate.",
-        "traits": "Humanoid. Monster. Abomination."
+        "flavor": "Eine bösartige Macht hat ihren Geist übernommen und sie zu einer seelenlosen Marionette gemacht.",
+        "name": "Willenlose Marionette",
+        "text": "<b>Erscheinen</b> - Ort mit den meisten Hinweisen.\nZurückschlagen.",
+        "traits": "Humanoid. Monster. Abscheulichkeit."
     },
     {
         "code": "02087",
-        "name": "Wizard of Yog-Sothoth",
-        "text": "<b>Prey</b> - Least cards in hand.\nHunter.\n<b>Forced</b> - When the engaged investigator draws a <i>Hex</i> or <i>Pact</i> card: Wizard of Yog-Sothoth attacks that investigator.",
-        "traits": "Humanoid. Sorcerer."
+        "name": "Hexenmeister von Yog-Sothoth",
+        "text": "<b>Beute</b> - Die wenigsten Handkarten.\nJäger.\n<b>Erzwungen</b> - Sobald der mit ihm in einen Kampf verwickelte Ermittler eine <i>Verwünschung</i> oder <i>Pakt</i>-Karte zieht: Hexenmeister von Yog-Sothoth greift diesen Ermittler an.",
+        "traits": "Humanoid. Zauberer."
     },
     {
         "code": "02088",
-        "name": "Unhallowed Country",
-        "text": "<b>Revelation</b> - Put Unhallowed Country into play in your threat area.\nYou cannot play <i>Ally</i> assets. Treat the printed text box of each <i>Ally</i> asset you control as if it were blank.\n<b>Forced</b> - At the end of your turn: Test [willpower] (3). If you succeed, discard Unhallowed Country.",
-        "traits": "Terror."
+        "name": "Unheiliges Land",
+        "text": "<b>Enthüllung</b> - Bringe Unheiliges Land in deiner Bedrohungszone ins Spiel.\nDu kannst keine <i>Verbündeter</i>-Vorteilskarten spielen. Behandle das aufgedruckte Textfeld jeder <i>Verbündeter</i>-Vorteilskarten, die du kontrollierst, als ob es leer wäre.\n<b>Erzwungen</b> - Am Ende deines Zuges: Lege eine [willpower]-Probe (3) ab. Falls die Probe gelingt, lege Unheiliges Land ab.",
+        "traits": "Schrecken."
     },
     {
         "code": "02089",
-        "name": "Sordid and Silent",
-        "text": "<b>Revelation</b> - Attach Sordid and Silent to your location.\n<b>Forced</b> - At the end of the round: Each investigator at attached location takes 1 horror.\n<b>Forced</b> - When the agenda advances: Discard Sordid and Silent.",
-        "traits": "Terror."
+        "name": "Schäbig und still",
+        "text": "<b>Enthüllung</b> - Hänge Schäbig und still an deinen Ort an.\n<b>Erzwungen</b> - Am Ende der Runde: Jeder Ermittler am Ort mit der Verstärkung nimmt 1 Horro.\n<b>Erzwungen</b> - Sobald von der aktuellen Agenda vorgerückt wird: Lege Schäbig und still ab.",
+        "traits": "Schrecken."
     },
     {
         "code": "02090",
-        "flavor": "\"It is vowed that the birds are psychopomps lying in wait for the souls of the dying...\" <cite>H. P. Lovecraft, \"The Dunwich Horror\"</cite>",
-        "name": "Whippoorwill",
-        "text": "Aloof. Hunter.\nEach investigator at Whippoorwill's location gets -1 [willpower], -1 [intellect], -1 [combat], and -1 [agility].",
-        "traits": "Creature."
+        "flavor": "\"Man glaubt, diese Vögel warten auf die Seelen der Sterbenden...\" <cite>H. P. Lovecraft, \"Das Grauen von Dunwich\"</cite>",
+        "name": "Ziegenmelker",
+        "text": "Zurückhaltend. Jäger.\nJeder Ermittler am Ort von Ziegenmelker bekommt -1 [willpower], -1 [intellect], -1 [combat], und -1 [agility].",
+        "traits": "Kreatur."
     },
     {
         "code": "02091",
-        "name": "Eager for Death",
-        "text": "<b>Revelation</b> - Test [willpower] (2). Increase this skill test's difficulty by 1 for each damage on you. If you fail, take 2 horror.",
+        "name": "Begierig auf den Tod",
+        "text": "<b>Enthüllung</b> - Lege eine [willpower]-Probe (2) ab. Erhöhe die Schwierigkeit dieser Fertigkeitsprobe um 1 für jeden Schaden, den du genommen hast. Falls die Probe misslingt, nimm 2 Horror.",
         "traits": "Omen."
     },
     {
         "code": "02092",
-        "name": "Cursed Luck",
-        "text": "<b>Revelation</b> - Put Cursed Luck into play in your threat area.\nYou get -1 skill value during skill tests.\n<b>Forced</b> - After you succeed at a skill test by 1 or more: Discard Cursed Luck.",
+        "name": "Vom Pech verfolgt",
+        "text": "<b>Enthüllung</b> - Bringe Vom Pech verfolgt in deiner Bdrohungszone ins Spiel.\nDu bekommst bei Fertigkeitsproben -1 auf deinen Fertigkeitswert.\n<b>Erzwungen</b> - Nachdem dir eine Fertigkeitsprobe um 1 oder mehr gelungen ist: Lege Vom Pech verfolgt ab.",
         "traits": "Omen."
     },
     {
         "code": "02093",
-        "name": "Twist of Fate",
-        "text": "<b>Revelation</b> - Reveal a random token from the chaos bag.\nIf you reveal a [elder_sign] symbol or positive number, nothing happens.\nIf you reveal any other number, take 1 damage.\nIf you reveal a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, take 2 horror.",
+        "name": "Schicksalswende",
+        "text": "<b>Enthüllung</b> - Enthülle einen zufälligen Marker aus dem Chaosbeutel.\nWenn du ein [elder_sign]-Symbol oder eine positive Zahl enthüllst, passiert nichts.\nFalls du eine andere Zahl enthüllst, nimm 1 Schaden.\nFalls du ein [skull], [cultist], [tablet], [elder_thing], oder [auto_fail]-Symbol enthüllst, nimm 2 Horror.",
         "traits": "Omen."
     },
     {
         "code": "02094",
-        "name": "Avian Thrall",
-        "text": "<b>Prey</b> - Lowest [intellect].\nHunter.\nWhile Avian Thrall is being attacked using a <i>Ranged</i>, <i>Firearm</i>, or <i>Spell</i> asset, it gets -3 fight.",
-        "traits": "Creature. Monster. Abomination."
+        "name": "Vogeldiener",
+        "text": "<b>Beute</b> - Niedrigster [intellect]-Wert.\nJäger.\nSolange Vogeldiener mit einer <i>Fernkampf-</i>, <i>Feuerwaffe-</i> oder <i>Zauber</i>-Vorteilskarte angegriffen wird, bekommt er -3 Kampf.",
+        "traits": "Kreatur. Monster. Abscheulichkeit."
     },
     {
         "code": "02095",
-        "flavor": "What manner of wolf has that many teeth?",
-        "name": "Lupine Thrall",
-        "text": "<b>Spawn</b> - Farthest location from you.\n<b>Prey</b> - Lowest [agility].\nHunter. Retaliate.",
-        "traits": "Creature. Monster. Abomination."
+        "flavor": "Welcher Wolf hat so viele Zähne?",
+        "name": "Wolfsdiener",
+        "text": "<b>Erscheinen</b> - Am weitesten von dir entfernter Ort.\n<b>Beute</b> - Niedrigster [agility]-Wert.\nJäger. Zurückschlagen.",
+        "traits": "Kreatur. Monster. Abscheulichkeit."
     },
     {
         "code": "02096",
-        "name": "Altered Beast",
-        "text": "<b>Revelation</b> - If there are no <i>Abomination</i> enemies in play, Altered Beast gains surge. Otherwise, choose an <i>Abomination</i> enemy. Heal all damage from that enemy and attached Altered Beast to it.\n<b>Forced</b> - When you enter attached enemy's location (or vice-versa): Take 1 horror.",
-        "traits": "Power."
+        "name": "Veränderte Bestie",
+        "text": "<b>Enthüllung</b> - Falls sich keine <i>Abscheulichkeit</i>-Gegner im Spiel befinden, erhält Veränderte Bestie Nachrüsten. Ansonsten wähle einen <i>Abscheulichkeit</i>-Gegner. Heile sämtlichen Schaden von diesem Gegner und hänge Veränderte Bestie an ihn an.\n<b>Erzwungen</b> - Sobald du den Ort des Gegners mit dieser Verstärkung betrittst (oder er deinen): Nimm 1 Horror.",
+        "traits": "Macht."
     },
     {
         "code": "02097",
-        "flavor": "\"Are we going to have a problem here?\"",
-        "name": "O'Bannion's Thug",
-        "text": "While O'Bannion's Thug is engaged with you, you cannot gain resources.",
-        "traits": "Human. Criminal. Syndicate."
+        "flavor": "\"Haben wir hier etwa ein Probelm?\"",
+        "name": "O'Bannions Schläger",
+        "text": "Solange O'Bannions Schläger mit dir in einen Kampf verwickelt ist, kannst du keine Ressourcen erhalten.",
+        "traits": "Mensch. Krimineller. Syndikat."
     },
     {
         "code": "02098",
-        "name": "Mobster",
-        "text": "Retaliate.\n<b>Forced</b> - After Mobster attacks you: Lose 1 resource.",
-        "traits": "Human. Criminal. Syndicate."
+        "flavor": "\"Du verschwindest besser, Freundchen, falls du nicht wild darauf bist, Stiefelleder und Blei zu schmecken\"",
+        "name": "Mafiosi",
+        "text": "Zurückschlagen.\n<b>Erzwungen</b> - Nachdem dich Mafiosi angegriffen hat: Verliere 1 Ressource.",
+        "traits": "Mensch. Krimineller. Syndikat."
     },
     {
         "code": "02099",
-        "name": "Hunted Down",
-        "text": "<b>Revelation</b> - If there are no unengaged <i>Criminal</i> enemies in play, Hunted Down gains surge. If there are 1 or more unengaged <i>Criminal</i> enemies in play, each of them moves 1 location toward you. Each <i>Criminal</i> enemy that engages you as a result of this effect makes an immediate attack.",
-        "traits": "Tactic."
+        "name": "Zur Strecke gebracht",
+        "text": "<b>Enthüllung</b> - Falls sich keine nicht in einen Kampf verwickelte <i>Krimineller</i>-Gegner im Spiel befinden, enthält Zur Strecke gebracht Nachrüsten. Falls sich 1 oder mehr nicht in einem Kampf verwickelte <i>Krimineller</i>-Gegner im Spiel befinden, bewegt sich jeder von ihnen 1 Ort auf dich zu. Jeder <i>Krimineller</i>-Gegner, der dich als Ergebnis diese Effektes in einen Kampf verwickelt, führt sofort einen Angriff durch.",
+        "traits": "Taktik."
     },
     {
         "code": "02100",
-        "name": "Pushed into the Beyond",
-        "text": "<b>Revelation</b> - Choose and shuffle a non-story asset you control into your deck and discard the top 3 cards of your deck. If a copy of that asset is discarded, take 2 horror.",
-        "traits": "Hex."
+        "name": "Ins Jenseits gedrängt",
+        "text": "<b>Enthüllung</b> - Wähle eine Nicht-Storyvorteilskarte, die du kontrollierst, mische sie in dein Deck und lege die obersten 3 Karten deines Decks ab. Falls eine Kopie dieser Vorteilskarte abgelegt wird, nimm 2 Horror.",
+        "traits": "Verwünschung."
     },
     {
         "code": "02101",
-        "name": "Terror from Beyond",
-        "text": "Peril.\n<b>Revelation</b> - Choose one of the following cardtypes (asset, event, or skill). Each player must discard each card in his or her hand that is of the chosen cardtype. If this is not the first copy of Terror from Beyond drawn this phase, choose two cardtypes instead.",
-        "traits": "Hex. Terror."
+        "name": "Schrecken aus dem Jenseits",
+        "text": "Wagnis.\n<b>Enthüllung</b> - Wähle einen der folgenden Kartentypen (Vorteil, Ereignis oder Fertigkeit). Jeder Spieler muss jede Karte des gewählten Kartentyps von seiner Hand ablegen. Falls dies nicht die erste in dieser Phase gezogene Kopie von Schrecken aus dem Jenseits ist, wähle stattdessen zwei Kartentypen.",
+        "traits": "Verwünschung. Schrecken."
     },
     {
         "code": "02102",
-        "name": "Arcane Barrier",
-        "text": "<b>Revelation</b> - Attach to your location.\nAs an additional cost to move into or out of attached location, test [willpower] (4). If successful, discard Arcane Barrier. Otherwise, you must either cancel the effects of the move or discard the top 5 cards of your deck.",
-        "traits": "Hex. Obstacle."
+        "name": "Arkane Barriere",
+        "text": "<b>Enthüllung</b> - Hänge diese Karte an deinen Ort an.\nLege als zusätzliche Kosten für das Bewegen zum oder vom Ort mit dieser Verstärkung eine [willpower]-Probe (4) ab. Falls die Probe gelingt, lege Arkane Barriere ab. Ansonsten musst du die Effekte der Bewegung entweder aufheben oder die obersten 5 Karten deines Decks ablegen.",
+        "traits": "Verwünschung. Hindernis."
     },
     {
         "code": "02103",
-        "name": "Conglomeration of Spheres",
-        "text": "<b>Prey</b> - Lowest [willpower].\nHunter.\n<b>Forced</b> - After you perform an attack against the Conglomeration of Spheres using a <i>Melee</i> card: Discard that card.",
-        "traits": "Monster. Abomination."
+        "name": "Ansammlung schillernder Kugeln",
+        "text": "<b>Beute</b> - Lowest [willpower].\nJäger.\n<b>Erzwungen</b> - Nachem du einen Angriff gegen Ansammlung schillernder Kugeln durchgeführt hast, in dem du eine <i>Nahkampf-</i>-Karte verwendet hast: Lege diese Karte ab.",
+        "traits": "Monster. Abscheulichkeit."
     },
     {
         "code": "02104",
-        "name": "Servant of the Lurker",
-        "text": "<b>Prey</b> - Lowest [agility].\nHunter.\n<b>Forced</b> - When Servant of the Lurker attacks you: Discard the top 2 cards of your deck.",
-        "traits": "Monster. Abomination."
+        "name": "Diener des Lauerers",
+        "text": "<b>Beute</b> - Niedrigster [agility]-Wert.\nJäger.\n<b>Erzwungen</b> - Sobald dich Diener des Lauerers angreift: Lege die obersten 2 Karten deines Decks ab.",
+        "traits": "Monster. Abscheulichkeit."
     }
 ]

--- a/translations/de/pack/dwl/litas.json
+++ b/translations/de/pack/dwl/litas.json
@@ -1,87 +1,87 @@
 [
     {
         "code": "02299",
-        "flavor": "With a sickening smack, he struck the abomination over and over…until at last, it stopped moving.",
-        "name": "Vicious Blow",
-        "text": "If this skill test is successful during an attack, that attack deals +1 damage (+2 damage instead if it succeeds by 2 or more).",
-        "traits": "Practiced. Expert."
+        "flavor": "Begleitet von einem widerlichen Schmatzen schlug er immer und immer wieder auf die Scheußlichkeit ein… bis sie schließlich aufhörte sich zu bewegen.",
+        "name": "Brutaler Schlag",
+        "text": "Falls diese Fertigkeitsprobe während eines Angriffs erfolgreich ist, fügt dieser Angriff +1 Schaden zu (+2 Schaden, falls sie um 2 oder mehr gelingt).",
+        "traits": "Trainiert. Experte."
     },
     {
         "code": "02300",
-        "name": "Monster Slayer",
-        "text": "<b>Fight.</b> If this attack succeeds against a non-<i>Elite</i> enemy, defeat that enemy.",
-        "traits": "Spirit."
+        "name": "Monsterschlächter",
+        "text": "<b>Kampf.</b> Falls dieser Angriff gegen einen Nicht-<i>Elite</i>-Gegener erfolgreich ist, besiege diesen Gegner.",
+        "traits": "Geist."
     },
     {
         "code": "02301",
-        "name": "Lightning Gun",
-        "text": "Uses (3 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You get +5 [combat] for this attack. This attack deals +2 damage.",
-        "traits": "Item. Weapon. Firearm.",
+        "name": "Tesla-Kanone",
+        "text": "Anwendungen (3 Munition).\n[action] Gib 1 Munition aus: <b>Kampf.</b> Du bekommst für diesen Angriff +5 [combat]. Dieser Angriff fügt +2 Schaden zu.",
+        "traits": "Gegenstand. Waffe. Feuerwaffe.",
         "slot": "Hand x2"
     },
     {
         "code": "02302",
         "name": "Dr. William T. Maleson",
-        "subname": "Working on Something Big",
-        "text": "[reaction] When you draw an encounter card, exhaust Dr. William T. Maleson and place 1 of your clues on your location: Cancel the drawing of that card and shuffle it back into the encounter deck. Then, draw a new card from the top of the encounter deck.",
-        "traits": "Ally. Miskatonic.",
+        "subname": "An etwas Großem arbeiten",
+        "text": "[reaction] Sobald du eine Begegnungskarte ziehst, erschöpfe Dr. William T. Maleson und platziere 1 deiner Hinweise auf deinem Ort: Hebe das Ziehen dieser Karte auf und mische sie zurück ins Begegnungsdeck. Ziehe dann eine neue Karte oben vom Begegnungsdeck.",
+        "traits": "Verbündeter. Miskatonic.",
         "slot": "Ally"
     },
     {
         "code": "02303",
-        "name": "Deciphered Reality",
-        "text": "<b>Investigate.</b> The difficulty of this skill test is equal to the highest shroud value among revealed locations in play. If you succeed, discover 1 clue from each revealed location in play.",
-        "traits": "Insight."
+        "name": "Entschlüsselte Realität",
+        "text": "<b>Ermitteln.</b> Die Schwierigkeit dieser Fertigkeitsprobe entspricht dem höchsten Schleierwert unter den enthüllten Orten im Spiel. Falls die Probe gelingt, entdecke 1 Hinweis an jedem enthüllten Ort im Spiel.",
+        "traits": "Erkenntnis."
     },
     {
         "code": "02304",
         "name": "Chicago Typewriter",
-        "text": "Uses (4 ammo).\n[action] Spend 1 ammo: <b>Fight.</b> You may spend any number of additional actions when you perform this attack. You get +2 [combat] for this attack for each action being spent (including this ability's [action] cost). This attack deals +2 damage.",
-        "traits": "Item. Weapon. Firearm. Illicit.",
+        "text": "Anwendungen (4 Munition).\n[action] Gib 1 Munition aus: <b>Kampf.</b> Du darfst eine beliebige Anzahl zusätzlicher Aktionen ausgeben, sobald du diesen Angriff durchführst. Du bekommst für diesen Angriff +2 [combat] für jede ausgegebene Aktion (einschließlich der [action]-Fähigkeitskosten dieser Karte). Dieser Angriff fügt +2 Schaden zu.",
+        "traits": "Gegenstand. Waffe. Feuerwaffe. Illegal.",
         "slot": "Hand x2"
     },
     {
         "code": "02305",
-        "name": "The Gold Pocket Watch",
-        "subname": "Stealing Time",
-        "text": "Exceptional.\n[free] When a phase begins, remove The Gold Pocket Watch from the game: Skip this phase.\n[free] After a phase ends, remove The Gold Pocket Watch from the game: Repeat that phase.",
-        "traits": "Item. Relic.",
+        "name": "Die Goldene Taschenuhr",
+        "subname": "Zeit stehlen",
+        "text": "Außergewöhnlich.\n[free] Sobald eine Phase beginnt, entferne Die Goldene Taschenuhr aus dem Spiel: Überspringe diese Phase.\n[free] Nachdem eine Phase geendet hat, entferne Die Goldene Taschenuhr aus dem Spiel: Wiederhole diese Phase.",
+        "traits": "Gegenstand. Relikt.",
         "slot": "Accessory"
     },
     {
         "code": "02306",
-        "name": "Shrivelling",
-        "text": "Uses (4 charges).\n[action] Spend 1 charge: <b>Fight.</b> This attack uses [willpower] instead of [combat]. You get +3 [willpower] and deal +2 damage for this attack. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this attack, take 2 horror.",
-        "traits": "Spell.",
+        "name": "Vertrocknen",
+        "text": "Anwendungen (4 Ladungen).\n[action] Gib 1 Ladung aus: <b>Kampf.</b> Dieser Angriff verwendet [willpower] statt [combat]. Du bekommst für diesen Angriff +3 [willpower] und fügst +2 Schaden zu. Falls ein [skull]-, [cultist]-, [tablet]-, [elder_thing]-, oder [auto_fail]-Symbol während dieses Angriffs enthüllt wird, nimmst du 2 Horror.",
+        "traits": "Zauber.",
         "slot": "Arcane"
     },
     {
         "code": "02307",
-        "name": "Ward of Protection",
-        "text": "Fast. Play when you draw a non-weakness encounter card. \nCancel all of that card's effects and discard it. Then, take 1 horror.",
-        "traits": "Spell. Spirit."
+        "name": "Schutzsiegel",
+        "text": "Schnell. Spiele diese Karte, sobald du eine Nicht-Schwäche-Verratskarte ziehst. \nHebe den Enthüllungseffekt dieser Karte auf. Dann nimmst du 1 Horror.",
+        "traits": "Zauber. Geist."
     },
     {
         "code": "02308",
-        "flavor": "\"Do not be frightened by what you see.\nBe frightened by what you cannot see.\"",
+        "flavor": "\"Fürchte nicht das, was du siehst.\nFürchte das, was du nicht siehst.\"",
         "name": "Aquinnah",
-        "subname": "The Forgotten Daughter",
-        "text": "[reaction] When an enemy attacks you, exhaust Aquinnah and deal 1 horror to her: Deal that enemy's damage to any enemy at your location, instead. (You still take horror dealt by the attack.)",
-        "traits": "Ally.",
+        "subname": "Die vergessene Tochter",
+        "text": "[reaction] Sobald dich ein Gegner angreift, erschöpfe Aquinnah und füge ihr 1 Horror zu: Füge den Schaden des Gegners stattdessen einem beliebigen Gegner an deinem Ort zu. (Du nimmst immer noch den Horror, der durch diesen Angriff zugefügt wird.)",
+        "traits": "Verbündeter.",
         "slot": "Ally"
     },
     {
         "code": "02309",
-        "name": "Try and Try Again",
-        "text": "[reaction] After a skill test is failed, if a skill card you own is committed to that test, exhaust Try and Try Again: Return that skill card to your hand.",
+        "name": "Versuch um Versuch",
+        "text": "[reaction] Nachdem eine Fertigkeitsprobe misslungen ist, falls eine Fertigkeitskarte, die du besitzt, zu dieser Probe beigetragen worden ist, erschöpfe Versuch um Versuch: Schicke diese Fertigkeitskarte auf deine Hand zurück.",
         "traits": "Talent."
     },
     {
         "code": "02310",
-        "name": "The Red-Gloved Man",
-        "subname": "He Was Never There",
-        "text": "Fast.\n[reaction] After The Red-Gloved Man enters play: Choose two of your skills. While The Red-Gloved Man is in play, raise the base value of each of those skills to 6.\n<b>Forced</b> - At the end of the mythos phase: Discard The Red-Gloved Man.",
-        "traits": "Ally. Conspirator.",
+        "name": "Der Mann mit den roten Handschuhen",
+        "subname": "Er war nie da",
+        "text": "Schnell.\n[reaction] Nachdem Der Mann mit den roten Handschuhen ins Spiel gekommen ist: Wähle zwei deiner Fertigkeiten. Solange Der Mann mit den roten Handschuhen im Spiel ist, erhöhe den Grundfertigkeitswert dieser Fertigkeiten auf 6.\n<b>Erzwungen</b> - Am Ende der Mythosphase: Lege Der Mann mit den roten Handschuhen ab.",
+        "traits": "Verbündeter. Verschwörer.",
         "slot": "Ally"
     }
 ]

--- a/translations/de/pack/dwl/litas_encounter.json
+++ b/translations/de/pack/dwl/litas_encounter.json
@@ -1,167 +1,167 @@
 [
     {
         "code": "02311",
-        "name": "Lost in Time and Space",
-        "text": "<b>Easy / Standard</b>\n[skull] -1 for each <i>Extradimensional</i> location in play (max -5).\n[cultist] Reveal another token. If you fail, after this skill test, discard cards from the top of the encounter deck until a location is discarded. Put that location into play and move there.\n[tablet] -3. If Yog-Sothoth is in play, it attacks you after this skill test.\n[elder_thing] -X. X is the shroud value of your location. If you fail and your location is <i>Extradimensional</i>, discard it.",
-        "back_text": "<b>Hard / Expert</b>\n[skull] -1 for each <i>Extradimensional</i> location in play.\n[cultist] Reveal another token. After this skill test, discard cards from the top of the encounter deck until a location is discarded. Put that location into play and move there.\n[tablet] -5. If Yog-Sothoth is in play, it attacks you after this skill test.\n[elder_thing] -X. X is twice the shroud value of your location. If you fail and your location is <i>Extradimensional</i>, discard it."
+        "name": "Verloren in Zeit und Raum",
+        "text": "<b>Einfach / Normal</b>\n[skull] -1 für jeden  <i>Außerdimensional</i>-Ort im Spiel (max. -5).\n[cultist] Enthülle einen weiteren Marker. Falls die Probe misslingt, lege nach dieser Fertigkeitsprobe Karten oben vom Begegnungsdeck ab, bis ein Ort abgelegt wird. Bringe diesen Ort ins Spiel und bewege dich dorthin.\n[tablet] -3. Falls sich Yog-Sothoth im Spiel befindet, greift er dich nach dieser Fertigkeitsprobe an.\n[elder_thing] -X. X ist der Schleierwert deines Ortes. Falls die Probe misslingt und der Ort <i>Außerdimensional</i> ist, lege ihn ab.",
+        "back_text": "<b>Schwer / Experte</b>\n[skull] -1 für jeden <i>Außerdimensional</i>-Ort im Spiel.\n[cultist] Enthülle einen weiteren Marker. Falls die Probe misslingt, lege nach dieser Fertigkeitsprobe Karten oben vom Begegnungsdeck ab, bis ein Ort abgelegt wird. Bringe diesen Ort ins Spiel und bewege dich dorthin.\n[tablet] -5. Falls sich Yog-Sothoth im Spiel befindet, greift er dich nach dieser Fertigkeitsprobe an.\n[elder_thing] -X. X ist zwei Mal der Schleierwert deines Ortes. Falls die Probe misslingt und der Ort <i>Außerdimensional</i> ist, lege ihn ab."
     },
     {
         "code": "02312",
-        "flavor": "Pathways of sound and color extend for an eternity in all directions, dotted with impossible architecture, and overgrown with alien wildlife. The lines between objects are jagged and shifting, and your skin feels as if it were inside out.",
-        "name": "All is One",
-        "text": "<b>Forced</b> - After you are moved to a location by an encounter card effect: Take 1 horror.",
-        "back_name": "Familiar Echoes",
-        "back_text": "Shuffle the encounter discard pile into the encounter deck. Then, discard cards from the top until a location is discarded. The lead investigator resolves that location's 'revelation' effect.\n<b>Check Campaign Log. If the investigators failed to save the students, read the following:</b>\n\"A huge canine creature, alien to your eyes and yet familiar, appears before you. The creature rushes forward, and you prepare to fend it off, but to your surprise it runs through you, towards a building that wasn't behind you moments before: Derby Hall from the Miskatonic University. The creature bursts through the building's front door and you hear screams of panic from inside, followed by the crunch of snapping bones and cries of pain.\"\nEach investigator takes 1 horror, regardless of their location."
+        "flavor": "Pfade aus Tönen und Farben erstrecken sich endlos in alle Richtungen. Hier und da stehen unmögliche Gebäude, überwuchert mit fremdartigen Lebensformen. Die Linien zwischen den Objekten sind verzerrt und in Bewegung. Deine Haut fühlt sich an, als hätte man sie von links auf rechts gezogen.",
+        "name": "Alles ist eins",
+        "text": "<b>Erzwungen</b> - Nachdem du durch den Effekt einer Begegnungskarte an einen Ort bewegt worden bist: Nimm 1 Horror.",
+        "back_name": "Vertrauter Widerhall",
+        "back_text": "Mische den Begegnungs-Ablagestapel in das Begegnungsdeck. Lege dann Karten oben vom Begegnungsdeck ab, bis ein Ort abgelegt worden ist. Der leitende Ermittler handelt den \"Enthüllungs\"-Effekt dieses Ortes ab.\n<b>Überprüfe das Kampagnenlogbuch. Falls die Ermittler die Studenten nicht retten konnten, lies folgenden Text:</b>\n\"Eine riesige, hundeartige Kreatur, die auf dich fremdartig und doch vertraut wirkt, erscheint vor dir. Die Kreatur springt vor und du erwartest jeden Moment sie abwehren zu müssen, aber zu deiner Überraschung rennt sie durch dich hindurch auf ein Gebäude zu, das vor wenigen Momenten noch nicht hinter dir gestanden hat: Die Derby Hall der Miskatonic Universität. Die Kreatur bricht durch die Vordertür des Gebäudes und du hörst panische Schreie aus dem Inneren, gefolgt vom Knacken brechender Knochen und Schmerzensschreien.\"\nJeder Ermittler nimmt 1 Horror, egal auf welchem Ort er sich befindet."
     },
     {
         "code": "02313",
-        "flavor": "As you cross this realm, you catch occasional glimpses of reality – scenes from old memories, more recent visions from the past few days, and sometimes even events that you do not remember ever happening…",
-        "name": "Past, Present and Future",
-        "text": "<b>Forced</b> - After you are moved to a location by an encounter card effect: Take 1 horror.",
-        "back_name": "The Price of Failure",
-        "back_text": "Shuffle the encounter discard pile into the encounter deck. Then, discard cards from the top until a location is discarded. The lead investigator resolves that location's 'revelation' effect.\n<b>Check Campaign Log. If at least one name is recorded under \"Sacrificed to Yog-Sothoth,\" read the following:</b>\n\"You hear a familiar voice calling out to you, and you enter an impossibly shaped building of cracked stone. \"No… don't!\" the voice cries. You rush toward the voice, down a set of steep, narrow stairs. Upon reaching the bottom, you find yourself in the hidden chamber from Dunwich. Bound by shackles, you see those you failed to save, bloodied and maimed. A creature with a man's face feeds from a corpse on the ground. The head of the corpse turns to face you, and a sharp pain stabs your heart.\"\nEach investigator tests [willpower] (X), where X is the number of names recorded under \"Sacrificed to Yog-Sothoth.\" For each point an investigator fails by, that investigator takes 1 damage."
+        "flavor": "Als du dieses Reich durchquerst, erhaschst du gelegentlich einen Blick auf die Realität – Szenen aus alten Erinnerungen, Visionen der Geschehnisse der letzten Tage und manchmal sogar Ereignisse, an die du dich überhaupt nicht erinnern kannst …",
+        "name": "Vergangenheit, Gegenwart und Zukunft",
+        "text": "<b>Erzwungen</b> - Nachdem du durch den Effekt einer Begegnungskarte an einen Ort bewegt worden bist: Nimm 1 Horror.",
+        "back_name": "Der Preis der Niederlage",
+        "back_text": "Mische den Begegnungs-Ablagestapel in das Begegnungsdeck. Lege dann Karten oben vom Begegnungsdeck ab, bis ein Ort abgelegt worden ist. Der leitende Ermittler handelt den \"Enthüllungs\"-Effekt dieses Ortes ab.\n<b>Überprüfe das Kampagnenlogbuch. Falls mindestens ein Name unter \"Yog-Sothoth geopfert\" steht, lies folgenden Text:</b>\n\"Du horst eine vertraute Stimme nach dir rufen und betrittst ein unmöglich geformtes Gebäude aus gesprungenen Stein. \"Nein… tu es nicht!\", schreit die Stimme- Du eilst einige steile, enge Stufen hinunter in die Richtung, aus der die Stimme gekommen ist. Am Fuß der Treppe findest du dich in der verborgenen Kammer in Dunwich wieder. In Ketten gelegt erwarten dich dort all jene, die du nicht retten konntest, blutüberströmt und verstümmelt. Eine Kreatur mit dem Gesicht eines Mannes frisst an einem Leichnam auf dem Boden. Der Kopf des Leichnams dreht sich in deine Richtung und ein scharfer Schmerz führt durch dein Herz.\"\nJeder Ermittler legt eine [willpower]-Probe (X) ab, wobei X die Anzahl der Namen unter \"Yog-Sothoth geopfert\" ist. Für jeden Punkt, um den die Probe eines Ermittlers misslingt, nimmt dieser Ermittler 1 Schaden."
     },
     {
         "code": "02314",
-        "flavor": "Throughout this warped dimension, no matter where you travel, there is a haunting shape in the distance. At first, it appears as a disc, like a black moon with many wriggling arms. But as time passes, you can tell it is growing larger and larger…",
-        "name": "Breaking Through",
-        "text": "<b>Forced</b> - After you are moved to a location by an encounter card effect: Take 1 horror.",
-        "back_name": "The Key and the Gate",
-        "back_text": "<b>Revelation</b> - Spawn the set-aside Yog-Sothoth enemy at The Edge of the Universe. If The Edge of the Universe is not in play, spawn it in Another Dimension, instead. Advance to agenda 4a."
+        "flavor": "Egal wohin du dich in dieser verzerrten Dimension wendest, immer ist eine Gestalt in der Ferne, die dich heimzusuchen scheint. Zunächst wirkt sie wie eine Scheibe, ein schwarzer Mond mit vielen sich windenden Armen. Aber mit der Zeit kannst du sehen, wie sie größer und größer wird.",
+        "name": "Durchbrechen",
+        "text": "<b>Erzwungen</b> - Nachdem du durch den Effekt einer Begegnungskarte an einen Ort bewegt worden bist: Nimm 1 Horror.",
+        "back_name": "Der Schlüssel und das Tor",
+        "back_text": "<b>Enthüllung</b> - Der beiseitegelegte Gegner Yog-Sothoth erscheint auf dem Rand des Universums. Falls sich der Rand des Universums nicht im Spiel befindet, erscheint er stattdessen auf Einer anderen Dimension. Rücke zu Agenda 4a vor."
     },
     {
         "code": "02315",
-        "flavor": "The shape in the distance smashes through the barriers of this dimension, its many arms reaching to envelop everything you see. Its body is like an ooze, covered in eyes and mouths. You feel insignificant, like a bug, next to the creature’s terrifying grandeur.",
-        "name": "The End of All Things",
-        "text": "<b>Forced</b> - After you are moved by an encounter card effect: Take 1 horror.\n<b>Forced</b> - If Yog-Sothoth is defeated, <b>(→R3)</b>.",
-        "back_name": "Yog-Sothoth Attacks!",
-        "back_flavor": "Seeking the rift from which you entered this dimension, the extradimensional horror lashes out, crushing entire realms within its grasp.",
-        "back_text": "In player order, Yog-Sothoth attacks each investigator in play, regardless of Yog-Sothoth's current location. Then, flip this agenda back to its \"a\" side."
+        "flavor": "Die Gestalt in der Ferne dringt durch die Barrieren dieser Dimension und streckt ihre vielen Arme aus, um alles zu verschlingen, was du siehst. Ihr Körper ähnelt einem Schleim, der von Augen und Mündern bedeckt ist. Du fühlst dich unbedeutend wie ein Käfer in der Gegenwart der schrecklichen Größe dieser Kreatur.",
+        "name": "Das Ende von allem",
+        "text": "<b>Erzwungen</b> - Nachdem du durch den Effekt einer Begegnungskarte an einen Ort bewegt worden bist: Nimm 1 Horror.\n<b>Erzwungen</b> - Falls Yog-Sothoth besiegt wird, <b>(?A3)</b>.",
+        "back_name": "Yog-Sothoth greift an!",
+        "back_flavor": "Während du nach dem Riss suchst, durch den du in diese Dimension gelangt bist, schlägt der außerdimensionale Horror um sich und zerstört ganze Reich emit seinem Griff.",
+        "back_text": "Yog-Sothoth greift jeden Ermittler in Spielerreihenfolge an, unabhängig von Yog-Sothoths aktuellem Ort. Dreht danach diese Agenda zurück auf ihre \"a\"-Seite."
     },
     {
         "code": "02316",
-        "flavor": "Somehow, you must find your way across this alien landscape in order to find the nexus that was described in Old Whateley’s tome.",
-        "name": "Out of this World",
-        "text": "[action]: Discard the top 3 cards of the encounter deck. Choose a location discarded by this effect and resolve its 'revelation' ability.",
-        "back_name": "The Nexus of Dimensions",
-        "back_flavor": "A light shimmers in the distance, and you head toward it to investigate. The wispy light drifts away from you, floating through the realm's strange gateways, ascending looping staircases, and crossing through barriers you dared not cross earlier. With little chance of finding the nexus on your own, you follow the light, hoping it is guiding you in the right direction.",
-        "back_text": "Put the set-aside The Edge of the Universe location into play."
+        "flavor": "Irgendwie must du dir deinen Weg durch diese fremdartige Landschaft suchen, um den Nexus zu finden, der im Buch des alten Whatley beschrieben ist.",
+        "name": "Aus dieser Welt hinaus",
+        "text": "[action]: Lege die obersten 3 Karten des Begegnungsdecks ab. Wähle einen durch diesen Effekt abgelegten Ort und handle seine \“Enthüllung\“-Fähigkeit ab.",
+        "back_name": "Der Nexus der Dimensionen",
+        "back_flavor": "Ein Licht schimmert in der Ferne und du gehst darauf zu, um es zu untersuchen. Das flackernde Licht bewegt sich von dir weg und schwebt durch die merkwürdigen Tore des Reiches, steigt sich windende Treppen empor und überquert die Grenzen, die du vorher nicht gewagt hast zu überqueren. Da du kaum eine Chance hast, den Nexus alleine zu finden, folgst du dem Licht in der Hoffnung, dass es dich in die richtige Richtung führt.",
+        "back_text": "Bringe den beiseitegelegten Ort Rand des Universums ins Spiel."
     },
     {
         "code": "02317",
-        "flavor": "You continue to follow the wisp of light, though the treacherous landscape makes it a difficult quarry to chase.",
-        "name": "Into the Beyond",
-        "text": "[action]: Discard the top 3 cards of the encounter deck. Choose a location discarded by this effect and resolve its 'revelation' ability.\n<b>Objective</b> - If an investigator enters The Edge of the Universe, advance.",
-        "back_name": "The World's Edge",
-        "back_flavor": "You reach an impossibly dense pitch-black void, and realize that this place is where all of reality - all that is and all that ever will be - ends. In its center, you see a minuscule rift, suspended just out of reach. When you peer through the tear, you are surprised to see the peak of Sentinel Hill. Somehow, you've reached the other side of the rift. Now you must find a way to close it for good."
+        "flavor": "Du folgst weiter dem Irrlicht, obwohl die trügerische Landschaft dir die Verfolgung erschwert.",
+        "name": "Ins Jenseits",
+        "text": "[action]: Lege die obersten 3 Karten des Begegnungsdecks ab. Wähle einen durch diesen Effekt abgelegten Ort und handle seine \”Enthüllung\”-Fähigkeit ab.\n<b>Ermittlungsziel</b> - Falls ein Ermittler den Rand des Universums betritt, rücke vor.",
+        "back_name": "Der Rand der Welt",
+        "back_flavor": "Du erreichst eine Leere, schwärzer als alles, was du dir je hast vorstellen können, und erkennst, dass dies der Ort ist, an dem die Realität – alles, was ist, und alles, was je sein wird – endet. In seiner Mitte siehst du einen winzigen Riss, gerade außerhalb deiner Reichweite. Als du durch den Riss blickst, bist du erstaunt, den Gipfel des Sentinel Hill zu erblicken. Irgendwie musst du auf die andere Seite des Risses gelangt sein. Nun musst du einen Weg finden, ihn für immer zu verschließen."
     },
     {
         "code": "02318",
-        "flavor": "The unearthly stones on the ground are inscribed with some sort of seal. Approaching them causes a voice to enter your mind, speaking in an alien tongue.",
-        "name": "Close the Rift",
-        "text": "[action]: Discard the top 3 cards of the encounter deck. Choose a location discarded by this effect and resolve its 'revelation' ability.\n<b>Objective</b> - Only investigators at The Edge of the Universe may spend the requisite number of clues, as a group, to advance.",
-        "back_name": "Mending the Tear",
-        "back_flavor": "You are utterly exhausted, with no idea as to what can be done to close the rift. It is too distant to touch, and nothing you do has any effect. There is nothing here to guide you apart from the unearthly words that are seeping into your mind. Just then, you hear a familiar voice within the echoing chorus, and feel yourself compelled to repeat it. \"Claude ostium…\" You whisper at first, the words on the tip of your tongue. You close your eyes to concentrate, and the echo grows louder. When it ends and you open your eyes, you face nothing but an inky abyss, and the tear has vanished.",
-        "back_text": "Remove the Edge of the Universe from the game.\nPut the set-aside Tear Through Time location into play."
+        "flavor": "Auf den unirdischen Steinen am Boden befindet sich eine Art Siegel. Als du näher kommst, hörst du eine Stimme, die in deinem Geist eindringt und eine fremdartige Sprache spricht.",
+        "name": "Schließe den Riss",
+        "text": "[action]: Lege die obersten 3 Karten des Begegnungsdecks ab. Wähle einen durch diesen Effekt abgelegten Ort und handle seine \”Enthüllung\”-Fähigkeit ab.\n<b>Ermittlungsziel</b> - Nur Ermittler auf dem Rand des Universums können als Gruppe die benötigten Hinweise ausgeben, um vorzurücken.",
+        "back_name": "Flicke den Riss",
+        "back_flavor": "Du bist völlig erschöpft und hast keine Ahnung, wie du diesen Riss schließen kannst. Er ist zu weit entfernt, um ihn zu berühren, und nichts, was du tust, hat irgendeine Auswirkung. Es gibt nichts, was dich leiten könnte, außer den unirdischen Worten, die in deinen Geist tröpfeln. In diesem Moment hörst du eine vertraute Stimme in dem widerhallenden Chor und fühlst den Zwang, ihre Worte zu wiederholen. \"Claude ostium…\" Zunächst flüsterst du, die Worte liegen dir auf der Zunge. Du schließt deine Augen, um dich zu konzentrieren und der Widerhall wird lauter. Als er endet und du deine Augen erneut öffnest, erblickst du nichts außer einem tintenschwarzen Abgrund und der Riss ist verschwunden.",
+        "back_text": "Entferne den Rand des Universums aus dem Spiel.\nBringe den beiseitegelegten Ort Riss durch die Zeit ins Spiel."
     },
     {
         "code": "02319",
-        "flavor": "With no clear way out of this dimension, you seek another path.",
-        "name": "Finding a New Way",
-        "text": "[action]: Discard the top 3 cards of the encounter deck. Choose a location discarded by this effect and resolve its 'revelation' ability.\n<b>Objective</b> - If each undefeated investigator has resigned, advance.",
-        "back_name": "Reality Beckons",
-        "back_flavor": "You discover a path that looks somewhat familiar and follow it. Even though your task is complete, you now understand that in closing the tear, you may never make it home. The fear of being lost here forever spurs you onward, through an archway leading into an overgrown corridor. A damp wooden door leads you out into a pocket of thin rain and dark sky. Cement turns to gravel, then marble, then steel, then grass. You cross impossibly long meadows and make your way through dense woods before fatigue finally sets in. Drained of all energy, you cannot go on any further. Your body gives out.",
-        "back_text": "<b>(→R1)</b>"
+        "flavor": "Da es keinen klar erkennbaren Weg aus dieser Dimension gibt, suchst du nach einem neuen Pfad.",
+        "name": "Finde einen neuen Weg",
+        "text": "[action]: Lege die obersten 3 Karten des Begegnungsdecks ab. Wähle einen durch diesen Effekt abgelegten Ort und handle seine \”Enthüllung\”-Fähigkeit ab.\n<b>Ermittlungsziel</b> - Falls jeder unbesiegte Ermittler aufgegeben hat, rücke vor.",
+        "back_name": "Schimmer der Realität",
+        "back_flavor": "Du entdeckst einen Weg, der dir vage vertraut erscheint, und folgst ihm. Obwohl deine Aufgabe abgeschlossen ist, verstehst du nun, dass du, wenn du den Riss schließt, niemals nach Hause zurückkehren kannst. Die Furcht davor, hier für immer verloren zu sein, treibt dich voran durch einen Bogen, der in einen überwucherten Gang führt. Eine feuchte Holztür führt dich in eine Tasche der Realität, in der feiner Regen fällt und über der sich ein düsterer Himmel wölbt. Zement wird zu Schotter, dann zu Mamor, zu Stahl und schließlich zu Gras. Du überquerst unmöglich lange Weiden, schlägst dich durch dichte Wälder, bis schließlich die Müdigkeit die Oberhand gewinnt. Du hast keine Energie mehr, um weiter zu gehen. Dein Körper gibt auf.",
+        "back_text": "<b>(?A1)</b>"
     },
     {
         "code": "02320",
-        "name": "Another Dimension",
-        "subname": "Unfettered by Reality",
-        "text": "<b>Forced</b> - When a location leaves play: Move each investigator and unengaged enemy at that location to Another Dimension. Cannot be canceled.",
-        "traits": "Otherworld.",
-        "back_flavor": "You gape in disbelief at the swirling colors and alien angles surrounding you. This is true madness. "
+        "name": "Eine andere Dimension",
+        "subname": "Von der Realität losgelöst",
+        "text": "<b>Erzwungen</b> - Sobald ein Ort das Spiel verlässt: Bewege jeden Ermittler und jeden nicht in einen Kampf verwickelten Gegner an diesem Ort auf Eine andere Dimension. Kann nicht aufgehoben werden.",
+        "traits": "Anderswelt.",
+        "back_flavor": "Du bestaunst mit offenen Mund die wirbelnden Farben und fremdartigen Winkel, die dich umgeben. Dies ist echter Wahnsinn."
     },
     {
         "code": "02321",
-        "name": "The Edge of the Universe",
-        "text": "You must have at least 2 clues in order to move to The Edge of the Universe.\nInvestigators at The Edge of the Universe cannot draw cards during the upkeep phase.",
-        "traits": "Otherworld.",
-        "back_flavor": "Nothing could have possibly prepared you for this.\nIt is beautiful and terrible to behold.",
-        "back_text": "You must have at least 2 clues in order to move to The Edge of the Universe."
+        "name": "Rand des Universums",
+        "text": "Du musst mindestens 2 Hinweise haben, um dich zum Rand des Universums zu bewegen.\nErmittler auf dem Rand des Universums können während der Unterhaltphase keine Karten ziehen.",
+        "traits": "Anderswelt.",
+        "back_flavor": "Nichts hätte dich darauf vorbereiten können.\nEs ist wunderschön und zugleich schrecklich anzusehen.",
+        "back_text": " Du musst mindestens 2 Hinweise haben, um dich zum Rand des Universums zu bewegen."
     },
     {
         "code": "02322",
-        "name": "Tear Through Time",
-        "text": "[action] Spend 2 clues: <b>Resign.</b> You find a new path and hope that it leads back to safety.",
-        "traits": "Otherworld.",
-        "back_flavor": "What is, what was, what will never be…\nyou see it all, and it sees you."
+        "name": "Riss durch die Zeit",
+        "text": "[action] Gib 2 Hinweise aus: <b>Aufgeben.</b> Du findest einen neuen Weg und hoffst, dass er dich zurück in Sicherheit führt.",
+        "traits": "Anderswelt.",
+        "back_flavor": "Was ist, was war, was niemals sein wird…\nDu siehst es alles und es sieht dich."
     },
     {
         "code": "02323",
         "name": "Yog-Sothoth",
-        "subname": "The Lurker Beyond the Threshold",
-        "text": "Massive. Hunter. Retaliate.\nYog-Sothoth gets +6[per_investigator] health.\nYog-Sothoth cannot be evaded and cannot make attacks of opportunity.\n[reaction] When Yog-Sothoth attacks you: Instead of taking up to X horror, you may discard the top X cards from your deck. Then, if you have no cards in your deck, you are driven insane.",
-        "traits": "Ancient One. Elite."
+        "subname": "Der Lauerer jenseits der Schwelle",
+        "text": "Gewaltig. Jäger. Zurückschlagen.\nYog-Sothoth erhält +6[per_investigator] Ausdauer.\nMan kann Yog-Sothoth nicht enkommen und er kann keine Gelegenheitsangriffe durchführen.\n[reaction] Sobald dich Yog-Sothoth angreift: Statt bis zu X Horror zu nehmen, darfst du die obersten X Karten von deinem Deck ablegen. Falls du dann keine Karten in deinem Deck hast, wirst du wahnsinnig.",
+        "traits": "Großer Alter. Elite."
     },
     {
         "code": "02324",
-        "name": "Tear Through Space",
-        "text": "Surge.\n<b>Revelation</b> - Put Tear Through Space into play.\n<b>Forced</b> - At the end of the round: Either place 1 doom on Tear Through Space, or discard it.",
-        "traits": "Otherworld. Extradimensional."
+        "name": "Riss durch den Raum",
+        "text": "Nachrüsten.\n<b>Enthüllung</b> - Bringe den Riss durch den Raum ins Spiel.\n<b>Erzwungen</b> - Am Ende der Runde: Platziere entweder 1 Verderben auf den Riss durch den Raum oder lege diesen Ort ab.",
+        "traits": "Anderswelt. Außerdimensional."
     },
     {
         "code": "02325",
-        "name": "Prismatic Cascade",
-        "text": "<b>Revelation</b> - Put Prismatic Cascade into play and discard a random card from your hand.\n<b>Forced</b> - After the last clue on Prismatic Cascade is removed: Discard Prismatic Cascade.",
-        "traits": "Otherworld. Extradimensional."
+        "name": "Prismatische Kaskade",
+        "text": "<b>Enthüllung</b> - Bringe die Prismatische Kaskade ins Spiel und lege eine zufällige Karte von deiner Hand ab.\n<b>Erzwungen</b> - Nachdem der letzte Hinweis auf der Prismatischen Kaskade entfernt worden ist: Lege die Prismatische Kaskade ab.",
+        "traits": "Anderswelt. Außerdimensional."
     },
     {
         "code": "02326",
-        "name": "Endless Bridge",
-        "text": "<b>Revelation</b> - Put Endless Bridge into play and lose 2 resources.\n<b>Forced</b> - After an investigator leaves Endless Bridge: Either place 1 doom on Endless Bridge, or discard it.",
-        "traits": "Otherworld. Extradimensional."
+        "name": "Endlose Brücke",
+        "text": "<b>Enthüllung</b> - Bringe die Endlose Brücke ins Spiel und verliere 2 Ressourcen.\n<b>Erzwungen</b> - Nachdem ein Ermittler die Endlose Brücke verlässt; Platziere entweder 1 Verderben auf die Endlose Brücke oder lege sie ab.",
+        "traits": "Anderswelt. Außerdimensional."
     },
     {
         "code": "02327",
-        "name": "Steps of Y'hagharl",
-        "text": "<b>Revelation</b> - Put Steps of Y'hagharl into play. Then, draw the topmost <i>Madness</i> card in your discard pile.\n<b>Forced</b> - When you would leave Steps of Y'hagharl: Test [willpower] (2). If you fail, shuffle Steps of Y'hagharl into the encounter deck instead of moving to your original destination.",
-        "traits": "Otherworld. Extradimensional."
+        "name": "Stufen von Y'hagharl",
+        "text": "<b>Enthüllung</b> - Bringe die Stufen von Y'hagharl ins Spiel. Ziehe dann die oberste <i>Wahnsinn</i>-Karte in deinem Ablagestapel.\n<b>Erzwungen</b> - Sobald du die Stufen von Y'hagharl verlassen würdest: Lege eine [willpower]-Probe (2) ab. Falls die Probe misslingt, mische die Stufen von Y'hagharl in das Begegnungsdeck, statt dich zu deinem ursprünglichen Ziel zu bewegen.",
+        "traits": "Anderswelt. Außerdimensional."
     },
     {
         "code": "02328",
-        "name": "Dimensional Doorway",
-        "text": "<b>Revelation</b> - Put Dimensional Doorway into play. Then, draw the topmost <i>Hex</i> card in the encounter discard pile.\n<b>Forced</b> - At the end of your turn, if you are at Dimensional Doorway: You must either spend 2 resources or shuffle Dimensional Doorway into the encounter deck.",
-        "traits": "Otherworld. Extradimensional."
+        "name": "Tor zwischen den Dimensionen",
+        "text": "<b>Enthüllung</b> - Bringe das Tor zwischen den Dimensionen ins Spiel. Ziehe dann die oberste <i>Verwünschung</i>-Karte im Begegnungs-Ablagestapel.\n<b>Erzwungen</b> - Falls du dich am Ende deines Zuges im Tor zwischen den Dimensionen befindest: Gib entweder 2 Ressourcen aus oder mische das Tor zwischen den Dimensionen in das Begegnungsdeck.",
+        "traits": "Anderswelt. Außerdimensional."
     },
     {
         "code": "02329",
-        "name": "Interstellar Traveler",
-        "text": "<b>Spawn</b> - Any <i>Extradimensional</i> location.\nHunter.\n<b>Forced</b> - When Interstellar Traveler enters a location: Flip 1 clue on that location to its doom side and place it on Interstellar Traveler, or place 1 doom on Interstellar Traveler if there are no clues on that location.",
-        "traits": "Monster. Yithian."
+        "name": "Reisender zwischen den Sternen",
+        "text": "<b>Erscheinen</b> - Beliebiger <i>Außerdimensional</i>-Ort.\nJäger.\n<b>Erzwungen</b> - Sobald der Reisender zwischen den Sternen einen Ort betritt: Drehe 1 Hinweis auf diesem Ort auf seine Verderben-Seite und platziere ihn auf den Reisenden zwischen den Sternen oder platziere 1 Verderben auf den Reisenden zwischen den Sternen, falls sich keine Hinweise auf diesem Ort befinden.",
+        "traits": "Monster. Yith."
     },
     {
         "code": "02330",
-        "name": "Yithian Starseeker",
-        "text": "<b>Spawn</b> - Another Dimension.\nRetaliate.\n<b>Forced</b> - When Yithian Starseeker attacks an investigator with more than 10 cards in his or her discard pile: Place 1 doom on Yithian Starseeker.",
-        "traits": "Monster. Yithian."
+        "name": "Yith-Sternensucher",
+        "text": "<b>Erscheinen</b> - Eine andere Dimension.\nZurückschlagen.\n<b>Erzwungen</b> - Sobald der Yith-Sternensucher einen Charakter angreift, der mehr als 10 Karten in seinem Ablagestapel hat: Platziere 1 Verderben auf den Yith-Sternensucher.",
+        "traits": "Monster. Yith."
     },
     {
         "code": "02331",
-        "flavor": "The world around you appears to be folding in on itself, warping, twisting, bending.",
-        "name": "Collapsing Reality",
-        "text": "<b>Revelation</b> - If you are at an <i>Extradimensional</i> location, discard it and take 1 damage. Otherwise, take 2 damage.",
-        "traits": "Hazard."
+        "flavor": "Die Welt um dich herum scheint sich zusammenzufalten, zu verzerren, zu verdrehen und zu krümmen.",
+        "name": "Einstürzende Realität",
+        "text": "<b>Enthüllung</b> - Falls du auf einem <i>Außerdimensional</i>-Ort bist, lege diesen ab und nimm 1 Schaden. Ansonsten nimm 2 Schaden.",
+        "traits": "Gefahr."
     },
     {
         "code": "02332",
-        "name": "Wormhole",
-        "text": "<b>Revelation</b> - Discard cards from the top of the encounter deck until a location is discarded. Resolve that location's 'revelation' ability, then move to that location.",
-        "traits": "Hazard."
+        "name": "Wurmloch",
+        "text": "<b>Enthüllung</b> - Lege Karten oben vom Begegnungsdeck ab, bis ein Ort abgelegt wird. Handle die \”Enthüllung\”-Fähigkeit dieses Ortes ab und bewege dich dann auf diesen Ort.",
+        "traits": "Gefahr."
     },
     {
         "code": "02333",
-        "name": "Vast Expanse",
-        "text": "<b>Revelation</b> - If there are no <i>Extradimensional</i> locations in play, Vast Expanse gains surge. Otherwise, test [willpower] (X), where X is the number of <i>Extradimensional</i> locations in play (max 5). For each point you fail by, take 1 horror.",
-        "traits": "Terror."
+        "name": "Große Weite",
+        "text": "<b>Enthüllung</b> - Falls sich keine <i>Außerdimensional</i>-Orte im Spiel befinden, erhält Große Weite Nachrüsten. Ansonsten lege eine [willpower]-Probe (X) ab, wobei X die Anzahl der <i>Außerdimensional</i>-Orte im Spiel ist (max. 5). Für jeden Punkt um den die Probe misslingt, nimm 1 Horror.",
+        "traits": "Schrecken."
     }
 ]

--- a/translations/de/pack/dwl/tece.json
+++ b/translations/de/pack/dwl/tece.json
@@ -2,87 +2,87 @@
     {
         "code": "02147",
         "flavor": "",
-        "name": "Bandolier",
-        "text": "You have 1 additional hand slot, which can only be used to hold a <b>Weapon</b> asset.",
-        "traits": "Item.",
+        "name": "Patronengurt",
+        "text": "Du hast 1 zusätzlichen Handslot, der nur für <b>Waffe</b>-Vorteilskarten verwendet werden kann.",
+        "traits": "Gegenstand.",
         "slot": "Body"
     },
     {
         "code": "02148",
-        "flavor": "They won't take us down that easily!",
-        "name": "Stand Together",
-        "text": "Choose another investigator at your location. Both you and that investigator draw 2 cards and gain 2 resources.",
-        "traits": "Spirit."
+        "flavor": "So einfach bekommen sie uns nicht!",
+        "name": "Zusammenhalten",
+        "text": "Wähle einen anderen Ermittler an deinem Ort. Ihr zieht jeder 2 Karten und erhaltet 2 Ressourcen.",
+        "traits": "Geist."
     },
     {
         "code": "02149",
         "flavor": "",
-        "name": "Art Student",
-        "text": "[reaction] After Art Student enters play: Discover 1 clue at your location.",
-        "traits": "Ally. Miskatonic.",
+        "name": "Kunststudentin",
+        "text": "[reaction] Nachdem Kunststudentin ins Spiel gekommen ist: Entdecke 1 Hinweis an deinem Ort.",
+        "traits": "Verbündeter. Miskatonic.",
         "slot": "Ally"
     },
     {
         "code": "02150",
-        "flavor": "I knew I had seen this symbol before. I must warn the others before it is too late!",
-        "name": "Deduction",
-        "text": "If this skill test is successful while investigating a location, discover 1 additional clue at that location (2 additional clues instead if it succeeds by 2 or more).",
-        "traits": "Practiced. Expert."
+        "flavor": "Ich wusste doch, dass ich dieses Symbol schon einmal gesehen habe. Ich muss die anderen warnen, bevor es zu spät ist!",
+        "name": "Deduktion",
+        "text": "Falls diese Fertigkeitsprobe gelingt, solange du an einem Ort ermittelst, entdeckst du 1 zusätzlichen Hinweis an diesem Ort (stattdessen 2 zusätzliche Hinweise, falls die Probe um 2 oder mehr gelingt).",
+        "traits": "Trainiert. Experte."
     },
     {
         "code": "02151",
-        "flavor": "Quitters may never win, but they also rarely die.",
-        "name": "\"I'm outta here!\"",
-        "text": "Play only if there is a scenario card with a 'resign' ability in play.\n<b>Resign.</b> You get the hell out of here.",
-        "traits": "Trick. Spirit."
+        "flavor": "Wer wegläuft, gewinnt zwar nie, stirbt aber auch selten.",
+        "name": "\"Ich bin dann mal weg!\"",
+        "text": "Spiele diese Karte nur, falls sich eine Szenariokarte mit einer \”Aufgeben\”-Fähigkeit im Spiel befindet.\n<b>Aufgeben.</b> Nichts wie weg von hier.",
+        "traits": "Trick. Geist."
     },
     {
         "code": "02152",
         "flavor": "",
-        "name": "Switchblade",
-        "text": "Fast.\n[action] <b>Fight.</b> You get +2 [combat] for this attack. If you succeed by 2 or more, this attack deals +1 damage.",
-        "traits": "Item. Weapon. Melee. Illicit.",
+        "name": "Springmesser",
+        "text": "Schnell.\n[action] <b>Kampf.</b> Du bekommst für diesen Angriff +2 [combat]. Falls dir diese Probe um 2 oder mehr gelingt, fügt dieser Angriff +1 Schaden zu.",
+        "traits": "Gegenstand. Waffe. Nahkampf. Illegal.",
         "slot": "Hand"
     },
     {
         "code": "02153",
-        "name": "Hypnotic Gaze",
-        "text": "Fast. Play when an enemy attacks an investigator at your location.\nCancel that attack. Then, reveal a random token from the chaos bag. If it has a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, deal the attacking enemy's damage to itself. ",
-        "traits": "Spell."
+        "name": "Hypnotisierender Blick",
+        "text": "Schnell. Spiele diese Karte, sobald ein Gegner einen Ermittler an deinem Ort angreift.\nHebe den Angriff auf. Enthülle dann einen zufälligen Marker aus dem Chaosbeutel. Fall er ein [skull]-, [cultist]-, [tablet]-, [elder_thing]-, oder [auto_fail]-Symbol hat, füge dem angreifenden Gegner seinen eigenen Schaden zu.",
+        "traits": "Zauber."
     },
     {
         "code": "02154",
-        "name": "Shrivelling",
-        "text": "<b>Uses</b>: 4 charges.\n[Action] Spend one charge: <b>Fight.</b> This attack uses [willpower] instead of [combat]. You get +2 [willpower] and deal +1 damage for this attack. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this attack, take 1 horror. ",
-        "traits": "Spell.",
+        "name": "Vertrocknen",
+        "text": "<b>Anwendungen</b>: 4 Ladungen.\n[Action] Gib 1 Ladung aus: <b>Kampf.</b> Dieser Angriff verwendet [willpower] statt [combat]. Du bekommst für diesen Angriff +2 [willpower] und fügst +1 Schaden zu. Falls ein [skull]-, [cultist]-, [tablet]-, [elder_thing]-, oder [auto_fail]-Symbol während dieses Angriffs enthüllt wird, nimmst du 1 Horror.",
+        "traits": "Zauber.",
         "slot": "Arcane"
     },
     {
         "code": "02155",
-        "flavor": "There's nothing in the headlines about the horrors you've witnessed. But the obituaries section is disturbingly long.",
-        "name": "Newspaper",
-        "text": "You get +2 [intellect] while investigating if you have no clues.",
-        "traits": "Item.",
+        "flavor": "In den Schlagzeilen findest du nichts über die fürchterlichen Dinge, die du gesehen hast. Aber es gibt erschreckend viele Nachrufe.",
+        "name": "Zeitung",
+        "text": "Du bekommst +2 [intellect] solange du ermittelst, falls du keine Hinweise hast.",
+        "traits": "Gegenstand.",
         "slot": "Hand"
     },
     {
         "code": "02156",
-        "name": "Lure",
-        "text": "Attach to your location.\n During the enemy phase, each enemy that moves does so along the shortest path toward the attached location, instead of to where it would normally move.\n <b>Forced</b> - While attached, at the end of the round: Discard Lure. ",
+        "name": "Köder",
+        "text": "Hänge diese Karte an deinen Ort an.\n Während der Gegnerphase nimmt jeder Gegner, der sich bewegt, den kürzesten Weg in Richtung des Ortes mit dieser Verstärkung, statt sich normal zu bewegen.\n <b>Erzwungen</b> - Solange diese Verstärkung am Ende der Runde angehängt ist: Lege Köder ab.",
         "traits": "Trick."
     },
     {
         "code": "02157",
-        "flavor": "No stone unturned, no ancient treasure left behind.",
-        "name": "Relic Hunter",
-        "text": "Permanent.\nYou have 1 additional accessory slot.",
+        "flavor": "Kein Ort bleibt unerforscht, kein uralter Schatz wird zurückgelassen.",
+        "name": "Reliktjäger",
+        "text": "Dauerhaft.\nDu hast 1 zusätzlichen Zubehörslot.",
         "traits": "Talent."
     },
     {
         "code": "02158",
-        "flavor": "When you turn on the charm, it could light the entire town.",
+        "flavor": "Wenn du deinen Charme spielen lässt, könntest du damit die gesamte Stadt um den Finger wickeln.",
         "name": "Charisma",
-        "text": "Permanent.\nYou have 1 additional ally slot.",
+        "text": "Dauerhaft.\nDu hast 1 zusätzlichen Verbündeter-Slot.",
         "traits": "Talent."
     }
 ]

--- a/translations/de/pack/dwl/tece_encounter.json
+++ b/translations/de/pack/dwl/tece_encounter.json
@@ -1,171 +1,184 @@
 [
     {
         "code": "02159",
-        "name": "Essex County Express",
-        "text": "[skull]: -X. X is the current Agenda #.\n[cultist]: -1. If you fail and it is your turn, lose all remaining actions and end your turn immediately.\n[tablet]: -2. Add 1 doom token to the nearest Cultist enemy.\n[elder_thing]: -3. If you fail, choose and discard a card from your hand.",
-        "back_text": "[skull]: -X. X is 1 more than the current Agenda #. \n[cultist]: Reveal another token. If you fail and it is your turn, lose all remaining actions and end your turn immediately.\n[tablet]: -4. Add 1 doom token to each Cultist enemy in play.\n[elder_thing]: -3. If you fail, choose and discard a card from your hand for each point you failed by."
+        "name": "Der Essex-County-Express",
+        "text": "<b>Einfach / Normal</b>\n[skull]: -X. X ist die Nummer der aktuellen Agenda.\n[cultist]: -1. Falls die Probe misslingt und es dein Zug ist, verlierst du alle verbliebenden Aktionen und beendest sofort deinen Zug.\n[tablet]: -2. Füge dem nächstgelegenen <i>Kultist</i>-Gegner 1 Verderbensmarker hinzu.\n[elder_thing]: -3. Falls die Probe misslingt, wähle eine Karte von deiner Hand und lege sie ab.",
+        "back_text": "<b>Schwer / Experte</b>\n [skull]: -X. X ist die Nummer der aktuellen Agenda plus 1. \n[cultist]: Enthülle einen weiteren Marker. Falls die Probe misslingt und es dein Zug ist, verlierst du alle verbliebenden Aktionen und beendest sofort deinen Zug.\n[tablet]: -4. Füge jedem <i>Kultist</i>-Gegner im Spiel 1 Verderbensmarker hinzu. \n[elder_thing]: -3. Falls die Probe misslingt, wähle für jeden Punkt, um den sie misslingt, eine Karte von deiner Hand und lege sie ab."
     },
     {
         "code": "02160",
-        "flavor": "As the train to Dunwich comes to a jarring stop, you look out the window behind you and see an immense tear in the sky, like a rip in a piece of cloth. Several of the rearmost train cars are pulled backwards, and there is a dreadful metallic crunch as they are detached. The train cars topple upwards and into the rift in the sky. Nearby passengers are panicking, others are cowering in their seats, and one elderly man has fainted in fear.",
-        "name": "A Tear in Reality",
-        "back_text": "Remove the leftmost location from the game (or place it in the victory display if it has Victory X and no clues on it). Each investigator at that location is defeated. Each enemy and asset at that location is discarded.\nDiscard all clues controlled by the investigators."
+        "flavor": "Als der Zug nach Dunwich mit kreischenden Bremsen anhält, siehst du durch das Fenster hinter dir einen gewaltigen Riss im Himmel, wie durch ein Stück Stoff. Einige der hinteren Wagen werden zurückgezogen und mit einem fürchterlichen metallischen Knirschen vom Zug getrennt. Dann werden die Wagen des Zuges nach oben in den Riss am Himmel gezogen. Einige der Fahrgäste um dich herum verfallen in Panik, andere kauern auf ihren Sitzen und ein älterer Mann ist vor Angst ohnmächtig geworden.",
+        "name": "Ein Riss in der Realität",
+        "back_name": "Bleib in Bewegung!",
+        "back_flavor": "Der hintere Wagen des Zuges wird abgerissen, als er nach hinten gezogen wird. Zu deinem Schrecken erhebt er sich von den Schienen und wird vom Tor über dir verschlungen.",
+        "back_text": "Der Ort ganz links wird aus dem Spiel entfernt (oder auf den Siegespunktestapel platziert, falls er Sieg X hat und sich keine Hinweise auf ihm befinden). Jeder Ermittler an diesem Ort ist besiegt. Jeder Gegner und Vorteil an diesem Ort werden abgelegt. \nAlle Hinweise, welche die Ermittler kontrollieren, werden abgelegt."
     },
     {
         "code": "02161",
-        "flavor": "The tear grows larger, and you can feel the rearmost car of the train shaking as it is pulled backwards. The situation threatens to erupt into chaos as more passengers realize the danger they are in. Some passengers are looking for places to hide, while others are running about the compartments in terror.",
-        "name": "The Maw Widens",
-        "back_text": "Remove the leftmost location from the game (or place it in the victory display if it has Victory X and no clues on it). Each investigator at that location is defeated. Each enemy and asset at that location is discarded.\nDiscard all clues controlled by the investigators."
+        "flavor": "Der Riss wird größer und du spürst, wie der hinterste Wagen bebt, als ob er nach hinten gezogen würde. Während mehr und mehr Fahrgäste die Gefahr erkennen, in der sie sich befinden, droht Chaos auszubrechen. Einige Fahrgäste suchen nach Verstecken, andere rennen panisch durch die Abteile.",
+        "name": "Der Schlund wird größer",
+        "back_name": "Halte nicht an!",
+        "back_flavor": "Der nächste Wagen wird mit gewaltiger Kraft nach hinten gerissen. Ein Mann in mittleren Jahren kann sich gerade eben noch festhalten, als der Wagen ungehindert in Richtung Riss fliegt. Dort wird er sofort vollständig verschlungen und der Mann lässt los, um nicht in den Riss gezogen zu werden. Er fällt zunächst, wird aber von der Kraft des Risses aufgefangen und trotzdem hineingezogen.",
+        "back_text": "Der Ort ganz links wird aus dem Spiel entfernt (oder auf den Siegespunktestapel platziert, falls er Sieg X hat und sich keine Hinweise auf ihm befinden). Jeder Ermittler an diesem Ort ist besiegt. Jeder Gegner und Vorteil an diesem Ort werden abgelegt. \nAlle Hinweise, welche die Ermittler kontrollieren, werden abgelegt."
     },
     {
         "code": "02162",
-        "flavor": "The pull of the rift in the sky seems to grow stronger, and the entire train begins to roll backwards along the tracks. The rearmost cars of the train begin to rattle, the force of the rift threatening to detach them. You must get out of these cars as fast as you can!",
-        "name": "Rolling Backwards",
-        "back_text": "Remove each of the two leftmost locations from the game (or place it in the victory display if either one has Victory X and no clues on it). Each investigator at those locations is defeated. Each enemy and asset at those locations is discarded.\nDiscard all clues controlled by the investigators."
+        "flavor": "Der Sog des Risses im Himmel scheint ständig zuzunehmen und der gesamte Zug beginnt rückwärts über die Schienen zu rollen. Die hintersten Wagen des Zuges werden durchgerüttelt und die Kraft des Risses droht sie abzutrennen. Du musst so schnell wie möglich aus diesem Teil des Zuges heraus!",
+        "name": "Rückwärtsbewegung",
+        "back_name": "Es wird schneller!",
+        "back_flavor": "Die beiden Wagen, die dem Tor am nächsten sind, werden vom Rest des Zuges durch eine Wand aus übernatürlich heißem Dampf getrennt, die durch das Metall gleitet wie ein Messer durch Butter. Die Wagen werden nach oben gesogen und fliegen durch das Tor. Irgendetwas über dem Zug stößt ein fürchterliches Kreischen aus, das in deinen Ohren wie das schrille Geräusch eines gebrochenes Dampfrohrs klingt.",
+        "back_text": "Die beiden Orte ganz links werden aus dem Spiel entfernt (oder auf den Siegespunktestapel platziert, falls einer von ihnen Sieg X hat und sich keine Hinweise darauf befinden). Jeder Ermittler an diesen Orten ist besiegt. Jeder Gegner und Vorteil an diesen Orten werden abgelegt. \nAlle Hinweise, welche die Ermittler kontrollieren, werden abgelegt."
     },
     {
         "code": "02163",
-        "flavor": "The gate crackles with power as its strength increases. Dirt and rocks from the edge of the bridge behind you are torn from the ground and trees are uprooted, pulled in by the gate. One younger passenger smashes the window of your car and shouts, “We gotta get outta here!” He leaps out of the window, but before he lands in the river below, he is snatched in the talons of a swift flying creature, and carried out of sight. A trail of steam is left in the creature’s wake.",
-        "name": "Drawn In",
-        "back_text": "Remove each of the two leftmost locations from the game (or place it in the victory display if either one has Victory X and no clues on it). Each investigator at those locations is defeated. Each enemy and asset at those locations is discarded.\nDiscard all clues controlled by the investigators."
+        "flavor": "Das Tor knistert elektrisch, als seine Stärke zunimmt. Erdboden und Felsen vom Rand der Brücke hinter dir werden hochgerissen, Bäume werden entwurzelt und vom Tor eingesogen. Ein jüngerer Fahrgast schlägt ein Fenster deines Wagens ein und schreit \"Wir müssen hier raus!\" Er springt aus dem Fenster, aber noch bevor er im Fluss landet, packt ihn eine schnell vorbeifliegende Kreatur mit ihren Klauen und trägt ihn fort. Dabei hinterlässt sie eine Spur aus Dampf.",
+        "name": "Hineingezogen",
+        "back_name": "Es ist nirgendwo sicher",
+        "back_flavor": "Die beiden hinteren Wagen des Zuges beginnen zu schmelzen, als der heiße Dampf in sie eindringt. Das Metall verbiegt sich und die Fahrgäste schreien in Todequalen. Zusammen mit den Bahnschwellen und Teilen der Brücke hinter dir werden die Wagen von den Schienen in die Luft gerissen.",
+        "back_text": "Die beiden Orte ganz links werden aus dem Spiel entfernt (oder auf den Siegespunktestapel platziert, falls einer von ihnen Sieg X hat und sich keine Hinweise darauf befinden). Jeder Ermittler an diesen Orten ist besiegt. Jeder Gegner und Vorteil an diesen Orten werden abgelegt. \nAlle Hinweise, welche die Ermittler kontrollieren, werden abgelegt."
     },
     {
         "code": "02164",
-        "flavor": "The rift in the sky twists and shakes, completely distorted. Its size is now massive, its shape warping and shifting, as if it is about to explode.",
-        "name": "Out of Time",
-        "back_text": "Each investigator is immediately defeated and takes 1 mental trauma. <b>(&rarr;R2)</b>"
+        "flavor": "Der Riss im Himmel verformt sich, zittert und wirkt völlig verzerrt. Inzwischen ist er riesig und verändert ständig seine Form, als ob er bald explodieren würde.",
+        "name": "Es bleibt keine Zeit mehr",
+        "back_name": "Hineingesogen",
+        "back_flavor": "Die ganze Brücke ächzt unter dem Druck des Tores und bricht zusammen. Statt in den Fluss zu fallen, werden die übrigen Wagen in Richtung des Risses im Himmel gezogen. Du klammerst dich verzweifelt fest und schreist vor Schreck auf, als du in das Tor gezogen wirst. Dann wird um dich herum alles schwarz.",
+        "back_text": "Jeder überlebende Ermittler ist sofort besiegt und erleidet 1 seelisches Trauma. <b>(&rarr;A2)</b>"
     },
     {
         "code": "02165",
-        "flavor": "The train has stopped on a bridge high above the Miskatonic River – you might be able to survive the fall, but you don’t like your chances. Your best bet is to make your way to the engine car as fast as you can and get the train running again.",
-        "name": "Run!",
-        "text": "<b>Objective</b> - If an investigator enters the Engine Car, immediately advance.",
-        "back_text": "<b>The investigator entering the Engine Car reads the following (out loud):\n</b>You must decide (choose one):\n- Test [agility] (3) to attempt to dodge the creature. If you fail, you leap too far and barely grip the side of the train, hanging on for dear life. Although you manage to pull yourself up, the experience is terrifying. You suffer 1 mental trauma.\n- Test [combat] (3) to attempt to endure the creature's extreme heat. If you fail, the creature flies through you and the heat burns you. You suffer 1 physical trauma."
+        "flavor": "Der Zug hat auf einer Brücke hoch über dem Miskatonic-Fluss angehalten – vielleicht könntest du den Fall überleben, aber die Wahrscheinlichkeit ist dir zu gering. Deine Überlebenschance ist am größten, wenn du so schnell wie möglich die Lokomotive erreichst und den Zug erneut startest.",
+        "name": "Lauf!",
+        "back_name": "Flügel aus Dampf",
+        "text": "<b>Ermittlungsziel</b> - Falls ein Ermittler die Lokomotive betritt, rücke sofort vor.",
+        "back_text": "<b>Der Ermittler, der die Lokomotive betritt, liest folgenden Text laut vor:\n</b>Du musst entscheiden (wähle eins):\n- Lege eine [agility]-Probe (3) ab, um zu versuchen der Kreatur auszuweichen. Falls die Probe misslingt, springst du zu weit und schaffst es gerade eben noch, den Rand des Zuges zu erwischen und dich dort festzuklammern. Obwohl du es schaffst, dich hochzuziehen, ist die Erfahrung beängstigend. Du erleidest 1 seelisches Trauma.\n- Lege eine [combat]-Probe (3) ab, um zu versuchen die extreme Hitze der Kreatur auszuhalten. Falls die Probe misslingt, fliegt die Kreatur durch dich hindurch und die Hitze verbrennt dich. Du erleidest 1 körperliches Trauma."
     },
     {
         "code": "02166",
-        "flavor": "You’ve managed to make it to the engine cab, but now you have to get the engine started again so you can outrun the pulling force of the gate!",
-        "name": "Get the Engine Running!",
-        "text": "<b>Objective</b> - If there are no clues in the Engine Car, immediately advance.",
-        "back_text": "<b>(&rarr;R1)</b>"
+        "flavor": "Du hast es in die Kabine der Lokomotive geschafft, aber nun musst du die Maschine erneut anlassen, um der Zugkraft des Tores etwas entgegensetzen zu können!",
+        "name": "Bring den Motor zum Laufen!",
+        "text": "<b>Ermittlungsziel</b> - Falls sich keine Hinweise auf der Lokomotive befinden, rücke sofort vor.",
+        "back_name": "Vorwärtsbewegung",
+        "back_flavor": "Der Motor erwacht fauchend zum Leben und fängt an zu arbeiten. Du schaufelst Kohle in die Feuerstelle der Lokomotive und bist erleichert, dass der Zug sich erneut vorwärts bewegt.",
+        "back_text": "<b>(&rarr;A1)</b>"
     },
     {
         "code": "02167",
-        "name": "Train Car",
-        "text": "Passenger Car is connected to the locations to the left and right of it.\n<b>Forced</b> - After you enter Passenger Car: You must either discard cards from your hand with at least 2 total [agility] icons or take 2 damage.",
-        "traits": "Train.",
-        "back_text": "Train Car is connected to the locations to the left and right of it.\nYou cannot enter Train Car unless all of the clues on the location to its left have been discovered."
+        "name": "Waggon",
+        "text": "Der Passagierwagen ist mit den Orten links und rechts von ihm verbunden.\n<b>Erzwungen</b> - Nachdem du den Passagierwagen betreten hast: Lege entweder Karten mit insgesamt mindestens 2 [agility]-Symbolen von deiner Hand ab oder nimm 2 Schaden.",
+        "traits": "Zug.",
+        "back_text": "Der Waggon ist mit den Orten links und rechts von ihm verbunden.\nDu kannst den Wagon nicht betreten, bis alle Hinweise auf dem Ort links von ihm entdeckt worden sind."
     },
     {
         "code": "02168",
-        "name": "Train Car",
-        "text": "Passenger Car is connected to the locations to the left and right of it.\n<b>Forced</b> - After you enter Passenger Car: You must either discard cards from your hand with at least 2 total [combat] icons or take 2 damage.",
-        "traits": "Train.",
-        "back_text": "Train Car is connected to the locations to the left and right of it.\nYou cannot enter Train Car unless all of the clues on the location to its left have been discovered."
+        "name": "Waggon",
+        "text": "Der Passagierwagen ist mit den Orten links und rechts von ihm verbunden.\n<b>Erzwungen</b> - Nachdem du den Passagierwagen betreten hast: Lege entweder Karten mit insgesamt mindestens 2 [combat] ]-Symbolen von deiner Hand ab oder nimm 2 Schaden.",
+        "traits": "Zug.",
+        "back_text": "Der Waggon ist mit den Orten links und rechts von ihm verbunden.\nDu kannst den Wagon nicht betreten, bis alle Hinweise auf dem Ort links von ihm entdeckt worden sind."
     },
     {
         "code": "02169",
-        "name": "Train Car",
-        "text": "Passenger Car is connected to the locations to the left and right of it.\n<b>Forced</b> - After you enter Passenger Car: You must either discard cards from your hand with at least 2 total [willpower] icons or take 2 horror.",
-        "traits": "Train.",
-        "back_text": "Train Car is connected to the locations to the left and right of it.\nYou cannot enter Train Car unless all of the clues on the location to its left have been discovered."
+        "name": "Waggon",
+        "text": "Der Passagierwagen ist mit den Orten links und rechts von ihm verbunden.\n<b>Erzwungen</b> - Nachdem du den Passagierwagen betreten hast: Lege entweder Karten mit insgesamt mindestens 2 [willpower]-Symbolen von deiner Hand ab oder nimm 2 Horror.",
+        "traits": "Zug.",
+        "back_text": "Der Waggon ist mit den Orten links und rechts von ihm verbunden.\nDu kannst den Wagon nicht betreten, bis alle Hinweise auf dem Ort links von ihm entdeckt worden sind."
     },
     {
         "code": "02170",
-        "name": "Train Car",
-        "text": "Passenger Car is connected to the locations to the left and right of it.\n<b>Forced</b> - After you enter Passenger Car: You must either discard cards from your hand with at least 2 total [intellect] icons or take 2 horror.",
-        "traits": "Train.",
-        "back_text": "Train Car is connected to the locations to the left and right of it.\nYou cannot enter Train Car unless all of the clues on the location to its left have been discovered."
+        "name": "Waggon",
+        "text": "Der Passagierwagen ist mit den Orten links und rechts von ihm verbunden.\n<b>Erzwungen</b> - Nachdem du den Passagierwagen betreten hast: Lege entweder Karten mit insgesamt mindestens 2 [intellect]-Symbolen von deiner Hand ab oder nimm 2 Horror.",
+        "traits": "Zug.",
+        "back_text": "Der Waggon ist mit den Orten links und rechts von ihm verbunden.\nDu kannst den Wagon nicht betreten, bis alle Hinweise auf dem Ort links von ihm entdeckt worden sind."
     },
     {
         "code": "02171",
-        "name": "Train Car",
-        "text": "Passenger Car is connected to the locations to the left and right of it.\n<b>Forced</b> - After you enter Passenger Car: You must either discard a card from your hand with at least 1 [wild] icon or take 1 damage and 1 horror.",
-        "traits": "Train.",
-        "back_text": "Train Car is connected to the locations to the left and right of it.\nYou cannot enter Train Car unless all of the clues on the location to its left have been discovered."
+        "name": "Waggon",
+        "text": "Der Passagierwagen ist mit den Orten links und rechts von ihm verbunden.\n<b>Erzwungen</b> - Nachdem du den Passagierwagen betreten hast: Lege entweder eine Karte mit mindestens 1 [wild]-Symbol von deiner Hand ab oder nimm 1 Schaden und 1 Horror.",
+        "traits": "Zug.",
+        "back_text": "Der Waggon ist mit den Orten links und rechts von ihm verbunden.\nDu kannst den Wagon nicht betreten, bis alle Hinweise auf dem Ort links von ihm entdeckt worden sind."
     },
     {
         "code": "02172",
-        "name": "Train Car",
-        "text": "Sleeping Car is connected to the locations to the left and right of it.\n[action]:<b> </b>Gain 3 resources. Remember that you have \"stolen a passenger's luggage.\" (Group limit once per game).\n",
-        "traits": "Train.",
-        "back_text": "Train Car is connected to the locations to the left and right of it.\nYou cannot enter Train Car unless all of the clues on the location to its left have been discovered."
+        "name": "Waggon",
+        "text": "Der Schlafwagen ist mit den Orten links und rechts von ihm verbunden.\n[action]: Du erhälst 3 Ressourcen. Merke dir, dass du \“das Gepäck eines Passagiers gestohlen hast\“. (Nur ein Mal pro Spiel für die gesamte Gruppe.)\n",
+        "traits": "Zug.",
+        "back_text": "Der Waggon ist mit den Orten links und rechts von ihm verbunden.\nDu kannst den Wagon nicht betreten, bis alle Hinweise auf dem Ort links von ihm entdeckt worden sind."
     },
     {
         "code": "02173",
-        "name": "Train Car",
-        "text": "Dining Car is connected to the locations to the left and right of it.\n<b>Forced</b> - After you reveal Dining Car: Search the encounter deck and discard pile for a Grappling Horror and draw it.",
-        "traits": "Train.",
-        "back_text": "Train Car is connected to the locations to the left and right of it.\nYou cannot enter Train Car unless all of the clues on the location to its left have been discovered."
+        "name": "Waggon",
+        "text": "Der Speisewagen ist mit den Orten links und rechts von ihm verbunden.\n<b>Erzwungen</b> - Nachdem du den Speisewagen enthüllt hast: Durchsuche das Begegnungsdeck und den Ablagestapel nach einem Packenden Schrecken und ziehe ihn.",
+        "traits": "Zug.",
+        "back_text": "Der Waggon ist mit den Orten links und rechts von ihm verbunden.\nDu kannst den Wagon nicht betreten, bis alle Hinweise auf dem Ort links von ihm entdeckt worden sind."
     },
     {
         "code": "02174",
-        "name": "Train Car",
-        "text": "Parlor Car is connected to the locations to the left and right of it.\nParlor Car cannot be investigated.\n[action] Spend 3 resources: Discover 1 clue in the Parlor Car.",
-        "traits": "Train.",
-        "back_text": "Train Car is connected to the locations to the left and right of it.\nYou cannot enter Train Car unless all of the clues on the location to its left have been discovered."
+        "name": "Waggon",
+        "text": "Der Salonwagen ist mit den Orten links und rechts von ihm verbunden.\nIm Salonwagen kann nicht ermittelt werden.\n[action] Gib 3 Ressourcen aus: Entdecke 1 Hinweis im Salonwagen.",
+        "traits": "Zug.",
+        "back_text": "Der Waggon ist mit den Orten links und rechts von ihm verbunden.\nDu kannst den Wagon nicht betreten, bis alle Hinweise auf dem Ort links von ihm entdeckt worden sind."
     },
     {
         "code": "02175",
-        "flavor": "There is no sign of the conductor anywhere. You have to figure out how to start the engine on your own.",
-        "name": "Engine Car",
-        "text": "Engine Car is connected to the location to the left of it.",
-        "traits": "Train.",
-        "back_text": "Engine Car is connected to the location to the left of it.\nYou cannot enter Engine Car unless all of the clues on the location to its left have been discovered."
+        "flavor": "Vom Lokomotivführer fehlt jede Spur. Du musst selbst herausbekommen, wie man die Lokomotive startet.",
+        "name": "Lokomotive",
+        "text": "Die Lokomotive ist mit dem Ort links von ihr verbunden.",
+        "traits": "Zug.",
+        "back_text": "Die Lokomotive ist mit dem Ort links von ihr verbunden.\nDu kannst die Lokomotive nicht betreten, bis alle Hinweise auf dem Ort links von ihr entdeckt worden sind."
     },
     {
         "code": "02176",
-        "flavor": "You see a foul beast atop the terrified train conductor, who cries out in panic!",
-        "name": "Engine Car",
-        "text": "Engine Car is connected to the location to the left of it.<b>\nForced</b> - After you reveal Engine Car: Search the encounter deck and discard pile for a Grappling Horror and draw it. Shuffle the encounter deck.",
-        "traits": "Train.",
-        "back_text": "Engine Car is connected to the location to the left of it.\nYou cannot enter Engine Car unless all of the clues on the location to its left have been discovered."
+        "flavor": "Du siehst eine bösartige Bestie über dem verängstigten Lokomotivführer aufragen, der panisch schreit!",
+        "name": "Lokomotive ",
+        "text": "Die Lokomotive ist mit dem Ort links von ihr verbunden.<b>\nErzwungen</b> - Nachdem du die Lokomotive enthüllt hast: Durchsuche das Begegnungsdeck und den Ablagestapel nach einem Packenden Schrecken und ziehe ihn.\nMische das Begegnungsgdeck.",
+        "traits": "Zug.",
+        "back_text": "Die Lokomotive ist mit dem Ort links von ihr verbunden.\nDu kannst die Lokomotive nicht betreten, bis alle Hinweise auf dem Ort links von ihr entdeckt worden sind."
     },
     {
         "code": "02177",
-        "flavor": "The slain body of the conductor is draped across the many control mechanisms of the engine car.",
-        "name": "Engine Car",
-        "text": "Engine Car is connected to the location to the left of it.\n<b>Forced</b> - After you reveal Engine Car: Draw the top 3 cards of the encounter deck.",
-        "traits": "Train.",
-        "back_text": "Engine Car is connected to the location to the left of it.\nYou cannot enter Engine Car unless all of the clues on the location to its left have been discovered."
+        "flavor": "Die Leiche des Lokomotivführers wurde über die vielen Kontrollinstrumente der Lokomotive drapiert.",
+        "name": "Lokomotive",
+        "text": "Die Lokomotive ist mit dem Ort links von ihr verbunden.\n<b>Erzwungen</b> - Nachdem du die Lokomotive enthüllt hast: Ziehe die obersten 3 Karten des Begegnungsdecks.",
+        "traits": "Zug.",
+        "back_text": "Die Lokomotive ist mit dem Ort links von ihr verbunden.\nDu kannst die Lokomotive nicht betreten, bis alle Hinweise auf dem Ort links von ihr entdeckt worden sind."
     },
     {
         "code": "02178",
-        "flavor": "What happened on the other side?",
-        "name": "Across Space and Time",
-        "text": "<b>Revelation</b> - Discard the top 3 cards of your deck.",
-        "traits": "Madness."
+        "flavor": "Was ist auf der anderen Seite passiert?",
+        "name": "Durch Raum und Zeit",
+        "text": "<b>Enthüllung</b> - Lege die obersten 3 Karten deines Decks ab.",
+        "traits": "Wahnsinn."
     },
     {
         "code": "02179",
-        "name": "Helpless Passenger",
-        "text": "Surge.\n<b>Revelation</b> - Put Helpless Passenger into play at the location to your left (or at your location if you cannot).\n[action]<b> Parley</b>. Take control of Helpless Passenger.\n<b>Forced</b> - If Helpless Passenger leaves play: Each investigator takes 1 horror.",
-        "traits": "Ally. Bystander."
+        "name": "Hilfloser Passagier",
+        "text": "Nachrüsten.\n<b>Enthüllung</b> - Bringe Hilfloser Passagier am Ort links von die (oder falls das nicht möglich ist, an deinem Ort) ins Spiel.\n[action]<b>Verhandlung</b>. Übernimm die Kontrolle über Hilfloser Passagier.\n<b>Erzwungen</b> - Falls Hilfloser Passagier das Spiel verlässt: Jeder Ermittler nimmt 1 Horror.",
+        "traits": "Verbündeter. Unbeteiligter."
     },
     {
         "code": "02180",
-        "name": "Claws of Steam",
-        "text": "<b>Revelation</b> - Test [willpower] (3). If you fail, take 2 damage and you cannot move from this location this round. Damage from this effect must be assigned to your assets first, if able.",
-        "traits": "Power."
+        "name": "Klauen aus Dampf",
+        "text": "<b>Enthüllung</b> - Lege eine [willpower]-Probe (3) ab. Falls die Probe misslingt, nimmst du 2 Schaden und kannst dich in dieser Runde nicht von diesem Ort bewegen. Schaden durch diesen Effekt muss falls möglich zuerst deinen Vorteilskarten zugewiesen werden.",
+        "traits": "Macht."
     },
     {
         "code": "02181",
-        "flavor": "Your train car begins to shake and shudder violently back and forth along the tracks, knocking you to the ground.",
-        "name": "Broken Rails",
-        "text": "<b>Revelation</b> - Each investigator at your location loses 1 action. Each investigator at your location with 4 or more damage must also discard an asset he or she controls.",
-        "traits": "Hazard."
+        "flavor": "Dein Zugabteil beginnt so heftig zu schwanken, und auf den Schienen zu zittern, dass du zu Boden geworfen wirst.",
+        "name": "Zerstörte Schienen",
+        "text": "<b>Enthüllung</b> - Jeder Ermittler an deinem Ort verliert 1 Aktion. Jeder Ermittler an deinem Ort mit 4 oder mehr Schaden muss außerdem eine Vorteilskarte ablegen, die er kontrolliert.",
+        "traits": "Gefahr."
     },
     {
         "code": "02182",
-        "name": "Grappling Horror",
-        "text": "Hunter.\nWhile you are engaged with Grappling Horror, you cannot move.",
-        "traits": "Monster. Abomination."
+        "name": "Packender Schrecken",
+        "text": "Jäger.\nSolange du mit Packender Schrecken in einem Kampf verwickelt bist, kannst du dich nicht bewegen.",
+        "traits": "Monster. Abscheulichkeit."
     },
     {
         "code": "02183",
-        "flavor": "The creature erupts from underneath one of the seats, growing ceaselessly in mass and volume, threatening to envelop the entire compartment.",
-        "name": "Emergent Monstrosity",
-        "text": "<b>Spawn</b> - The location to your right (or your location if there is no location to your right).\nEmergent Monstrosity enters play exhausted.",
-        "traits": "Monster. Abomination."
+        "flavor": "Das Wesen bricht unter einem Sitz hervor und wächst mit enormer Geschwindigkeit. Es droht, das gesamte Abteil zu füllen.",
+        "name": "Auftauchende Monstrosität.",
+        "text": "<b>Erscheinen</b> - Am Ort rechts von dir (oder an deinem Ort, falls es keinen Ort rechts von dir gibt).\nAuftauchende Monstrosität kommt erschöpft ins Spiel.",
+        "traits": "Monster. Abscheulichkeit."
     }
 ]

--- a/translations/de/pack/dwl/tmm.json
+++ b/translations/de/pack/dwl/tmm.json
@@ -1,83 +1,89 @@
 [
     {
         "code": "02105",
-        "name": "Emergency Aid",
-        "text": "Choose an investigator at your location. Heal 2 damage from that investigator or from an <i>Ally</i> asset he or she controls.",
-        "traits": "Insight. Science."
+        "name": "Soforthilfe",
+        "text": "Wähle einen Ermittler an deinem Ort. Heile 2 Schaden von diesem Ermittler oder von einer <i>Verbündeter</i>-Vorteilskarte, die er kontrolliert.",
+        "traits": "Erkenntnis. Wissenschaft."
     },
     {
         "code": "02106",
-        "name": "Brother Xavier",
-        "text": "You get +1 [willpower].\nBrother Xavier may be assigned damage and/or horror dealt to other investigators at your location.\nWhen Brother Xavier is defeated: Deal 2 damage to an enemy at your location.",
-        "traits": "Ally. ",
-        "slot": "Ally"
+        "name": "Bruder Xavier",
+        "text": "Du bekommst +1 [willpower].\nBruder Xavier darf Schaden und/oder Horror zugewiesen werden, der anderen Ermittlern an deinem Ort zugefügt worden ist.\nSobald Bruder Xavier besiegt ist: Füge einem Gegner an deinem Ort 2 Schaden zu.",
+        "traits": "Verbündeter.",
+        "slot": "Verbündeter"
     },
     {
         "code": "02107",
-        "name": "\"I've got a plan!\"",
-        "text": "<b>Fight</b>. This attack uses [intellect]. You deal +1 damage for this attack for each clue you have (max +3 damage).",
-        "traits": "Insight. Tactic."
+        "flavor": "Das ist der schlechteste Plan, den ich je gehört habe. Also, worauf warten wir noch?"
+        "name": "\"Ich habe einen Plan!\"",
+        "text": "<b>Kampf</b>. Dieser Angriff verwendet [intellect]. Du fügst für diesen Angriff +1 Schaden für jeden Hinweis zu, den du hast (maximal +3 Schaden).",
+        "traits": "Erkenntnis. Taktik."
     },
     {
         "code": "02108",
-        "name": "Pathfinder",
-        "text": "[free]During your turn, if you are not engaged with any enemies, exhaust Pathfinder: Move to a connecting location.",
+        "flavor": "Forscher, die hinter dem Grauen her sind, halten sich gerne in ungewöhnlichen fernen Gegenden auf.\nH.P. Lovecraft, \"Das Bild im Haus\""
+        "name": "Spurensucher",
+        "text": "[free] Falls du in deinem Zug nicht mit einem Gegner in einen Kampf verwickelt bist, erschöpfe Spurensucher: Bewege dich auf einen verbundenen Ort.",
         "traits": "Talent."
     },
     {
         "code": "02109",
-        "name": "Contraband",
-        "text": "Choose an asset controlled by an investigator at your location. Double the number of ammo or supply tokens on that asset.",
-        "traits": "Supply. Illicit."
+        "flavor": "Es ist vielleicht nicht legal, aber es hilft."
+        "name": "Schmuggelware",
+        "text": "Wähle eine Vorteilskarte, die ein Ermittler an deinem Ort kontrolliert. Verdopple die Anzahl an Munitions- oder Vorratsmarkern auf dieser Vorteilskarte.",
+        "traits": "Vorrat. Illegal."
     },
     {
         "code": "02110",
-        "name": "Adaptable",
-        "text": "Permanent.\nIn between each game of a campaign, you may swap up to two level 0 cards out of your deck in exchange for an equal number of level 0 cards. (You must still follow all deckbuilding rules for your investigator).",
+        "name": "Anpassungsfähig",
+        "text": "Dauerhaft.\nZwischen den Spielen einer Kampagne darfst du bis zu zwei Karten der Stufe 0 aus deinem Deck gegen dieselbe Anzahl anderer Karten der Stufe 0 austauschen. (Du musst dabei weiterhin alle Deckbauregeln für deinen Ermittler beachten.)",
         "traits": "Talent."
     },
     {
         "code": "02111",
-        "name": "Delve Too Deep",
-        "text": "In player order, each investigator draws 1 card from the top of the encounter deck. Then, add Delve Too Deep to the victory display.",
-        "traits": "Insight."
+        "name": "Zu tief graben",
+        "flavor": "Einige Dinge kann man, wenn man sie erst gesehen hat, nicht mehr ungesehen machen."
+        "text": "In Spielerreihenfolge zieht jeder Ermittler 1 Karte oben vom Begegnungsdeck. Füge dann Zu tief graben dem Siegpunktestapel hinzu.",
+        "traits": "Erkenntnis."
     },
     {
         "code": "02112",
-        "name": "Song of the Dead",
-        "text": "Uses (5 charges).\n[action]<b> </b>Spend 1 charge: <b>Fight. </b>This attack uses [willpower] instead of [combat]. You get +1 [willpower] for this attack. If a [skull] symbol is revealed during this attack, this attack deals +2 damage.",
-        "traits": "Spell. Song.",
-        "slot": "Arcane"
+        "name": "Lied der Toten",
+        "text": "Anwendungen (5 Ladungen).\n[action] Gib 1 Ladung aus: <b>Kampf.</b> Dieser Angriff verwendet [willpower] statt [combat]. Du bekommst für diesen Angriff +1 [willpower]. Falls während dieses Angriffs ein [skull]-Symbol enthüllt wird, fügt dieser Angriff +2 Schaden zu.",
+        "traits": "Zauber. Lied.",
+        "slot": "Arkan"
     },
     {
         "code": "02113",
-        "name": "Oops!",
-        "text": "Fast. Play after you fail a skill test by 2 or less while attacking an enemy engaged with you.\nDeal this attack's damage to a different enemy at your location.",
-        "traits": "Fortune."
+        "name": "Ups!",
+        "text": "Schnell. Spiele diese Karte, nachdem dir eine Fertigkeitsprobe um 2 oder weniger misslungen ist, solange du einen Gegner angreifst, der mit dir in einen Kampf verwickelt ist.\nFüge den Schaden dieses Angriffs einem anderen Gegner an deinem Ort zu.",
+        "traits": "Glücksfall."
     },
     {
         "code": "02114",
-        "name": "Fire Extinguisher",
-        "text": "[action]: <b>Fight</b>. You get +1 [combat] for this attack.\n[action] Exile Fire Extinguisher: <b>Evade</b>. You get +3 [agility] for this test. If you are successful, evade each other enemy engaged with you, as well.",
-        "traits": "Item. Tool. Melee.",
+        "name": "Feuerlöscher",
+        "text": "[action]: <b>Kampf.</b>. Du bekommst für diesen Angriff +1 [combat].\n[action] Schicke Feuerlöscher ins Exil: <b>Entkommen</b>. Du bekommst für diese Probe +3 [agility]. Falls die Probe gelingt, entkommst du auch jedem anderen Gegner, der mit dir in einen Kampf verwickelt ist.",
+        "traits": "Gegenstand. Werkzeug. Nahkampf.",
         "slot": "Hand"
     },
     {
         "code": "02115",
-        "name": "Flare",
-        "text": "Either (choose one):\n- <b>Fight</b>. You get +3 [combat] and deal +2 damage for this attack. Exile Flare.\n- Search the top 9 cards of any investigator's deck for an <i>Ally</i> asset and put it into play under your control. Then, exile Flare. Shuffle the searched deck.",
-        "traits": "Tactic."
+        "name": "Leuchtgeschoss",
+        "text": "(Wähle eins) entweder:\n- <b>Kampf.</b> Du bekommst für diesen Angriff +3 [combat] und fügst +2 Schaden zu. Schicke Leuchtgeschoss ins Exil.\n- Durchsuche die obersten 9 Karten des Decks eines beliebigen Ermittlers nach einer <i>Verbündeter</i>-Vorteilskarte und bringe sie unter deiner Kontrolle ins Spiel. Schicke dann Leuchtgeschoss ins Exil. Mische das durchsuchte Deck.",
+        "traits": "Taktik."
     },
     {
         "code": "02116",
-        "name": "Smoking Pipe",
-        "text": "Uses (3 supplies).\n[free]Spend 1 supply, exhaust Smoking Pipe, and take 1 damage: Heal 1 horror.",
-        "traits": "Item."
+        "flavor": "Eine gute Pfeife beruhigt auch die angespannsten Nerven."
+        "name": "Tabakpfeife",
+        "text": "Anwendungen (3 Vorräte).\n[free] Gib 1 Vorrat aus, erschöpfe Tabakpfeife und nimm 1 Schaden: Heile 1 Horror.",
+        "traits": "Gegenstand."
     },
     {
         "code": "02117",
-        "name": "Painkillers",
-        "text": "Uses (3 supplies).\n[free]Spend 1 supply, exhaust Painkillers, and take 1 horror: Heal 1 damage.",
-        "traits": "Item."
+        "flavor": "Die empfohlene Dosierung nicht überschreiten."
+        "name": "Schmerzmittel",
+        "text": "Anwendungen (3 Vorräte).\n[free] Gib 1 Vorrat aus, erschöpfe Schmerzmittel und nimm 1 Horror: Heile 1 Schaden.",
+        "traits": "Gegenstand."
     }
 ]

--- a/translations/de/pack/dwl/tmm_encounter.json
+++ b/translations/de/pack/dwl/tmm_encounter.json
@@ -1,225 +1,231 @@
 [
     {
         "code": "02118",
-        "name": "The Miskatonic Museum",
-        "text": "[skull]: -1 (-3 instead if Hunting Horror is at your location.)\n[cultist]: -1. If you fail, search the encounter deck, discard pile, and the void for Hunting Horror and spawn it at your location, if able.\n[tablet]: -2. Return 1 of your clues to your current location.\n[elder_thing]: -3. If you fail, discard an asset you control.",
-        "back_text": "[skull]: -2 (-4 instead if Hunting Horror is at your location.)\n[cultist]: -3. If you fail, search the encounter deck, discard pile, and the void for Hunting Horror and spawn it at your location, if able.\n[tablet]: -4. If Hunting Horror is at your location, it immediately attacks you.\n[elder_thing]: -5. If you fail, discard an asset you control."
+        "name": "Das Miskatonic-Museum",
+        "text": "<b>Einfach / Normal</b>\n[skull]: -1 (-3 stattdessen, falls sich Hetzender Schrecken an deinem Ort befindet.)\n[cultist]: -1. Falls die Probe misslingt, durchsuche das Begegnungsdeck, den Ablagestapel und die Leere nach Hetzender Schrecken, der falls möglich an deinem Ort erscheint.\n[tablet]: -2. Schicke 1 deiner Hinweise zurück auf deinen aktuellen Ort.\n[elder_thing]: -3. Falls die Probe misslingt, lege eine Vorteilskarte ab, die du kontrollierst.",
+        "back_text": "<b>Schwer / Experte</b>\n[skull]: -2 (-4 stattdessen, falls sich Hetzender Schrecken an deinem Ort befindet.)\n[cultist]: -3. Falls die Probe misslingt, durchsuche das Begegnungsdeck, den Ablagestapel und die Leere nach Hetzender Schrecken, der falls möglich an deinem Ort erscheint.\n[tablet]: -4. Falls sich Hetzender Schrecken an deinem Ort befindet, greift er dich sofort an.\n[elder_thing]: -5. Falls die Probe misslingt, lege eine Vorteilskarte ab, die du kontrollierst."
     },
     {
         "code": "02119",
-        "flavor": "Dr. Armitage has given the university’s Latin translation of The Necronomicon to his associate, Harold Walsted, the curator of the Miskatonic University Museum. Worried that someone might still be after the book, you have gone to the museum to recover it.",
-        "name": "Restricted Access",
-        "text": "<b>Forced</b> - When Hunting Horror enters play: Attach the set-aside copy of Shadow-spawned to it, or add 1 resource to Shadow-spawned if it is already attached.",
-        "back_flavor": "From the shadows of the museum halls, a terrible creature slithers forth, long and serpentine, and propelled by black leathery wings.",
-        "back_text": "If Hunting Horror is in play, add 1 doom to it.\nIf Hunting Horror is not in play, search the encounter deck, discard pile, and the void for Hunting Horror and spawn it in Museum Halls, if able. Shuffle the encounter discard pile into the encounter deck."
+        "flavor": "Dr. Armitage hat seinen Kollegen Harold Walsted, dem Kurator des Museums der Miskatonic Universität, die lateinische Übersetzung des Necronomicons gegeben. Weil du befürchtest, dass noch jemand hinter dem Buch her sein könnte, hast du dich auf den Weg gemacht, um es zurückzuholen.",
+        "name": "Eingeschränkter Zugang",
+        "text": "<b>Erzwungen</b> - Sobald Hetzender Schrecken ins Spiel kommt, hänge die beiseiteglegte Kopie von Brut der Schatten an ihn an oder füge Brut der Schatten 1 Ressource hinzu, falls sie bereits angehängt ist.",
+        "back_name": "Eine Kreatur aus der Leere",
+        "back_flavor": "Aus den Schatten der Museumshalle gleitet eine furchterregende Kreatur. Sie ist Lang und schlangenartig und hat schwarze, lederartige Flügel.",
+        "back_text": "Falls sich Hetzender Schrecken im Spiel befindet, füge ihm 1 Verderben hinzu.\nFalls sich Hetzender Schrecken nicht im Spiel befindet, durchsuche das Begegenungsdeck, den Ablagestapel und die Leere nach Hetzender Schrecken, der falls möglich in der Museumshalle erscheint. Mische den Begegnungs-Ablagestapel in des Begegnungsdeck."
     },
     {
         "code": "02120",
-        "flavor": "The shadows in the museum grow and become darker. As the shadows lengthen and shift, they begin to suggest the sinewy body of an uncanny creature darting at the periphery of your awareness...",
-        "name": "Shadows Deepen",
-        "text": "<b>Forced</b> - When Hunting Horror enters play: Attach the set-aside copy of Shadow-spawned to it, or add 1 resource to Shadow-spawned if it is already attached.",
-        "back_flavor": "The creature does not relent, pursuing you throughout the museum. ",
-        "back_text": "If Hunting Horror is in play, add 1 doom to it.\nIf Hunting Horror is not in play, search the encounter deck, discard pile, and the void for Hunting Horror and spawn it in Museum Halls, if able. Shuffle the encounter discard pile into the encounter deck."
+        "flavor": "Die Dunkelheit bereitet sich allmählich im Museum aus. In den länger werdenden und sich bewegenden Schatten nimmst du aus den Augenwinkeln etwas wahr, was du für den sehnigen Körper einer unheimlichen Kreatur hälst, die an dir vorbeischießt.",
+        "name": "Die Schatten werden dunkler",
+        "text": "<b>Erzwungen</b> - Sobald Hetzender Schrecken ins Spiel kommt, hänge die beiseitegelegte Kopie von Brut der Schatten an ihn an oder füge Brut der Schatten 1 Ressource hinzu, falls sie bereits angehängt ist.",
+        "back_name": "Zur Strecke gebracht",
+        "back_flavor": "Das Wesen gibt nicht auf und verfolgt dich durch das gesamte Museum.",
+        "back_text": "Falls sich Hetzender Schrecken im Spiel befindet, füge ihm 1 Verderben hinzu.\nFalls sich Hetzender Schrecken nicht im Spiel befindet, durchsuche das Begegenungsdeck, den Ablagestapel und die Leere nach Hetzender Schrecken, der falls möglich in der Museumshalle erscheint. Mische den Begegnungs-Ablagestapel in des Begegnungsdeck."
     },
     {
         "code": "02121",
-        "flavor": "The creature in the museum grows larger and more terrifying with each passing moment. Its body slithers from shadow to shadow, every corner of every room a potential hiding place for the hideous beast.",
-        "name": "In Every Shadow",
-        "text": "<b>Forced</b> - When Hunting Horror enters play: Attach the set-aside copy of Shadow-spawned to it, or add 1 resource to Shadow-spawned if it is already attached.",
-        "back_flavor": "With no way of defeating the creature in the museum, you flee. In every shadow of every corridor, the serpentine horror’s slithering body can be seen, the museum halls growing darker with the creature’s presence. As you reach the entrance, it blocks the doorway and attacks you with its terrible fangs. You barely manage to escape the building with your life, though the effects of the creature’s venom will scar you forever.",
-        "back_text": "Each investigator who has not resigned is defeated and suffers 1 physical trauma."
+        "flavor": "Das Wesen im Museum wird von Moment zu Moment größer und beängstigender. Sein Körper gleitet von Schatten zu Schatten, jede Ecke jedes Raumes ist ein mögliches Versteck für diese fürchterliche Bestie.",
+        "name": "In jedem Schatten",
+        "text": "<b>Erzwungen</b> - Sobald Hetzender Schrecken ins Spiel kommt, hänge die beiseitegelegte Kopie von Brut der Schatten an ihn an oder füge Brut der Schatten 1 Ressource hinzu, falls sie bereits angehängt ist.",
+        "back_name": "Herausgejagt",
+        "back_flavor": "Da du das Wesen im Muesum nicht besiegen kannst, fliehst du. In jedem Schatten jedes Flurs siehst du den fürchterlichen, schlangenartigen Körper des Schreckens, dessen Anwesenheit die Dunkelheit im Museum noch verstärkt. Als du den Eingang erreichst, versperrt er die Tür und greift dich mit seinen gewaltigen Fangzähnen an. Du schaffst es nur knapp, lebend aus dem Gebäude zu kommen. Die Wirkung des Gifts dieser Bestie aber wird dich für dein Leben zeichnen.",
+        "back_text": "Jeder Ermittler, der nicht aufgegeben hat, ist besiegt und erleidet 1 körperliches Trauma."
     },
     {
         "code": "02122",
-        "flavor": "Unfortunately, the entrance to the Museum is kept locked at this late hour. A security guard is visible through the building’s front windows, oblivious to his surroundings. Perhaps you can find a way to get his attention and convince him to let you in.",
-        "name": "Finding A Way Inside",
-        "back_flavor": "Unfortunately, the entrance to the Museum is kept locked at this late hour. A security guard is visible through the building’s front windows, oblivious to his surroundings. Perhaps you can find a way to get his attention and convince him to let you in.",
-        "back_text": "<b>If you spent clues to advance:\n</b><blockquote><i>You find the window nearest to the guard and tap it loud enough to get his attention. He gives a startled jump, then shifts open the window. “What do you want?” he asks timidly. You explain the situation to him and tell him he is in grave danger. He warily opens the front door to the Museum, shaking his head. “I wasn’t even supposed to be here today...”</i></blockquote>Choose an investigator to take control of the set-aside Adam Lynch asset. Reveal the Museum Halls. Advance to Act 2a - \"Night at the Museum.\"\n<hr><b>If you successfully performed the [action] ability on the Museum Halls to advance:\n</b><blockquote><i>With great strength, you break down the door to the Museum, making considerable noise as you do. The security guard sees you enter, cries out in fear, and rushes toward the back of the museum.</i></blockquote>The door leading into the Museum Halls is broken. Reveal the Museum Halls. Advance to Act 2a - \"Breaking and Entering.\""
+        "flavor": "Leider ist der Eingang des Museums zu so später Stunde verschlossen. Durch die Fenster an der Vorderfront ist ein Sicherheitsposten zu sehen, der seine Umgebung nicht wahrzunehmen scheint. Vielleicht kannst du seine Aufmerksamkeit erregen und ihn davon überzeugen, dich ins Gebäude zu lassen.",
+        "name": "Finde einen Weg hinein",
+        "back_name": "Einen Eingang finden",
+        "back_text": "<b>Falls die Ermittler Hinweise ausgegeben haben, um vorzurücken:\n</b><blockquote><i>Du findest das Fenster, das der Wache am nächsten ist, und klopfst laut gegen die Scheibe, um seine Aufmerksamkeit zu erregen. Er springt erschrocken auf und öffnet dann das Fenster. “Was wollen Sie?”, fragt er zaghaft. Du erklärst ihm, was los ist und dass er sich in großer Gefahr befindet. Zögernd öffnet er die Vordertür des Museums und schüttelt den Kopf. “Ich sollte heute nicht einmal hier sein...”</i></blockquote>Wähle einen Ermittler, der die Kontrolle über die beiseitegelegte Vorteilskarte Adam Lynch übernimmt. Enthülle die Museumshalle. Rücke zu Szene 2a - \"Nachts im Museum\" vor.\n<hr><b>Falls die Ermittler erfolgreich die [action]-Fähigkeit auf der Museumshalle durfgeführt haben, um vurzurücken:\n</b><blockquote><i>Mit aller Kraft schlägst du af die Tür des Museums ein und verursachst damit ziemlichen Lärm. Der Sicherheitsposten sieht dich hineinkommen, schreit vor Angst auf und eilt in den hinteren Teil des Museums.</i></blockquote>Die Tür, die in die Museumshalle führt, ist zerstört. Enthülle die Museumshalle. Rücke zu Szene 2a - \"Einbruch\" vor."
     },
     {
         "code": "02123",
-        "flavor": "The Necronomicon is being kept in a Restricted Hall somewhere in the museum. Adam barely knows his way around, and gives a startled jump at every creak of the old building. \"I just started here last week,\" he explains. \"What sort of trouble did you say was going on?\" You haven’t the heart to give him the full story.",
-        "name": "Night at the Museum",
-        "text": "<b>Objective</b> - If an investigator enters the Exhibit Hall (<i>Restricted Hall</i>), advance.",
-        "back_flavor": "When you enter the restricted hall, you find the curator of the museum lying in a pool of blood, his intestines strewn about in a grotesque display. Your stomach turns over and you resist the urge to vomit. Whatever did this, it’s still nearby...",
-        "back_text": "Search the encounter deck, discard pile, the void, and all play areas for Hunting Horror, and place it in the Exhibit Hall (<i>Restricted Hall</i>), ready.\nAdvance to Act 3a."
+        "flavor": "Das Necronomicon wird in einer für Besucher geschlossenen Halle irgendwo im Museum aufbewahrt. Adam kennt sich hir kaum aus und zuckt bei jedem Knarren im Gebälk des alten Gebäudes zusammen. \"Ich habe erst letzte Woche hier angefangen,\" erklärt er. \"Was haben Sie gesagt, was für Probleme es gibt?\" Du bringst es nicht übers Herz, ihm die ganze Geschichte zu erzählen.",
+        "name": "Nacht im Museum",
+        "text": "<b>Ermittlungsziel</b> - Falls ein Ermittler die Ausstellungshalle (<i>Für Besucher geschlossen</i>) betritt, rücke vor.",
+        "back_name": "Das Schicksal des Kurators",
+        "back_flavor": "Als du in die für Besucher geschlossene Halle kommst, findest du den Kurator des Museums in einer Blutlache liegend vor, seine Eingeweide sind auf groteske Weise um ihn herum drapiert. Dein Magen dreht sich um und du schaffst es nur mit Mühe, dich nicht zu übergeben. Was auch immer das verursacht hat, es muss sich noch in der Nähe befinden...",
+        "back_text": "Durchsuche das Begegnungsdeck, den Ablagestapel, die Leere und alle Spielzonen nach Hetzender Schrecken und platziere ihn spielbereit in der Ausstellungshalle (<i>Für Besucher geschlossen</i>).\nRücke zu Szene 3a vor."
     },
     {
         "code": "02124",
-        "flavor": "The Necronomicon is being kept in a Restricted Hall somewhere in the museum.",
-        "name": "Breaking and Entering",
-        "text": "<b>Objective</b> - If an investigator enters the Exhibit Hall (<i>Restricted Hall</i>), advance.",
-        "back_flavor": "When you enter the Restricted Hall, you find the curator of the museum clutching an ornate statue as if it were a club, his suit stained with blood, a panicked expression on his face. The security guard you saw earlier lies in a pool of blood nearby, his intestines strewn about in a grotesque display. Your stomach turns and you resist the urge to vomit. \"I tried to stop it, but...\" the curator says quietly, his voice quivering. Whatever did this, it’s still nearby...",
-        "back_text": "Choose an investigator to take control of the set-aside Harold Walsted asset. \nSearch the encounter deck, discard pile, the void, and all play areas for Hunting Horror, and place it in the Exhibit Hall (<i>Restricted Hall</i>), ready.\nAdvance to Act 3a."
+        "flavor": "Das Necronomicon wird in einer für Besucher geschlossenen Halle irgendwo im Museum aufbewahrt.",
+        "name": "Einbruch",
+        "text": "<b>Ermittlungsziel</b> - Falls ein Ermittler die Ausstellungshalle (<i>Für Besucher geschlossen</i>) betritt, rücke vor.",
+        "back_name": "Das Schicksal der Wache",
+        "back_flavor": "Als du die für Besucher geschlossene Halle betrittst, findest du den Kurator des Museums, der eine verzierte Statue wie eine Keule in der Hand hält. Sein Anzug ist blutbefleckt und sein Gesicht angstverzerrt. Der Wachposten, den du vorhin schon gesehen hast, liegt in einer Blutlache auf dem Boden, seine Eingeweide sind auf groteske Art um ihn drapiert. Dein Magen dreht sich um und du schaffst es nur mit Mühe, dich nicht zu übergeben. \"Ich habe versucht, es aufzuhalten, aber...\", sagt der Kurator mit zitternder, leiser Stimme. Was auch immer das verursacht hat, es muss sich noch in der Nähe befinden...",
+        "back_text": "Wähle einen Ermittler, der die Kontrolle über die beiseitegelegte Vorteilskarte Harold Walsted übernimmt. \nDurchsuche das Begegnungsdeck, den Ablagestapel, die Leere und alle Spielzonen nach Hetzender Schrecken und platziere ihn spielbereit in der Ausstellungshalle (<i>Für Besucher geschlossen</i>).\nRücke zu Szene 3a vor."
     },
     {
         "code": "02125",
-        "flavor": "Somewhere in this area is Olaus Wormius’s Latin translation of the Necronomicon. You must find it and escape while you can!",
-        "name": "Searching for the Tome",
-        "text": "<b>Objective</b> - If there are no clues remaining in the Exhibit Hall , advance.",
-        "back_flavor": "At last, you find the locked case containing the Necronomicon./nThe tome, over eight hundred pages in length, is filled with all manner of macabre imagery, formulae, spells, prophecies, and descriptions of creatures from beyond the threshold of space./nWithout a doubt, it is a dangerous book... But its secrets could be very useful.",
-        "back_text": "The investigators must decide (choose one):\n- It's too dangerous to keep around. We must destroy it. <b>(→R1)</b>\n- It's too valuable to destroy. We must keep it safe.<b>(→R2)</b>"
+        "flavor": "Irgendwo hier muss sich die lateinische Übersetzung des Necronomicons von Olaus Wormius befinden. Du musst sie finden und entkommen, solange das noch möglich ist!",
+        "name": "Auf der Suche nach dem Buch",
+        "text": "<b>Ermittlungsziel</b> - Falls sich keine Hinweise mehr auf der Ausstellungshalle (<i>Für Besucher geschlossen</i>) befinden, rücke vor.",
+        "back_name": "Das Necronomicon",
+        "back_flavor": "Endlich findest du den verschlossenen Koffer, in dem sich das Necronomicon befindet./nDas über achthundert Seiten umfassende Buch enthält jede Menge makabre Bilder, Formeln, Zaubersprüche, Prophezeihungen und Beschreibungen von Wesen, die aus einer Welt außerhalb unserer Realität stammen./nZweifellos handelt es sich um ein gefährliches Buch... Aber seine Geheimnisse könnten sehr hilfreich sein.",
+        "back_text": "Die Ermittler müssen entscheiden (wähle eins):\n- Es ist zu gefährlich, um es bei sich zu tragen. Wir müssen es zerstören. <b>(→A1)</b>\n- Es ist zu wertvoll, um es zu zerstören. Wir müssen es schützen.<b>(→A2)</b>"
     },
     {
         "code": "02126",
-        "flavor": "As you approach the museum, you draw your coat tighter around your body to keep the wintry air away. The full moon drapes the building in ominous bright moonlight.",
-        "name": "Museum Entrance",
-        "text": "Investigators at the Museum Entrance cannot gain resources.\n[action] <b>Resign</b>. \"Eh. How important can a book really be, anyway?\"",
+        "flavor": "Als du dem Museum näher kommst, ziehst du deinen Mantel als Schutz gegen die Winterluft enger um dich. Der Vollmond tauchst das Gebäude in ein unheilvolles Licht.",
+        "name": "Museumseingang",
+        "text": "Ermittler auf dem Museumseingang können keine Ressourcen erhalten.\n[action] <b>Aufgeben</b>. \"Hmm. Wie wichtig kann so ein Buch überhaupt sein?\"",
         "traits": "Miskatonic.",
-        "back_flavor": "The Miskatonic Museum is an opulent and stately building, supported by expeditions funded by the university. Its sizable collection of exotic artifacts, curios, and art has drawn visitors from all over the country."
+        "back_flavor": "Das Miskatonic-Museum ist ein gewaltiges und imposantes Gebäude, in dem die Gegenstände, die auf von der Universität bezahlten Forschungsreisen gefunden wurden, ausgestellt werden. Diese gewaltige Sammlung exotischer Artefakte, Kuriositäten und Kunstwerke hat schon Besucher aus dem gesamten Land angezogen."
     },
     {
         "code": "02127",
-        "name": "Museum Halls",
-        "text": "Museum Halls is connected to each copy of Exhibit Hall.\n[action] Investigators in the Museum Halls spend 1 [per_investigator] clues, as a group: Put the top card of the Exhibit deck into play, unrevealed.",
+        "name": "Museumshalle",
+        "text": "Die Museumshalle ist mit jeder Kopie der Ausstellungshalle verbunden.\n[action] Die Ermittler in der Museumshalle geben als Gruppe 1 [per_investigator] Hinweise aus: Bringe die oberste Karte des Ausstellungsdeck verhüllt ins Spiel.",
         "traits": "Miskatonic.",
-        "back_text": "The entrance to the Museum Halls is locked. You cannot move into the Museum Halls.\nMuseum Entrance gains: \"[action]: Test [combat] (5) to attempt to break down the door to the Museum. If you are successful, immediately advance to Act 1b.\""
+        "back_text": "Der Eingang zur Museumshalle ist verschlossen. Du kannst dich nicht in die Museumshalle bewegen.\nDer Museumseingang erhält: \"[action]: Lege eine [combat]-Probe (5) ab, um die Tür zum Museum aufzubrechen. Falls die Probe gelingt, rücke sofort zu Szene 1b vor.\""
     },
     {
         "code": "02128",
-        "flavor": "Somebody must have left the security office in a hurry. Blood stains the floor under the desk nearby. Thankfully, there are some useful supplies here you may be able to use.",
-        "name": "Security Office",
-        "text": "[action] [action]: Search the top 6 cards of your deck for a card and add it to your hand. Shuffle the rest back into your deck. (Limit once per turn.)",
+        "flavor": "Jemand muss das Büro des Sicherheitsdienstes überstürzt verlassen haben. Unter dem Tisch neben dir findest du Blutflecken auf dem Boden. Glücklicherweise findest du hier einige Gegenstände, die du gebrauchen kannst.",
+        "name": "Büro des Sicherheitsdienstes",
+        "text": "[action] [action]: Durchsuche die obersten 6 Karten deines Decks nach einer Karte und füge sie deiner Hand hinzu. Mische die übrigen Karten zurück in dein Deck. (Nur einmal pro Zug.)",
         "traits": "Miskatonic.",
-        "back_flavor": "A plaque next to this doorway reads: \"Security.\" The door is ajar, and inside you catch the scent of blood."
+        "back_flavor": "Auf dem Schild neben dieser Tür steht: \"Sicherheitsdienst.\" Sie ist nur angelehnt und im Büro selbst nimmst du den Geruch von Blut wahr."
     },
     {
         "code": "02129",
-        "flavor": "Somebody must have left the security office in a hurry. Blood stains the floor under the desk nearby. There are some maps of the Museum in here, as well.",
-        "name": "Security Office",
-        "text": "[action] [action]: Look at the revealed side of an Exhibit Hall in play, or the top card of the Exhibit deck. (Limit once per turn.)",
+        "flavor": "Jemand muss das Büro des Sicherheitsdienstes überstürzt verlassen haben. Unter dem Tisch neben dir findest du Blutflecken auf dem Boden. In diesem Raum befinden sich auch einige Karten des Museums.",
+        "name": "Büro des Sicherheitsdienstes",
+        "text": "[action] [action]: Sieh dir die enthüllte Seite einer Ausstellungshalle im Spiel oder die oberste Karte des Ausstellungsdecks an. (Nur einmal pro Zug.)",
         "traits": "Miskatonic.",
-        "back_flavor": "A plaque next to this doorway reads: \"Security.\" The door is ajar, and inside you catch the scent of blood."
+        "back_flavor": "Auf dem Schild neben dieser Tür steht: \"Sicherheitsdienst.\" Sie ist nur angelehnt und im Büro selbst nimmst du den Geruch von Blut wahr."
     },
     {
         "code": "02130",
-        "flavor": "This office is meticulously organized, from the books in alphabetical order on the shelves to the stacks of forms organized by category on each desk. A coat is draped over one of the nearby chairs; perhaps somebody other than the security guard is still here at this late hour.",
-        "name": "Administration Office",
-        "text": "You cannot investigate Administration Office while you have 4 or fewer resources.",
+        "flavor": "Dieses Büro ist gewissenhaft organisiert, die Bücher im Regal sind alphabetisch sortiert, die Antragsformulare auf den Schreibtischen sorgfältig nach Kategorie abgelegt. Ein Mantel hängt über einem der Stühle in der Nähe; vielleicht ist außer dem Sicherheitsposten noch jemand so spät im Gebäude.",
+        "name": "Verwaltungsbüro",
+        "text": "Du kannst nicht im Verwaltungsbüro ermitteln, solange du 4 oder weniger Ressourcen hast.",
         "traits": "Miskatonic.",
-        "back_flavor": "A sturdy wooden door with a plaque next to it reads: \"Administration.\" In the hall outside the doorway, you see a row of paintings depicting the museum’s many curators through the years, each adorned with their name and years of employment. Perhaps it’s just your imagination, but they look more distressed in recent years."
+        "back_flavor": "Auf dem Schild neben der schweren Holztür steht: \"Verwaltung.\" Im Flur vor der Tür siehst du eine Reihe von Gemälden, welche die vielen Kuratoren zeigen, die das Museum im Laufe der Jahre geleitet haben, jeweils versehen mit ihrem Namen und ihrer Amtszeit. Vielleicht kommt es dir nur so vor, aber die Kuratoren der letzten Jahre sehen deutlich angespannter aus."
     },
     {
         "code": "02131",
-        "flavor": "This office is meticulously organized, from the books in alphabetical order on the shelves to the stacks of forms organized by category on each desk. A coat is draped over one of the nearby chairs; perhaps somebody other than the security guard is still here at this late hour.",
-        "name": "Administration Office",
-        "text": "You cannot investigate Administration Office while you have 4 or fewer cards in your hand.",
+        "flavor": "Dieses Büro ist gewissenhaft organisiert, die Bücher im Regal sind alphabetisch sortiert, die Antragsformulare auf den Schreibtischen sorgfältig nach Kategorie abgelegt. Ein Mantel hängt über einem der Stühle in der Nähe; vielleicht ist außer dem Sicherheitsposten noch jemand so spät im Gebäude.",
+        "name": "Verwaltungsbüro",
+        "text": "Du kannst nicht im Verwaltungsbüro ermitteln, solange du 4 oder weniger Karten aud der Hand hast.",
         "traits": "Miskatonic.",
-        "back_flavor": "A sturdy wooden door with a plaque next to it reads: \"Administration.\" In the hall outside the doorway, you see a row of paintings depicting the museum’s many curators through the years, each adorned with their name and years of employment. Perhaps it’s just your imagination, but they look more distressed in recent years."
+        "back_flavor": "Auf dem Schild neben der schweren Holztür steht: \"Verwaltung.\" Im Flur vor der Tür siehst du eine Reihe von Gemälden, welche die vielen Kuratoren zeigen, die das Museum im Laufe der Jahre geleitet haben, jeweils versehen mit ihrem Namen und ihrer Amtszeit. Vielleicht kommt es dir nur so vor, aber die Kuratoren der letzten Jahre sehen deutlich angespannter aus."
     },
     {
         "code": "02132",
-        "flavor": "A strange chill fills this hall, as if the climate of Alaskan wilderness has traveled along with the artifacts on display.",
-        "name": "Exhibit Hall",
+        "flavor": "Eine seltsame Kälte erfüllt die Halle, beinahe, als wäre das Klima der Wildnis Alaskas mit den ausgestelten Artefakten hier angekommen.",
+        "name": "Ausstellungshalle",
         "subname": "Athabaskan Exhibit",
-        "text": "<b>Forced</b> - After you enter this location: Lose all of your remaining actions and immediately end your turn.\nWhile you are in this location, you get +2 [agility].",
-        "traits": "Miskatonic. Exhibit.",
-        "back_flavor": "What alluring artifacts are displayed inside?\nDo they, too, hold a sinister secret?"
+        "text": "<b>Erzwungen</b> - Nachdem du diesen Ort betreten hast: Du verlierst alle verbliebenen Aktionen und beendest sofort deinen Zug.\nSolange du dich an diesem Ort befindest, bekommst du +2 [agility].",
+        "traits": "Miskatonic. Ausstellung.",
+        "back_flavor": "Was für faszinierende Ausstellungsstücke befinden sich wohl in dieser Halle?\nHaben auch sie ein finsteres Geheimnis?"
     },
     {
         "code": "02133",
-        "flavor": "Who would immortalize such a terrible fate?",
-        "name": "Exhibit Hall",
-        "subname": "Medusa Exhibit",
-        "text": "<b>Forced</b> - After you fail a skill test while investigating this location: Discard an asset you control.",
-        "traits": "Miskatonic. Exhibit.",
-        "back_flavor": "What alluring artifacts are displayed inside?\nDo they, too, hold a sinister secret?"
+        "flavor": "Wer würde solch ein fürchterliches Schicksal für die Nachwelt erhalten?",
+        "name": "Ausstellungshalle",
+        "subname": "Medusa-Ausstellung",
+        "text": "<b>Erzwungen</b> - Nachdem dir eine Probe misslungen ist, solange du an diesem Ort ermittelst: Lege eine Vorteilskarte ab, die du kontrollierst.",
+        "traits": "Miskatonic. Ausstellung.",
+        "back_flavor": "Was für faszinierende Ausstellungsstücke befinden sich wohl in dieser Halle?\nHaben auch sie ein finsteres Geheimnis?"
     },
     {
         "code": "02134",
-        "flavor": "Nothing about this exhibit is natural.",
-        "name": "Exhibit Hall",
-        "subname": "Nature Exhibit",
-        "text": "<b>Forced</b> - After you enter this location: Discard 2 cards from your hand at random.",
-        "traits": "Miskatonic. Exhibit.",
-        "back_flavor": "What alluring artifacts are displayed inside?\nDo they, too, hold a sinister secret?"
+        "flavor": "Nichts in dieser Ausstellung ist natürlich.",
+        "name": "Ausstellungshalle",
+        "subname": "Naturausstellung",
+        "text": "<b>Erzwungen</b> - Nachdem du diesen Ort betreten hast: Lege 2 zufällige Karten von deiner Hand ab.",
+        "traits": "Miskatonic. Ausstellung.",
+        "back_flavor": "Was für faszinierende Ausstellungsstücke befinden sich wohl in dieser Halle?\nHaben auch sie ein finsteres Geheimnis?"
     },
     {
         "code": "02135",
-        "flavor": "Sandstone sculptures and bejeweled artifacts from another era clutter this exhibit, like the tomb of an ancient pharoah.",
-        "name": "Exhibit Hall",
-        "subname": "Egyptian Exhibit",
-        "text": "<b>Forced</b> - After you fail a skill test while investigating this location: Lose 1 action.",
-        "traits": "Miskatonic. Exhibit.",
-        "back_flavor": "What alluring artifacts are displayed inside?\nDo they, too, hold a sinister secret?"
+        "flavor": "Sandsteinskulpturen und mit Juwelen verzierte Artefakte aus einer anderen Zeit lassen die Ausstellung in dieser Halle wie das Grabmal des Pharaos wirken.",
+        "name": "Ausstellungshalle",
+        "subname": "Ägypthische-Ausstellung",
+        "text": "<b>Erzwungen</b> - Nachdem dir eine Probe misslungen ist, solange du an diesem Ort ermittelst: Du verlierst 1 Aktion.",
+        "traits": "Miskatonic. Ausstellung.",
+        "back_flavor": "Was für faszinierende Ausstellungsstücke befinden sich wohl in dieser Halle?\nHaben auch sie ein finsteres Geheimnis?"
     },
     {
         "code": "02136",
-        "flavor": "I need no reminder of my mortality.\nI know my death is imminent.",
-        "name": "Exhibit Hall",
-        "subname": "Hall of the Dead",
-        "text": "<b>Forced</b> - After you fail a skill test while investigating this location: Take 1 horror.",
-        "traits": "Miskatonic. Exhibit.",
-        "back_flavor": "What alluring artifacts are displayed inside?\nDo they, too, hold a sinister secret?"
+        "flavor": "Ich brauche keine Erinnerung an meine Sterblichkeit.\nIch weiß, dass mein Tod kurz bevorsteht.",
+        "name": "Ausstellungshalle",
+        "subname": "Halle der Toten",
+        "text": "<b>Erzwungen</b> - Nachdem dir eine Probe misslungen ist, solange du an diesem Ort ermittelst: Nimm 1 Horror.",
+        "traits": "Miskatonic. Ausstellung.",
+        "back_flavor": "Was für faszinierende Ausstellungsstücke befinden sich wohl in dieser Halle?\nHaben auch sie ein finsteres Geheimnis?"
     },
     {
         "code": "02137",
-        "flavor": "Exhibit Not Yet Open For Viewing.",
-        "name": "Exhibit Hall",
-        "subname": "Restricted Hall",
-        "text": "While Hunting Horror is at this location, this location cannot be investigated.",
-        "traits": "Miskatonic. Exhibit.",
-        "back_flavor": "What alluring artifacts are displayed inside?\nDo they, too, hold a sinister secret?"
+        "flavor": "Die Ausstellung ist noch nicht eröffnet.",
+        "name": "Ausstellungshalle",
+        "subname": "Für Besucher geschlossen",
+        "text": "Solange sich Hetzender Schrecken an diesem Ort befindet, kann an diesem Ort nicht ermittelt werden.",
+        "traits": "Miskatonic. Ausstellung.",
+        "back_flavor": "Was für faszinierende Ausstellungsstücke befinden sich wohl in dieser Halle?\nHaben auch sie ein finsteres Geheimnis?"
     },
     {
         "code": "02138",
         "name": "Harold Walsted",
-        "subname": "Curator of the Museum",
-        "text": "You get +2 [intellect] while investigating <i>Miskatonic</i> locations.\n<b>Forced</b> - When Harold Walsted leaves play: Remove him from the game and add 1 [tablet] token to the chaos bag for the remainder of the campaign.",
-        "traits": "Ally. Miskatonic."
+        "subname": "Kurator des Museums",
+        "text": "Du bekommst +2 [intellect], solange du an <i>Miskatonic</i>-Orten ermittelst.\n<b>Erzwungen</b> - Sobald Harold Walsted das Spiel verlässt: Entferne ihn aus dem Spiel und füge dem Chaosbeutel für den Rest der Kampagne 1 [tablet]-Marker hinzu.",
+        "traits": "Verbündeter. Miskatonic."
     },
     {
         "code": "02139",
         "name": "Adam Lynch",
-        "subname": "Museum Security",
-        "text": "While you control Adam Lynch, treat the \"[action] [action]\" ability on the Security Office as if it were an \"[action]\" ability.\n<b>Forced</b> - When Adam Lynch leaves play: Remove him from the game and add 1 [tablet] token to the chaos bag for the remainder of the campaign.",
-        "traits": "Ally. Miskatonic."
+        "subname": "Sicherheitsdienst des Museums",
+        "text": "Solange du Adam Lynch kontrollierst, behandle die \"[action] [action]\"-Fähigkeit auf dem Sicherheitsbüro, als ob sie eine \"[action]\"-Fähigkeit wäre.\n<b>Erzwungen</b> - Sobald Adam Lynch das Spiel verlässt: Entferne ihn aus dem Spiel und füge dem Chaosbeutel für den Rest der Kampagne 1 [tablet]-Marker hinzu.",
+        "traits": "Verbündeter. Miskatonic."
     },
     {
         "code": "02140",
-        "flavor": "It was Abdul Alhazred’s magnum opus.",
-        "name": "The Necronomicon",
-        "subname": "Olaus Wormius Translation",
-        "text": "You get +1 [intellect].\n[action]: Gain 2 resources.",
-        "traits": "Item. Tome.",
+        "flavor": "Es war das Hauptwerk von Abdul Alhazred.",
+        "name": "Das Necronomicon",
+        "subname": "Übersetzung von Olaus Wormius",
+        "text": "Du bekommst +1 [intellect].\n[action]: Du erhältst 2 Ressourcen.",
+        "traits": "Gegenstand. Buch.",
         "slot": "Hand"
     },
     {
         "code": "02141",
-        "name": "Hunting Horror",
-        "subname": "Spawned from the Void",
-        "text": "Hunter. Retaliate.\n<b>Forced</b> - At the start of the enemy phase: Reveal a random token from the chaos bag. If the revealed token has a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, ready Hunting Horror.\n<b>Forced</b> - When Hunting Horror leaves play, place it in the void.",
+        "name": "Hetzender Schrecken",
+        "subname": "Aus der Leere erschienen",
+        "text": "Jäger. Zurückschlagen.\n<b>Erzwungen</b> - Zu Beginn der Gegenerphase: Enthülle einen zufälligen Marker aus dem Chaosbeutel. Falls der enthüllte Marker ein [skull], [cultist], [tablet], [elder_thing], oder [auto-fail]-Symbol hat, mache Hetzender Schrecken spielbereit.\n<b>Erzwungen</b> - Sobald Hetzender Schrecken das Spiel verlässt, platziere ihn in die Leere.",
         "traits": "Monster. Elite."
     },
     {
         "code": "02142",
-        "name": "Shadow-spawned",
-        "text": "Shadow-spawned remains attached to Hunting Horror if it enters the void.\nHunting Horror gets +1 fight, +1 health, and +1 evade for each resource on Shadow-spawned. If there are 3 resources on Shadow-spawned, Hunting Horror also gains Massive.",
-        "traits": "Power."
+        "name": "Brut der Schatten",
+        "text": "Brut der Schatten bleibt an Hetzender Schrecken angehängt, falls dieser die Leere betritt.\nHetzender Schrecken bekommet +1 Kampf, +1 Ausdauer und +1 Entkommen für jede Ressource auf Brut der Schatten. Falls sich mindestens 3 Ressourcen auf Brut der Schatten befinden, erhält Hetzender Schrecken außerdem Gewaltig.",
+        "traits": "Macht."
     },
     {
         "code": "02143",
-        "flavor": "...viperine creatures, which had curiously distorted heads, and grotesquely great clawed appendages...\n–H.P. Lovecraft & August Derleth, The Lurker at the Threshold",
-        "name": "Stalked in the Dark",
-        "text": "<b>Revelation</b> - If Hunting Horror is in play, it readies, engages you, and attacks each investigator at your location. Otherwise, Stalked in the Dark gains surge.",
-        "traits": "Tactic."
+        "flavor": "...vipernartige Wesen, die merkwürdige deformierte Köpfe und Klauenfüße von grotesker Größe hatten...\n–H.P. Lovecraft & August Derleth, Das Tor des Verderbens",
+        "name": "Im Dunkeln verfolgt",
+        "text": "<b>Enthüllung</b> - Falls sich Hetzender Schrecken im Spiel befindet, wird er spielbereit gemacht, verwickelt dich in einen Kampf und greift jeden Ermittler an deinem Ort an. Ansonsten erhält Im Dunkeln verfolgt Nachrüsten.",
+        "traits": "Taktik."
     },
     {
         "code": "02144",
-        "name": "Passage into the Veil",
-        "text": "<b>Revelation</b> - Test [willpower] (3). This test has +2 difficulty if Hunting Horror is at your location. If you fail you must either (choose one): discard the top 5 cards of your deck, or take 1 direct damage and deal 1 damage to each of your <i><b>Ally</b></i> assets.",
-        "traits": "Power."
+        "name": "Weg hinter den Schleier",
+        "text": "<b>Enthüllung</b> - Lege eine [willpower]-Probe (3) ab. TDie Probe hat eine Schwierigkeit von +2, falls sich Hetzender Schrecken an deinem Ort befindet. Falls die Probe misslingt, musst du entweder (wähle ein): Lege die obersten 5 Karten deines Decks ab oder nimm 1 direkten Schaden und füge jedem deiner <i><b>Verbündeter</b></i>-Vorteilskarten 1 Schaden zu.",
+        "traits": "Macht."
     },
     {
         "code": "02145",
-        "flavor": "Are you watching the exhibits, or are the exhibits watching you?",
-        "name": "Ephemeral Exhibits",
-        "text": "<b>Revelation</b> - Test [intellect] (3). If you fail, lose 1 action for each point you failed by.",
-        "traits": "Terror."
+        "flavor": "Betrachtest du die Exponate oder betrachten sie dich?",
+        "name": "Vergängliche Exponate",
+        "text": "<b>Enthüllung</b> - Lege eine [intellect]-Probe (3) abe. Falls die Probe misslingt, verlierst du 1 Aktion für jeden Punkt, um den sie misslingt.",
+        "traits": "Schrecken."
     },
     {
         "code": "02146",
-        "name": "Slithering Behind You",
-        "text": "<b>Revelation</b> - If Hunting Horror is in play, add 1 doom to it. If Hunting Horror is not in play, search the encounter deck, discard pile, and the void for Hunting Horror and spawn it at your location, engaged with you. Shuffle the encounter deck."
+        "name": "Es schlängelt sich hinter dir",
+        "text": "<b>Enthüllung</b> - Falls sich Hetzender Schrecken im Spiel befindet, füge ihm 1 Verderben hinzu. Falls sich Hetzender Schrecken nicht im Spiel befindet, durchsuche das Begegnungsdeck, den Ablagestapel und die Leere nach Hetzender Schrecken, der mit dir in einen Kampf verwickelt an deinem Ort erscheint. Mische das Begegenungsdeck."
     }
 ]

--- a/translations/de/pack/dwl/uau.json
+++ b/translations/de/pack/dwl/uau.json
@@ -1,75 +1,75 @@
 [
     {
         "code": "02225",
-        "flavor": "The creature’s corpse lays motionless at your feet.\nIt’s a small comfort, but you’ll take it.",
-        "name": "\"If it bleeds...\"",
-        "text": "Fast. Play after you defeat a <i>Monster</i> enemy.\nEach investigator at your location heals horror equal to that enemy's horror value."
+        "flavor": "Es ist nur ein schwacher Trost, aber du nimmst ihn gerne an.",
+        "name": "\"Wenn es blutet...\"",
+        "text": "Schnell. Spiele diese Karte, nachdem du einen <i>Monster</i>-Gegner besiegt hast.\nJeder Ermittler an deinem Ort heilt Horror in Höhe des Horror-Wertes dieses Gegners."
     },
     {
         "code": "02226",
         "name": "Springfield M1903",
-        "text": "Uses (3 ammo).\n[action]<b> </b>Spend 1 ammo: <b>Fight</b>. You get +3 [combat] and deal +2 damage for this attack. Cannot be used to attack enemies engaged with you.",
-        "traits": "Item. Weapon. Firearm.",
+        "text": "Anwendungen (3 Munition).\n[action] Gib 1 Munition aus: <b>Kampf</b>. Du bekommst für diesen Angriff +3 [combat] und fügst +2 Schaden zu. Kann nicht verwendet werden, um Gegner anzugreifen, die mit dir in einen Kampf verwickelt sind.",
+        "traits": "Gegenstand. Waffe. Feuerwaffe.",
         "slot": "Hand x2"
     },
     {
         "code": "02227",
-        "flavor": "If we wish to learn, we must first question everything we know.",
-        "name": "Inquiring Mind",
-        "text": "Commit to a skill test only if there is a clue at your location.",
-        "traits": "Innate."
+        "flavor": "Wenn wir lernen wollen, müssen wir zunächst alles in Frage stellen, was wir bereits wissen.",
+        "name": "Forschergeist",
+        "text": "Trage diese Karte nur zu einer Fertigkeitsprobe bei, falls sich ein Hinweis an deinem Ort befindet.",
+        "traits": "Angeboren."
     },
     {
         "code": "02228",
-        "name": "Expose Weakness",
-        "text": "Fast. Play during any [free] player window.\nChoose an enemy at your location. Test [intellect] (X), where X is that enemy's fight value. For each point you succeed by, reduce that enemy's fight value by 1 for the next attack performed against it this phase.",
-        "traits": "Insight."
+        "name": "Schwäche aufzeigen",
+        "text": "Schnell. Spiele diese Karte in einem beliebigen [free]-Spielerfenster.\nWähle einen Gegner an deinem Ort. Lege eine [intellect]-Probe (X) ab, wobei X der Kampfwert dieses Gegners ist. Für jeden Punkt, um den die Probe gelingt, senke den Kampfwert dieses Gegners für den nächsten Angriff, der in dieser Phase gegen ihn durchgeführt wird, um 1.",
+        "traits": "Erkenntnis."
     },
     {
         "code": "02229",
-        "name": "Quick Thinking",
-        "text": "If this skill test is successful by 2 or more, after it resolves, you may immediately take an action as if it were your turn (this action does not count toward the number of actions you can take each turn).",
-        "traits": "Innate."
+        "name": "Geistesgegenwärtig",
+        "text": "Falls diese Fertigkeitsprobe um 2 oder mehr gelingt, darfst du, nachdem sie abgehandelt worden ist, sofort eine Aktion nehmen, als ob es dein Zug wäre (diese Aktion zählt nicht gegen die Anzahl der Aktionen, die du jede Runde nehmen kannst).",
+        "traits": "Angeboren."
     },
     {
         "code": "02230",
-        "name": "Lucky Dice",
-        "subname": "...Or Are They?",
-        "text": "Exceptional.\n[reaction]After you reveal a chaos token, spend 2 resources: Ignore that chaos token and reveal another one to resolve. If that token has a [auto_fail] symbol, remove Lucky Dice from the game.",
-        "traits": "Item. Relic.",
+        "name": "Glückswürfel",
+        "subname": "...oder doch nicht?",
+        "text": "Außergewöhnlich.\n[reaction]Nachdem du einen Chaosmarker enthüllt hast, gib 2 Ressourcen aus: Ignoriere diesen Chaosmarker und enthülle einen weiteren, der abgehandelt wird. Falls dieser Marker ein [auto_fail]-Symbol hat, entferne Glückswürfel aus dem Spiel.",
+        "traits": "Gegenstand. Relikt.",
         "slot": "Accessory"
     },
     {
         "code": "02231",
         "name": "Opportunist",
-        "text": "Commit only to a skill test you are performing.\nIf you succeed by 2 or more, return Opportunist to your hand after this test instead of discarding it.",
-        "traits": "Innate. Developed."
+        "text": "Diese Karte trägt nur zu einer Fertigkeitsprobe bei, die du durchführst.\nFalls dir die Probe um 2 oder mehr gelingt, schicke Opportunist nach dieser Probe zurück auf die Hand, statt sie abzulegen.",
+        "traits": "Angeboren. Entwickelt."
     },
     {
         "code": "02232",
         "name": "Alyssa Graham",
-        "subname": "Speaker to the Dead",
-        "text": "You get +1 [intellect].\n[free] Exhaust Alyssa Graham: Look at the top card of either the encounter deck or any player deck. You may then add 1 doom to Alyssa Graham to place the looked-at card on the bottom of its deck.",
-        "traits": "Ally. Sorcerer.",
+        "subname": "Sprecherin mit den Toten",
+        "text": "Du bekommst +1 [intellect].\n[free] Erschöpfe Alyssa Graham: Sieh dir die oberste Karte des Begegnungsdecks oder des Decks eines beliebigen Spielers an. Du darfst dann 1 Verderben zu Alyssa Graham hinzufügen, um die angesehene Karte unter dieses Deck zu platzieren.",
+        "traits": "Verbündeter. Zauberer.",
         "slot": "Ally"
     },
     {
         "code": "02233",
-        "name": "Rite of Seeking",
-        "text": "Uses (3 charges).\n[action]Spend 1 charge: <b>Investigate.</b> Investigate using [willpower] instead of [intellect]. You get +2 [willpower] for this test. If successful, you discover 2 additional clues at this location. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this test, after this test resolves lose all remaining actions and immediately end your turn.",
-        "traits": "Spell.",
+        "name": "Suchritual",
+        "text": "Anwendungen (3 Ladungen).\n[action} Gib 1 Ladung aus: <b>Ermitteln.</b> Verwende beim Ermittlen [willpower] statt [intellect]. Du bekommst für diese Probe +2 [willpower]. Falls die Probe gelingt, entdecke 2 Hinweise an diesem Ort. Falls ein [skull]-, [cultist]-, [tablet]-, [elder_thing]-, oder [auto_fail]-Symbol während dieser Probe enthüllt wird, verlierst du nach dieser Probe alle verbliebenen Aktionen und beendest sofort deinen Zug.",
+        "traits": "Zauber.",
         "slot": "Arcane"
     },
     {
         "code": "02234",
-        "name": "Dark Horse",
-        "text": "Limit 1 per investigator.\nDuring the upkeep phase, you may choose to not gain resources.\nWhile you have no resources in your resource pool, you get +1 [willpower], +1 [intellect], +1 [combat], and +1 [agility].",
-        "traits": "Condition."
+        "name": "Stille Wasser",
+        "text": "Nur 1 pro Ermittler.\nWährend der Unterhaltsphase darfst du wählen, keine Ressourcen zu erhalten.\nSolange du keine Ressourcen in deinem Ressourcenvorrat hast, bekommst du +1 [willpower], +1 [intellect], +1 [combat], und +1 [agility].",
+        "traits": "Zustand."
     },
     {
         "code": "02235",
-        "name": "Survival Instinct",
-        "text": "If this test is successful during an evasion attempt, the evading investigator may immediately evade each other enemy engaged with him or her, and may move to a connecting location.",
-        "traits": "Innate. Developed."
+        "name": "Überlebensinstinkt",
+        "text": "Falls diese Probe während eines Entkommen-Versuches erfolgreich ist, darf der entkommende Ermittler sofort jedem anderen Gegner entkommen, der mit ihm in einen Kampf verwickelt ist, und darf sich zu einem verbundenen Ort bewegen.",
+        "traits": "Angeboren. Entwickelt."
     }
 ]

--- a/translations/de/pack/dwl/uau_encounter.json
+++ b/translations/de/pack/dwl/uau_encounter.json
@@ -1,177 +1,179 @@
 [
     {
         "code": "02236",
-        "name": "Undimensioned and Unseen",
-        "text": "[skull]: -1 for each Brood of Yog-Sothoth in play.\n[cultist]: Reveal another token. If you fail this test, take 1 horror.\n[tablet]: 0. You must either remove all clue tokens from a Brood of Yog-Sothoth in play, or this token's modifier is -4 instead.\n[elder_thing]: -3. If this token is revealed during an attack or evasion attempt against a Brood of Yog-Sothoth, it immediately attacks you.",
-        "back_text": "[skull]: -2 for each Brood of Yog-Sothoth in play.\n[cultist]: Reveal another token. If you fail this test, take 1 horror and 1 damage.\n[tablet]: 0. You must either remove all clue tokens from a Brood of Yog-Sothoth in play, or this test automatically fails.\n[elder_thing]: -5. If this token is revealed during an attack or evasion attempt against a Brood of Yog-Sothoth, it immediately attacks you."
+        "name": "Gestaltlos und Unsichtbar",
+        "text": "[skull]: -1 für jede Brut von Yog-Sothoth im Spiel.\n[cultist]: Enthülle einen weiteren Marker. Falls die Probe misslingt, nimm 1 Horror.\n[tablet]: 0. Du musst entweder alle Hinweismarker von einer Brut von Yog-Sothoth im Spiel entfernen, oder der Modifikator dieses Markers ist stattdessen -4.\n[elder_thing]: -3. Falls dieser Marker während eines Angriffs- oder Entkommen-Versuchs gegen eine Brut von Yog-Sothoth enthüllt wird, greift diese dich sofort an.",
+        "back_text": "[skull]: -2 jede Brut von Yog-Sothoth im Spiel.\n[cultist]: Enthülle einen weiteren Marker. Falls die Probe misslingt, nimm 1 Horror und 1 Schaden.\n[tablet]: 0. Du musst entweder alle Hinweismarker von einer Brut von Yog-Sothoth im Spiel entfernen, oder diese Probe misslingt automatisch.\n[elder_thing]: -5. Falls dieser Marker während eines Angriffs- oder Entkommen-Versuchs gegen eine Brut von Yog-Sothoth enthüllt wird, greift diese dich sofort an."
     },
     {
         "code": "02237",
-        "flavor": "Reports of terrifying entities wreaking havoc across the countryside have caused the citizens of Dunwich to panic. Worse, the creatures seem to be invisible to the naked eye.",
-        "name": "Rampaging Creatures",
-        "text": "<b>Forced</b> - At the end of the enemy phase: Move each Brood of Yog-Sothoth enemy once toward a random location.",
-        "back_name": "Calamity Strikes",
-        "back_flavor": "An old pickup truck rolls to a stop along the weathered trails of Dunwich. The driver - Joe Osborn - calls out to you through a shattered driver-side window, the truck's engine still running. \"IT's over at the Ericks' farm!\" he shouts. \"Done blasted their place apart. Poor Henry and Martha...\"\nYou ask Osborn for the location of the Ericks' homestead, and it confirms your worst fear. For that attack to have occurred recently, there must be more of the monsters on the loose.",
-        "back_text": "Shuffle the encounter discard pile into the encounter deck.\nSpawn 1 of the set-aside Brood of Yog-Sothoth enemies at a random location, if able."
+        "flavor": "Berichte über furchterregende Wesenheiten, die das Land mit Zerstörung überziehen, haben die Einwohner von Dunwich in Panik versetzt. Schlimmer noch, die Kreaturen scheinen für das bloße Auge unsichtbar zu sein.",
+        "name": "Tobende Kreaturen",
+        "text": "<b>Erzwungen</b> - Bewege am Ende der Gegnerphase jede Brut von Yog-Sothoth ein Mal auf einen zufälligen Ort zu.",
+        "back_name": "Das Unheil bricht herein",
+        "back_flavor": "Ein alter Pickup rollt auf der abgenutzten Straße von Dunwich aus. Der Fahrer - Joe Osborn - ruft durch das kaputte Fenster an der Fahrerseite nach dir, schaltet aber den Motor nicht ab. \"Es ist drüben auf der Farm der Ericks!\", ruft er. \"Hat schon alles auseinandergenommen. Armer Henry, arme Martha…\"\nDu fragst Osborn, wo die Farm der Ericks liegt, und die Antwort bestätigt deine schlimmsten Befürchtungen. Das der Angriff noch nicht lange her ist, müssen mehrere Monster frei herumlaufen.",
+        "back_text": "Mische den Begegnungs-Ablagestapel in das Begegnungsdeck.\n1 der beiseitegelegten Gegner Brut von Yog-Sothoth erscheint falls möglich an einem zufälligen Ort."
     },
     {
         "code": "02238",
-        "flavor": "Once in a while a wind, sweeping up out of Cold Spring Glen, would bring a touch of ineffable foetor to the heavy night air... But the looked-for terror did not appear. Whatever was down there in the glen was biding its time, and Armitage told his colleagues it would be suicidal to try to attack it in the dark.\n—H.P. Lovecraft, \"The Dunwich Horror\"",
-        "name": "Biding Its Time",
-        "text": "<b>Forced</b> - At the end of the enemy phase: Move each Brood of Yog-Sothoth enemy once toward a random location.",
-        "back_name": "No Place to Hide",
-        "back_text": "Shuffle the encounter discard pile into the encounter deck. <b>If there is a set-aside Brood of Yog-Sothoth, the lead investigator reads the following (out loud):\n<i>Bleak storm clouds churn overhead and a blanket of rain pelts the countryside. As the downpour grows in intensity, you take refuge in a half-ruined shack nearby. There is a flash of lightning, and in the brief illumination, you spot the outline of something large in the rain. Without warning, the distant trees bend, though nothing seems to be bending them. Moments later, a force with the strength of a truck crashes into your refuge.</i>\n</b>Spawn 1 of the set-aside Brood of Yog-Sothoth enemies at the lead investigator's location, if able. Then, each investigator at that location tests [agility] (4). The newly spawned Brood of Yog-Sothoth makes an attack against each investigator who fails this skill test."
+        "flavor": "Ab und zu erfüllte ein Windstoß aus der Cold-Spring-Schlucht die Nachtluft mit einem abscheulichen Gestank. … Doch das erwartete Grauen erschien nicht. Was immer sich dort drinnen in der Schlucht befand, nahm sich Zeit und Armitage erklärte seinen Kollegen, es wäre Selbstmord, es in der Dunkelheit anzugreifen.\n—H.P. Lovecraft, \"Das Grauen von Dunwich\"",
+        "name": "Den richtigen Zeitpunkt abwarten",
+        "text": "<b>Erzwungen</b> - Bewege am Ende der Gegnerphase jede Brut von Yog-Sothoth ein Mal auf einen zufälligen Ort zu.",
+        "back_name": "Kein Versteck",
+        "back_text": "Mische den Begegnungs-Ablagestapel in das Begegnungsdeck. <b>Falls es eine beiseitegelegte Brut von Yog-Sothoth gibt, liest der Ermittlungsleiter folgenden Text laut vor:\n<i>Düstere Sturmwolken ziehen am Himmel auf und dichter Regen fällt auf das Land. Als der Regen stärker wird, flüchtest du in eine halb zerfallene Hütte in der Nähe. Ein Blitz zuckt am Himmel und erleuchtet für einen Moment die Umgebung, sodass du die Umrisse einer großen Gestalt im Regen sehen kannst. Ohne Vorwarnung biegen sich die Bäume in der Ferne, obwohl es keinen Grund dafür zu geben scheint. Kurz darauf bricht etwas mit der Kraft eines Lastwagens in dein Versteck.</i>\n</b>1 der beiseitegelegten Gegner Brut von Yog-Sothoth erscheint falls möglich am Ort des Ermittlungsleiters. Dann legt jeder Ermittler an diesem Ort eine[agility]-Probe (4). Die neu erschienene Brut von Yog-Sothoth führt einen Angriff gegen jeden Ermittler durch, dessen Fertigkeitsprobe misslingt."
     },
     {
         "code": "02239",
-        "flavor": "It was no joke tracking down something as big as a house that one could not see, but that had all the vicious malevolence of a daemon.\n—H.P. Lovecraft, \"The Dunwich Horror\"",
-        "name": "Horrors Unleashed",
-        "text": "Each <b><i>Abomination</i></b> enemy gets +1 fight and +1 evade.\n<b>Forced</b> - At the end of the enemy phase: Move each Brood of Yog-Sothoth enemy once toward a random location.",
-        "back_name": "Into the Hills",
-        "back_flavor": "There is a monstrous rumbling throughout the countryside, though it is impossible to tell whether its source is the creatures you hunt or the very mountains themselves. Soon after, you find more of the creatures' tracks leading up toward the hills: a thirty-foot path of crushed underbrush and trees snapped like twigs. Exhausted from battle, and with night fast approaching, you decide to head to safety rather than follow these hellish tracks.",
-        "back_text": "<b>(→R1)</b>"
+        "flavor": "Es war kein Vergnügen, etwas zu verfolgen, das so groß wie ein Haus und unsichtbar war und das über die Bösartigkeit eines Dämons verfügte.\n—H.P. Lovecraft, \"Das Grauen von Dunwich\"",
+        "name": "Der Horror ist entfesselt",
+        "text": "Jeder <b><i>Abscheulichkeit</i></b>-Gegner bekommt +1 Kampf und +1 Entkommen.\n<b>Erzwungen</b> - Bewege am Ende der Gegnerphase jede Brut von Yog-Sothoth ein Mal auf einen zufälligen Ort zu.",
+        "back_name": "In die Hügel",
+        "back_flavor": "Ein gewaltiges Rumpeln ertönt, aber du kannst nicht sagen, ob es von der Kreatur stammt, die du jagst, oder von den Bergen selbst. Bald darauf findest du weitere Spuren der Kreatur, die auf einen Hügel führen: ein etwas zehn Meter breiter Pfad aus plattgedrücktem Unterholz und Bäumen, die wie Zweige abgeknickt sind. Da du vom Kampf erschöpft bist und die Nacht schon bald hereinbrechen wird, entscheidest du dich lieber in Sicherheit zu bringen, statt die Spuren jetzt zu verfolgen.",
+        "back_text": "<b>(?A1)</b>"
     },
     {
         "code": "02240",
-        "flavor": "The monsters tearing through Dunwich county are immune to traditional weapons. Only by reciting a particular incantation can the creatures be defeated. First you must search the ruins of Wilbur Whateley’s home in order to find the final sections of the otherworldly script.",
-        "name": "Saracenic Script",
-        "text": "<b>Objective</b> - Only investigators at Whateley Ruins may spend the requisite number of clues, as a group, to advance.",
-        "back_name": "Obtaining the Formula",
-        "back_text": "<b>Check Campaign Log. If Dr. Armitage survived The Dunwich Legacy:</b>\n<i>\"There!\" Armitage sighs a breath of relief, jotting down the last phrases of the formula. \"I have translated the last of it.\" He shudders as he hands you the script, the words conjuring forth memories of his battle with the creature. \"I hope this is the last time I'll have to read it,\" he admits. \"But if we do nothing, the end result will be much, much worse.\"</i>\nEach investigator puts into play 1 set-aside Esoteric Formula.\n<b>If Dr. Armitage is listed under \"Sacrificed to Yog-Sothoth\":</b>\n<i>Using the information contained within the ruins of the Whateley homestead, you are able to transcribe the remainder of the formula previously used by Dr. Armitage to destroy the beast that plagued Dunwich. However, the endeavor sets you back several hours.</i>\nEach investigator puts into play 1 set-aside Esoteric Formula. Place 1 doom on the current agenda."
+        "flavor": "Das Monster, das die Umgebung von Dunwich unsicher macht, ist gegen traditionelle Waffen immun. Nur durch das Rezitieren eines bestimmten Zaubers kann die Kreatur besiegt werden. Zunächst musst du die Ruinen von Wilbur Whatleys Haus durchsuchen, um dort den letzten Teil dieser Aufzeichnungen aus einer anderen Welt zu finden.",
+        "name": "Sarazenische Schriften",
+        "text": "<b>Ermittlungsziel</b> - Nur Ermittler auf Whatleys Ruinen können als Gruppe die benötigten Hinweise ausgeben, um vorzurücken.",
+        "back_name": "Die Formel finden",
+        "back_text": "<b>Überprüfe das Kampagnenlogbuch. Falls Dr. Armitage Das Vermächtnis von Dunwich überlebt hat:</b>\n<i>\"Dort!\" Armitage seufzt erleichtert auf und notiert sich schnell die letzten Sätze der Formel. \"Ich habe sie nun vollständig übersetzt.\" Er schaudert, als er die Notizen reicht, weil die Worte die Erinnerungen an den Kampf mit der Kreatur erneut wecken. \"Ich hoffe, dies ist das letzte Mal, dass ich es lesen muss.\", gibt er zu. \"Aber wenn wir nichts tun, wird alles nur noch schlimmer.\"</i>\nJeder Ermittler bringt 1 beiseitegelegte Esoterische Formel ins Spiel.\n<b>Falls Dr. Armitage zu den unter \"Yog-Sothoth geopfert\" aufgelisteten Charakteren gehört:</b>\n<i>Mit den Informationen, die du in den Ruinen von Whatleys Farm gefunden hast, kannst du den Rest der Formel übertragen, die Dr. Armitage verwendet hat, um die Bestie zu töten, die Dunwich heimgesucht hat. Aber das wirft dich einige Stunden zurück.</i>\nJeder Ermittler bringt 1 beiseitegelegte Esoterische Formel ins Spiel. Platziere 1 Verderben auf die aktuelle Agenda."
     },
     {
         "code": "02241",
-        "flavor": "With the formula in hand, you finally have the means to destroy the creatures wreaking havoc in Dunwich... but only if you can survive long enough.",
-        "name": "They Must Be Destroyed!",
-        "text": "<b>Objective</b> - Defeat as many Brood of Yog-Sothoth enemies as you can. If there are no copies of Brood of Yog-Sothoth in play or set aside, advance.",
-        "back_name": "The Brood is Ended",
-        "back_flavor": "As you complete the incantation, the foul creature cries out with a raucous, inhuman voice. It rumbles and cracks, the syllables of its croaking far from English. As its cry plays out, the creature shrinks upon itself, and then, with little warning, it is gone. All that remains is a foul stench and a repulsive mark that mars the vegetation where the beast once stood.",
-        "back_text": "<b>(→R2)</b>"
+        "flavor": "Mit der Formel in der Hand hast du endlich eine Waffe gegen die Kreaturen, die Dunwich verwüsten… aber nur, wenn du lange genug am Leben bleibst.",
+        "name": "Sie müssen vernichtet werden!",
+        "text": "<b>Ermittlungsziel</b> - Besiege so viele Gegner Brut von Yog-Sothoth, wie du kannst. Falls keine Kopien von Brut von Yog-Sothoth im Spiel oder beiseitegelegt sind, rücke vor.",
+        "back_name": "Das Ende der Brut",
+        "back_flavor": "Als du die Beschwörungsformel vollendest, schreit die Kreatur mit rauer, unmenschlicher Stimme auf. Sie grummelt und knackt, die Silben, die sie krächzend ausstößt, klingen nicht im geringsten nach Englisch. Als ihr Schrei verstummt, sinkt die Kreatur in sich zusammen und ist dann plötzlich ohne Vorwarnung verschwunden. Alles, was von ihr bleibt, ist ein widerlicher Gestank und ein ekliger Fleck, der sämtliche Pflanzen an der Stelle, wo gerade noch die Kreatur gestanden hat, verdorren lässt.",
+        "back_text": "<b>(?A2)</b>"
     },
     {
         "code": "02242",
-        "name": "Dunwich Village",
-        "text": "[action]: <b>Resign.</b> You hide from the rampaging creatures.\n[free]: You borrow some hounds to track the creatures by scent. An investigator in Dunwich Village may place 1 of his or her clues on any <b><i>Abomination</i></b> enemy in play. (Group limit once per game).",
+        "name": "Dorf Dunwich",
+        "text": "[action]: <b>Aufgeben.</b> Du versteckst dich vor den Kreaturen.\n[free]: Du leihst dir einige Hunde aus, mit deren Hilfe du die Kreaturen aufspüren willst. Ein Ermittler im Dorf Dunwich darf 1 seiner Hinweise auf einen <b><i>Abscheulichkeit</i></b>-Gegner im Spiel platzieren. (Nur ein Mal pro Spiel für die gesamte Gruppe.)",
         "traits": "Dunwich.",
-        "back_flavor": "It is always a relief to get clear of the place, and to follow the narrow road around the base of the hills and across the level country beyond till it rejoins the Aylesbury pike. Afterward one sometimes learns that one has been through Dunwich.\n—H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "Man ist immer erleichtert, wenn man den Ort hinter sich gelassen hat, auf der schmalen Straße um den Fuß der Berge herum ist, die dahinterliegende Ebene durchquert und man wieder die Aylesbury_Überlandstraße erreicht hat. Manchmal erfährt man dann später, dass man durch Dunwich gekommen ist.\n—H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02243",
-        "flavor": "Ringing the church bell may draw the monsters toward the village, if you are brave enough to face them.",
-        "name": "Dunwich Village",
-        "text": "[action]: <b>Resign.</b> You hide from the rampaging creatures.\n[action]: Move a Brood of Yog-Sothoth enemy once toward Dunwich Village.",
+        "flavor": "Vielleicht könntest du die Kirchenglocken läuten, um das Monster in Richtung Dorf zu locken. Zumindest, falls du mutig genug bist, dich ihm zu stellen.
+",
+        "name": "Dorf Dunwich",
+        "text": "[action]: <b>Aufgeben.</b> Du versteckst dich vor den Kreaturen.\n[action]: Bewege einen Gegner Brut von Yog-Sothoth ein Mal auf das Dorf Dunwich zu.",
         "traits": "Dunwich.",
-        "back_flavor": "It is always a relief to get clear of the place, and to follow the narrow road around the base of the hills and across the level country beyond till it rejoins the Aylesbury pike. Afterward one sometimes learns that one has been through Dunwich.\n—H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "Man ist immer erleichtert, wenn man den Ort hinter sich gelassen hat, auf der schmalen Straße um den Fuß der Berge herum ist, die dahinterliegende Ebene durchquert und man wieder die Aylesbury_Überlandstraße erreicht hat. Manchmal erfährt man dann später, dass man durch Dunwich gekommen ist.\n—H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02244",
-        "name": "Cold Spring Glen",
-        "text": "Each enemy in Cold Spring Glen gets -1 evade.\n[free]: You lure the creature into the dense tree cover, and it becomes tangled. Investigators in Cold Spring Glen may, as a group, place up to 2 of their clues on an <b><i>Abomination</i></b> enemy in Cold Spring Glen. (Group limit once per game).",
+        "name": "Cold-Spring-Schlucht",
+        "text": "Jeder Gegner in der Cold-Spring-Schlucht bekommt -1 Entkommen.\n[free]: Du lockst die Kreatur in die dichten Bäume und sie verfängt sich darin. Die Ermittler in der Cold-Spring-Schlucht dürfen als Gruppe bis zu 2 ihrer Hinweise auf einen <b><i>Abscheulichkeit</i></b>-Gegner in der Cold-Spring-Schlucht legen. (Nur ein Mal pro Spiel für die gesamte Gruppe.)",
         "traits": "Dunwich.",
-        "back_flavor": "\"Gawd,\" he gasped, \"I telled 'em not ter go daown into the glen, an' I never thought nobody'd dew it with them tracks an' that smell an' the whippoorwills a-screechin' daown thar in the dark o' noonday...”\n—H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "\"Meint Gott,\" keuchte er, \"ich habe ihnen gesagt, sie sollen nicht in die Schlucht gehen, und ich hätte nie gedacht, das jemand es bei den Spuren, dem Gestank und den Ziegenmelkern, die den ganzen Tag zetern, wagen würde…"\n—H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02245",
-        "flavor": "The thick shadows and crowded trees make these woods a good hiding place.",
-        "name": "Cold Spring Glen",
-        "text": "Each enemy in Cold Spring Glen gets -1 evade.\n[reaction] After Cold Spring Glen is chosen as a random location: An investigator in Cold Spring Glen tests [agility] (3). If successful, choose a different random location.",
+        "flavor": "Die dicken Schatten und wuchernden Bäume bieten in diesem Wald gute Verstecke.",
+        "name": "Cold-Spring-Schlucht",
+        "text": "Jeder Gegner in der Cold-Spring-Schlucht bekommt -1 Entkommen.\n[reaction] Nachdem die Cold-Spring-Schlucht als zufälliger Ort bestimmt worden ist: Ein Ermittler in der Cold-Spring-Schlucht legt eine [agility]-Probe (3) ab. Falls die Probe gelingt, bestimme einen anderen zufälligen Ort.",
         "traits": "Dunwich.",
-        "back_flavor": "\"Gawd,\" he gasped, \"I telled 'em not ter go daown into the glen, an' I never thought nobody'd dew it with them tracks an' that smell an' the whippoorwills a-screechin' daown thar in the dark o' noonday...”\n—H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "\"Meint Gott,\" keuchte er, \"ich habe ihnen gesagt, sie sollen nicht in die Schlucht gehen, und ich hätte nie gedacht, das jemand es bei den Spuren, dem Gestank und den Ziegenmelkern, die den ganzen Tag zetern, wagen würde…\"\n—H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02246",
-        "name": "Ten-Acre Meadow",
-        "text": "[free]: You lure the monster into the rain. Place 1 clue from the token bank on an <b><i>Abomination</i></b> enemy in Ten-Acre Meadow. At the end of the round, remove 1 clue from that enemy. (Group limit once per game).",
+        "name": "Ten-Acre-Weide",
+        "text": "[free]: Du lockst das Monster in den Regen. Platziere 1 Hinweis aus dem Markervorrat auf einen <b><i>Abscheulichkeit</i></b>-Gegner auf der Ten-Acre-Weide. Entferne am Ende der Runde 1 Hinweis von diesem Gegner. (Nur ein Mal pro Spiel für die gesamte Gruppe.)",
         "traits": "Dunwich.",
-        "back_flavor": "The trees of the frequent forest belts seem too large, and the wild weeds, brambles, and grasses attain a luxuriance not often found in settled regions. At the same time the planted fields appear singularly few and barren...\n—H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "Die Bäume der vielen Waldungen erschienen zu hoch, und die Büsche, Sträucher und das Gras erreichten eine Dichte, wie man sie nicht oft in besiedelten Gebieten findet. Zur gleichen Zeit scheinen die Felder weniger und unfruchtbar zu werden…\n—H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02247",
-        "name": "Ten-Acre Meadow",
-        "text": "[free]: You set a bait using a live animal. Each investigator in Ten-Acre Meadow may place 1 of his or her clues on an <i>Abomination</i> enemy in Ten-Acre Meadow. (Group limit once per game).",
+        "name": "Ten-Acre-Weide",
+        "text": "[free]: Du stellst eine Falle mit einem lebenden Tier als Köder auf. Jeder Ermittler auf der Ten-Acre-Weide darf 1 seiner Hinweise auf einen <i>Abscheulichkeit</i>-Gegner auf der Ten-Acre-Weide platzieren. (Nur ein Mal pro Spiel für die gesamte Gruppe.)",
         "traits": "Dunwich.",
-        "back_flavor": "The trees of the frequent forest belts seem too large, and the wild weeds, brambles, and grasses attain a luxuriance not often found in settled regions. At the same time the planted fields appear singularly few and barren...\n—H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "Die Bäume der vielen Waldungen erschienen zu hoch, und die Büsche, Sträucher und das Gras erreichten eine Dichte, wie man sie nicht oft in besiedelten Gebieten findet. Zur gleichen Zeit scheinen die Felder weniger und unfruchtbar zu werden…\n—H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02248",
-        "flavor": "The ground here is loose and barely supports your weight.",
-        "name": "Blasted Heath",
-        "text": "[free]: You lure the creature into a patch of sand. Investigators in Blasted Heath may, as a group, place up to 2 of their clues on an <b><i>Abomination</i></b> enemy in Blasted Heath. (Group limit once per game).",
+        "flavor": "Der Boden ist hier sehr locker und trägt dein Gewicht kaum.",
+        "name": "Verdorrte Heide",
+        "text": "[free]: Du lockst die Kreatur auf eine Sandfläche. Die Ermittler in der Verdorrten Heide dürfen als Gruppe bis zu 2 Hinweise auf einen <b><i>Abscheulichkeit</i></b>-Gegner in der Verdorrten Heide legen. (Nur ein Mal pro Spiel für die gesamte Gruppe.)",
         "traits": "Dunwich.",
-        "back_flavor": "The summits are too rounded and symmetrical to give a sense of comfort and naturalness, and sometimes the sky silhouettes with especial clearness the queer circles of tall stone pillars with which most of them are crowned.\n—H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "Die Gipfel sind zu rund und zu symmetrisch, als dass sie natürlich und angenehm erscheinen würden, und manchmal sieht man vor dem unnatürlich klaren Himmel die Silhouetten von kreisförmig aufgestellten Steinsäulen, die sich auf den meisten Berggipfeln befinden.\n—H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02249",
-        "flavor": "A dense yellow mist, like a terrible miasma, permeates through this region. It crawls around your skin and causes your lungs to tighten.",
-        "name": "Blasted Heath",
-        "text": "<b>Forced</b> - At the end of your turn, if you are in Blasted Heath: Take 1 damage.",
+        "flavor": "Ein dichter gelber Nebel durchdringt die Gegend wie ein fürchterlicher Pesthauch. Er kriecht über deine Haut und erschwert dir das Atmen.",
+        "name": "Verdorrte Heide",
+        "text": "<b>Erzwungen</b> - Falls du am Ende deines Zuges in der Verdorrten Heide bist: Nimm 1 Schaden.",
         "traits": "Dunwich.",
-        "back_flavor": "The summits are too rounded and symmetrical to give a sense of comfort and naturalness, and sometimes the sky silhouettes with especial clearness the queer circles of tall stone pillars with which most of them are crowned.\n—H. P. Lovecraft, “The Dunwich Horror”"
+        "back_flavor": "Die Gipfel sind zu rund und zu symmetrisch, als dass sie natürlich und angenehm erscheinen würden, und manchmal sieht man vor dem unnatürlich klaren Himmel die Silhouetten von kreisförmig aufgestellten Steinsäulen, die sich auf den meisten Berggipfeln befinden.\n—H. P. Lovecraft, “Das Grauen von Dunwich”"
     },
     {
         "code": "02250",
-        "name": "Whateley Ruins",
-        "text": "Each investigator in Whateley Ruins gets -1 [willpower].\n[free]: You hurl a nearby canister of paint at the monster. An investigator in Whateley Ruins may place up to 3 of his or her clues on an <b><i>Abomination</i></b> enemy in Whateley Ruins. (Group limit once per game).",
+        "name": "Whateleys Ruinen",
+        "text": "Jeder Ermittler in Whateleys Ruinen bekommt -1 [willpower].\n[free]: Du schleuderst einen Farbeimer, der in der Nähe liegt, auf das Monster. Ein Ermittler in Whateleys Ruinen darf bis zu 3 seiner Hinweise auf einen <b><i>Abscheulichkeit</i></b>-Gegner in Whateleys Ruinen legen. (Nur ein Mal pro Spiel für die gesamte Gruppe.)",
         "traits": "Dunwich.",
-        "back_flavor": "It was as though a house, launched by an avalanche, had slid down through the tangled growths of the almost vertical slope.\n—H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "Es war, als ob eine Lawine ein Haus erfasst und durch das Unterholz den fast senkrechten Hang hinabgerissen hätte.\n—H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02251",
-        "flavor": "The ancient and arcane tomes found within the Whateley Ruins hold the secrets to manipulating the monsters.",
-        "name": "Whateley Ruins",
-        "text": "Each investigator in Whateley Ruins gets -1 [willpower].\n[action]: Test [intellect] (4). If you are successful, move a Brood of Yog-Sothoth enemy 1 location in any direction.",
+        "flavor": "Die uralten arkanen Bücher aus Whateleys Ruinen enthalten geheime Anweisungen zur Beeinflussung der Monster.",
+        "name": "Whateleys Ruinen",
+        "text": "Jeder Ermittler in Whateleys Ruinen bekommt -1 [willpower].\n[action]: Lege eine [intellect]-Probe (4) ab. Falls die Probe gelingt, bewege einen Gegner Brut von Yog-Sothoth 1 Ort in eine beliebige Richtung.",
         "traits": "Dunwich.",
-        "back_flavor": "It was as though a house, launched by an avalanche, had slid down through the tangled growths of the almost vertical slope.\n—H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "Es war, als ob eine Lawine ein Haus erfasst und durch das Unterholz den fast senkrechten Hang hinabgerissen hätte.\n—H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02252",
-        "name": "Devil's Hop Yard",
-        "text": "[free]: You lure the creature into the thick fog. An investigator in Devil's Hop Yard may place up to 2 of his or her clues on an <b><i>Abomination</i></b> enemy in Devil's Hop Yard. (Group limit once per game).",
+        "name": "Tanzplatz des Teufels",
+        "text": "[free]: Du lockst die Kreatur in den dichten Nebel. Ein Ermittler auf dem Tanzplatz des Teufels darf bis zu 2 seiner Hinweise auf einen <b><i>Abscheulichkeit</i></b>-Gegner auf dem Tanzplatz des Teufels legen. (Nur ein Mal pro Spiel für die gesamte Gruppe.)",
         "traits": "Dunwich.",
-        "back_flavor": "...still others try to explain the Devil’s Hop Yard - a bleak, blasted hillside where no tree, shrub, or grass-blade will grow.\n—H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "…während andere immer noch eine Erklärung für den Tanzplatz des Teufels suchten, einer blanken, verwüsteten Bergflanke, wo kein Baum, kein Strauch oder Gras wachsen will.\n—H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02253",
         "flavor": "A recent downpour has made the hop yard muddy and difficult to slog through.",
-        "name": "Devil's Hop Yard",
-        "text": "[free]: The creature follows you into the mud. Each investigator in Devil's Hop Yard may place 1 of his or her clues on an <i>Abomination</i> enemy in Devil's Hop Yard. (Group limit once per game).",
+        "name": "Tanzplatz des Teufels",
+        "text": "[free]: Die Kreatur folgt dir in den Schlamm. Jeder Ermittler auf dem Tanzlatz des Teufels darf 1 seiner Hinweise auf einen <i>Abscheulichkeit</i>-Gegner auf dem Tanzplatz des Teufels legen. (Nur ein Mal pro Spiel für die gesamte Gruppe.)",
         "traits": "Dunwich.",
-        "back_flavor": "...still others try to explain the Devil’s Hop Yard - a bleak, blasted hillside where no tree, shrub, or grass-blade will grow.\n—H.P. Lovecraft, \"The Dunwich Horror\""
+        "back_flavor": "…während andere immer noch eine Erklärung für den Tanzplatz des Teufels suchten, einer blanken, verwüsteten Bergflanke, wo kein Baum, kein Strauch oder Gras wachsen will.\n—H.P. Lovecraft, \"Das Grauen von Dunwich\""
     },
     {
         "code": "02254",
         "flavor": "Negotium perambulans in tenebris...",
-        "name": "Esoteric Formula",
-        "text": "[action] <b>Fight.</b> This attack uses [willpower] instead of [combat]. You get +2 [willpower] for this attack for each clue on the attacked enemy. Use this ability only on an <b><i>Abomination</i></b> enemy.",
-        "traits": "Spell."
+        "name": "Esoterische Formel",
+        "text": "[action] <b>Kampf.</b> Dieser Angriff verwendet [willpower] statt [combat]. Du bekommst für diesen Angriff +2 [willpower] für jeden Hinweis auf dem angegriffenen Gegner. Verwende diese Fähigkeit nur gegen einen <b><i>Abscheulichkeit</i></b>-Gegner.",
+        "traits": "Zauber."
     },
     {
         "code": "02255",
-        "flavor": "\"I believe there’s a chance of putting it out of business.\"\n–H.P. Lovecraft, \"The Dunwich Horror\"",
-        "name": "Brood of Yog-Sothoth",
-        "text": "Massive.\nBrood of Yog-Sothoth gets +1[per_investigator] health and cannot be damaged or attacked except using the ability on Esoteric Formula.",
-        "traits": "Monster. Abomination."
+        "flavor": "\"Ich bin überzeugt, dass wir eine Chance haben, es aus dem Verkehr zu ziehen.\"\n–H.P. Lovecraft, \"Das Grauen von Dunwich\"",
+        "name": "Brut von Yog-Sothoth",
+        "text": "Gewaltig.\nBrut von Yog-Sothoth bekommt +1 [per_investigator] Ausdauer und kann keinen Schaden nehmen oder angegriffen werden außer durch die Fähigkeit auf der Esoterischen Formel.",
+        "traits": "Monster. Abscheulichkeit."
     },
     {
         "code": "02256",
-        "name": "Towering Beasts",
-        "text": "Peril.\n<b>Revelation</b> - Attach to a Brood of Yog-Sothoth enemy in play. If that enemy is at your location, take 1 damage.\nAttached enemy gets +1 fight and +1 health."
+        "name": "Aufragende Bestien",
+        "text": "Wagnis.\n<b>Enthüllung</b> - Hänge diese Karte an einem Gegner Brut von Yog-Sothoth im Spiel an. Falls dieser Gegner an deinem Ort ist, nimm 1 Schaden.\nDer Gegner mit dieser Verstärkung bekommt +1 Kampf und +1 Ausdauer."
     },
     {
         "code": "02257",
-        "name": "Ruin and Destruction",
-        "text": "<b>Revelation</b> - If there are no investigators at the same location as a Brood of Yog-Sothoth, Ruin and Destruction gains surge. Otherwise, each investigator at the same location as a Brood of Yog-Sothoth tests [agility] (3). For each point he or she fails by, he or she takes 1 damage.",
-        "traits": "Hazard."
+        "name": "Verderben und Zerstörung",
+        "text": "<b>Enthüllung</b> - Falls sich keine Ermittler am selben Ort wie eine Brut von Yog-Sothoth befinden, erhält Verderben und Zerstörung Nachrüsten. Ansonsten legt jeder Ermittler am selben Ort wie eine Brut von Yog-Sothoth eine [agility]-Probe (3) ab. Für jeden Punkt, um den die Probe misslingt, nimmt er 1 Schaden.",
+        "traits": "Gefahr."
     },
     {
         "code": "02258",
-        "name": "Attracting Attention",
-        "text": "Surge.\n<b>Revelation</b> - Each Brood of Yog-Sothoth enemy in play moves once toward you."
+        "name": "Aufmerksamkeit erregen",
+        "text": "Nachrüsten.\n<b>Enthüllung</b> - Jeder Gegner Brut von Yog-Sothoth im Spiel bewegt sich ein Mal auf dich zu."
     },
     {
         "code": "02259",
-        "name": "The Creatures' Tracks",
-        "text": "Peril.\n<b>Revelation</b> - You must either (choose one): Take 2 horror, or spawn a set aside Brood of Yog-Sothoth at a random location.",
-        "traits": "Terror."
+        "flavor": "…zeugten die niedergewalzten Büsche an den Straßenrändern von der riesigen Masse des Grauens…\n—H.P. Lovecraft, \"Das Grauen von Dunwich\"",
+        "name": "Die Spuren der Kreatur",
+        "text": "Wagnis.\n<b>Enthüllung</b> - Du musst entweder (wähle ein): Nimm 2 Horror oder eine beiseitegelegte Brut von Yog-Sothoth erscheint an deinem Ort.",
+        "traits": "Schrecken."
     }
 ]

--- a/translations/de/pack/dwl/wda.json
+++ b/translations/de/pack/dwl/wda.json
@@ -1,97 +1,97 @@
 [
     {
         "code": "02260",
-        "name": "Leadership",
-        "text": "While Leadership is committed to a skill test being performed by another investigator, Leadership gains [willpower] [wild].",
-        "traits": "Practiced."
+        "name": "Führung",
+        "text": "Solange Führung zu einer Fertigkeitsprobe beigetragen wird, die von einem anderen Ermittler durchgeführt wird, erhält Führung [willpower] [wild].",
+        "traits": "Trainiert."
     },
     {
         "code": "02261",
-        "name": "\"I've had worse…\"",
-        "text": "Fast. Play when you are dealt damage and/or horror.\nCancel up to 5 damage and/or horror just dealt to you. Then, gain that many resources.",
-        "traits": "Spirit."
+        "name": "\"Es gibt schlimmeres…\"",
+        "text": "Schnell. Spiele diese Karte, sobald dir Schaden und/oder Horror zugefügt wird.\nHebe bis zu 5 Schaden und/oder Horror auf, der dir gerade zugefügt worden ist. Dann erhälst du genauso viele Ressourcen.",
+        "traits": "Geist."
     },
     {
         "code": "02262",
-        "name": "Strange Solution",
-        "subname": "Restorative Concoction",
-        "text": "You can only include this asset in your deck by upgrading it from Strange Solution <i>(Unidentified)</i>, and only if you have \"identified the solution\" in your Campaign Log.\nUses (4 supplies).\n[action] Spend 1 supply: Heal 2 damage from an investigator at your location.",
-        "traits": "Item. Science."
+        "name": "Seltsame Lösung",
+        "subname": "Gebräu zur Wiederherstellung",
+        "text": "Du kannst diese Vorteilskarte nur deinem Deck hinzufügen, indem du Seltsame Lösung <i>(Nicht identifiziert)</i> verbesserst, und nur, falls in deinem Kampagnenlogbuch steht, dass du \"die Lösung identifiziert hast\".\nAnwendungen (4 Vorräte).\n[action] Gib 1 Vorrat aus: Heile 2 Schaden von einem Ermittler an deinem Ort.",
+        "traits": "Gegenstand. Wissenschaft."
     },
     {
         "code": "02263",
-        "name": "Strange Solution",
-        "subname": "Acidic Ichor",
-        "text": "You can only include this asset in your deck by upgrading it from Strange Solution <i>(Unidentified)</i>, and only if you have \"identified the solution\" in your Campaign Log.\nUses (3 supplies).\n[action] Spend 1 supply: <b>Fight.</b> Attack with a base [combat] skill of 6. This attack deals +2 damage.",
-        "traits": "Item. Science."
+        "name": "Seltsame Lösung",
+        "subname": "Ätzendes Sekret",
+        "text": "Du kannst diese Vorteilskarte nur deinem Deck hinzufügen, indem du Seltsame Lösung <i>(Nicht identifiziert)</i> verbesserst, und nur, falls in deinem Kampagnenlogbuch steht, dass du \"die Lösung identifiziert hast\".\nAnwendungen (3 Vorräte).\n[action] Gib 1 Vorrat aus: <b>Kampf.</b> Greife mit einem Grund-[combat]-Fertigkeitswert von 6 an. Dieser Angriff fügt 2 Schaden zu.",
+        "traits": "Gegenstand. Wissenschaft."
     },
     {
         "code": "02264",
-        "name": "Strange Solution",
-        "subname": "Freezing Variant",
-        "text": "You can only include this asset in your deck by upgrading it from Strange Solution <i>(Unidentified)</i>, and only if you have \"identified the solution\" in your Campaign Log.\nUses (4 supplies).\n[action] Spend 1 supply: <b>Evade.</b> Evade with a base [agility] skill of 6.",
-        "traits": "Item. Science."
+        "name": "Seltsame Lösung",
+        "subname": "Eiskalte Variante",
+        "text": "Du kannst diese Vorteilskarte nur deinem Deck hinzufügen, indem du Seltsame Lösung <i>(Nicht identifiziert)</i> verbesserst, und nur, falls in deinem Kampagnenlogbuch steht, dass du \"die Lösung identifiziert hast\".\nAnwendungen (4 Vorräte).\n[action] Gib 1 Vorrat aus: <b>Entkommen.</b> Entkomme mit einem Grund-[agility]-Fertigkeitswert von 6.",
+        "traits": "Gegenstand. Wissenschaft."
     },
     {
         "code": "02265",
-        "flavor": "\"Murph, you know full well that The Rat would snitch on anyone, at any time, for anything, truth be damned if the price was right.\"\n–Jason Marker, Investigators of Arkham Horror",
-        "name": "Joey \"The Rat\" Vigil",
-        "subname": "Lookin' Out for #1",
-        "text": "[free] Spend 1 resource: Choose an <b>Item</b> asset from your hand and play it (paying its cost).",
-        "traits": "Ally. Criminal.",
+        "flavor": "\"Murph, du weißt genau, dass Die Ratte jeden verpfeifen würde, zu jeder Zeit, für alles und es mit der Wahrheit dabei nicht so genau nehmen würde, wenn der Preis stimmt.\"\n–Jason Marker, Die Welten von Arkham",
+        "name": "Joey \"Die Ratte\" Vigil",
+        "subname": "Auf der Suche nach #1",
+        "text": "[free] Gib 1 Ressource aus: Wähle eine <b>Gegenstand</b>-Vorteilskarte von deiner Hand und spiele sie (und zahle die Kosten dafür).",
+        "traits": "Verbündeter. Krimineller.",
         "slot": "Ally"
     },
     {
         "code": "02266",
-        "name": "Ace in the Hole",
-        "text": "Exceptional. Fast. Play only during your turn.\nYou may take an additional 3 actions this turn.",
+        "name": "Ass im Ärmel",
+        "text": "Außergewöhnlich. Schnell. Spiele diese Karte nur in deinem Zug.\nDu darfst in diesem Zug 3 zusätzliche Aktionen nehmen.",
         "traits": "Trick."
     },
     {
         "code": "02267",
-        "name": "Moonlight Ritual",
-        "text": "Remove all doom from 1 card you control.",
-        "traits": "Spell. Insight."
+        "name": "Mondlichtritual",
+        "text": "Entferne alles Verderben von 1 Karte, die du kontrollierst.",
+        "traits": "Zauber. Erkenntnis."
     },
     {
         "code": "02268",
-        "flavor": "Only by standing firm against the darkness can we live to see the light of another day.",
-        "name": "Fearless",
-        "text": "If this skill test is successful, heal 1 horror (2 horror instead if it succeeds by 2 or more).",
-        "traits": "Innate. Developed."
+        "flavor": "Nur wenn wir uns gegen die Dunkelheit behaupten, werden wir das Licht des nächsten Tages sehen.",
+        "name": "Furchtlos",
+        "text": "Falls diese Fertigkeitsprobe gelingt, heile 1 Horror (stattdessen 2 Horror, falls sie um 2 oder mehr gelingt).",
+        "traits": "Angeboren. Entwickelt."
     },
     {
         "code": "02269",
-        "name": "Jewel of Aureolus",
-        "subname": "Gift of the Homunculi",
-        "text": "[reaction] After a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during a skill test at your location, exhaust Jewel of Aureolus: Draw 1 card or gain 2 resources.",
-        "traits": "Item. Relic.",
+        "name": "Juwel von Aureolus",
+        "subname": "Geschenk des Homunkuli",
+        "text": "[reaction] Nachdem ein [skull]-, [cultist]-, [tablet]-, [elder_thing]-, oder [auto_fail]-Symbol während einer Fertigkeitsprobe enthüllt worden ist, erschöpfe Juwel von Aureolus: Ziehe 1 Karte oder erhalte 2 Ressourcen.",
+        "traits": "Gegenstand. Relikt.",
         "slot": "Accessory"
     },
     {
         "code": "02270",
-        "name": "A Chance Encounter",
-        "text": "Choose an <b>Ally</b> asset in any player's discard pile. Put that asset into play under your control. At the end of the round, if that asset is still in play, discard it.",
-        "traits": "Fortune."
+        "name": "Eine zufällige Begegnung",
+        "text": "^Wähle eine <b>Verbündeter</b>-Vorteilskarte im Ablagestapel eines beliebigen Spielers. Bringe diese Vorteilskarte unter deiner Kontrolle ins Spiel. Falls diese Vorteilskarte am Ende der Runde noch im Spiel ist, lege sie ab.",
+        "traits": "Glücksfall."
     },
     {
         "code": "02271",
-        "name": "Stroke of Luck",
-        "text": "Commit only to a skill test you are performing.\nAfter revealing chaos tokens for this test, you may choose to exile Stroke of Luck. If you do, this test is automatically successful (unless a [auto_fail] token was revealed).",
-        "traits": "Innate. Fortune."
+        "name": "Glückstreffer",
+        "text": "Diese Karte trägt nur zu einer Fertigkeitsprobe bei, die du durchführst.\nNachdem Chaosmarker für diese Probe enthüllt worden sind, darfst du wählen Glückstreffer ins Exil zu schicken. Falls du dies tust, gelingt diese Probe automatisch (außer wenn ein [auto_fail]-Marker enthüllt worden ist).",
+        "traits": "Angeboren. Glücksfall."
     },
     {
         "code": "02272",
-        "flavor": "There's nothing quite like the feel of silk against your skin.",
-        "name": "Fine Clothes",
-        "text": "Reduce the difficulty of skill tests you perform during 'parley' actions by 2.",
-        "traits": "Item. Clothing.",
+        "flavor": "Nichts ist besser als das Gefühl von Seide auf deiner Haut.",
+        "name": "Gute Kleidung",
+        "text": "Senke die Schwierigkeit von Fertigkeitsproben, die du während \"Verhandlung\"-Aktionen ablegst, um 2.",
+        "traits": "Gegenstand. Kleidung.",
         "slot": "Body"
     },
     {
         "code": "02273",
-        "name": "Moment of Respite",
-        "text": "Play only if there are no enemies at your location.\nHeal 3 horror and draw 1 card.",
-        "traits": "Spirit."
+        "name": "Eine kurze Ruhepause",
+        "text": "Spiele diese Karte nur, falls sich keine Gegner an deinem Ort befinden.\nHeile 3 Horror und ziehe 1 Karte.",
+        "traits": "Geist."
     }
 ]

--- a/translations/de/pack/dwl/wda_encounter.json
+++ b/translations/de/pack/dwl/wda_encounter.json
@@ -1,197 +1,197 @@
 [
     {
         "code": "02274",
-        "name": "Where Doom Awaits",
-        "text": "<b>Easy / Standard</b>\n[skull] -1 (-3 instead if you are at an <i>Altered</i> location).\n[cultist] Reveal another token. Cancel the effects and icons of each skill card committed to this test.\n[tablet] -2 (-4 instead if it is Agenda 2).\n[elder_thing] -X. Discard the top 2 cards of your deck. X is the total printed cost of those discarded cards.",
-        "back_text": "<b>Hard / Expert</b>\n[skull] -2 (-5 instead if you are at an <i>Altered</i> location).\n[cultist] Reveal another token. Cancel the effects and icons of each skill card committed to this test.\n[tablet] -3. If it is Agenda 2, you automatically fail instead.\n[elder_thing] -X. Discard the top 3 cards of your deck. X is the total printed cost of those discarded cards."
+        "name": "Wo das Verderben wartet",
+        "text": "<b>Einfach/Normal</b>\n[skull] -1 (stattdessen -3, falls du dich an einem <i>Verändert</i>-Ort befindest).\n[cultist] Enthülle einen weiteren Marker. Hebe die Effekte und Symbole jeder Fertigkeitskarte auf, die zu dieser Probe beigetragen worden ist.\n[tablet] -2 (stattdessen -4, falls es Agenda 2 ist).\n[elder_thing] -X. Lege die obersten 2 Karten deines Decks ab. X ist die Summe der aufgedruckten Kosten der abgelegten Karten.",
+        "back_text": "<b>Schwer/Experte</b>\n[skull] -2 (stattdessen -5, falls du dich an einem <i>Verändert</i>-Ort befindest).\n[cultist] Enthülle einen weiteren Marker. Hebe die Effekte und Symbole jeder Fertigkeitskarte auf, die zu dieser Probe beigetragen worden ist.\n[tablet] -3. Falls es Agenda 2 ist, misslingt die Probe stattdessen automatisch.\n[elder_thing] -X. Lege die obersten 3 Karten deines Decks ab. X ist die Summe der aufgedruckten Kosten der abgelegten Karten."
     },
     {
         "code": "02275",
-        "flavor": "As you approach Sentinel Hill, you hear ancient Latin rites bellowed across the night. The time for action has come. If you cannot stop the sorcerers in Dunwich, who knows what terrors they might unleash upon the world?",
-        "name": "Calling Forth the Old Ones",
-        "back_name": "The World is Altered",
-        "back_flavor": "As you explore the paths surrounding Sentinel Hill, the chanting at the hilltop rises to a crescendo and takes an otherworldly quality, reverberating through the trees as if carried by unseen currents.\nThe world begins to change. The grass and trees dissolve like sugar in a cup of tea. A vast endless sky slices through the reality you see before you, and you feel drawn to it, terrified and awestruck. The arcane power becomes distorted and seeps around you, creating strange alterations in the land.",
-        "back_text": "Shuffle the encounter discard pile into the encounter deck."
+        "flavor": "Als du dich dem Sentinel Hill näherst, hörst du, wie jemand alte Rituale auf Latein anstößt. Nun ist es Zeit zu handeln. Wer weiß, welche Schrecken es über die Welt bringen könnte, falls du die Zauberer von Dunwich nicht aufhalten kannst?",
+        "name": "Die Anrufung der großen Alten",
+        "back_name": "Die Welt ist verändert",
+        "back_flavor": "Als du die Wege um den Sentinel Hill erkundest, erheben sich die Gesänge auf dem Gipfel zu einem Höhepunkt und hören sich fast außerirdisch an, während sie durch die Bäume wie von einer unsichtbaren Strömung weitergetragen werden.\nDie Welt beginnt sich zu verändern. Die Gräser und Bäume lösen sich wie Zucker in einer Tasse Tee auf. Ein unermesslicher, endloser Himmel schneidet durch die Realität, die du vor dir siehst, und du fühlst verängstigt und erschrocken, wie dich etwas hineinzieht. Die arkane Macht wird verzerrt und verschwimmt um dich herum, wobei sie merkwürdige Veränderungen in der Landschaft auslöst.",
+        "back_text": "Mische den Begegnungs-Ablagestapel in das Begegnungsdeck."
     },
     {
         "code": "02276",
-        "flavor": "The Old Ones were, the Old Ones are, and the Old Ones shall be. Not in the spaces we know, but between them, They walk serene and primal, undimensioned and to us unseen. Yog-Sothoth knows the gate. Yog-Sothoth is the gate. Yog-Sothoth is the key and guardian of the gate. Past, present, future, all are one in Yog-Sothoth. He knows where the Old Ones broke through of old, and where They shall break through again. He knows where They have trod earth’s fields, and where They still tread them, and why no one can behold Them",
-        "name": "Beckoning for Power",
-        "back_name": "The Reward for Servitude",
-        "back_flavor": "The chanting reaches its climax, and at the summit of Sentinel Hill, a tear opens across the fabric of the sky, parting the clouds and slicing through the very air itself.\nYou watch as an indescribable entity - spheres, eyes, mouths, ooze - pours out of the rift. The sorcerers call its name as its form seeps into the sky, spreading forth above the earth.\"Ia! Ia! Yog-Sothoth! Ia! Ia! Yog-Sothoth!\"\nBefore their jubilant chant can continue, they are smothered by the growing mass, and are heard no more.\nTo your horror, the expansion of the mass does not cease.",
-        "back_text": "<b>(→R2)</b>"
+        "flavor": "Die Großen Alten waren, die Großen Alten sind und die Großen Alten werden sein. Nicht in den Räumen, wie wir sie kennen, sondern dazwischen. Sie schreiten ernst und urzeitlich, gestaltlos und unsichtbar für uns. Yog-Sothoth kennt das Tor. Yog-Sothoth ist das Tor. Yog-Sothoth ist der Schlüssel und der Wächter des Tores. Vergangenheit, Gegenwart und Zukunft sind in Yog-Sothoth eins. Er weiß, wo sie über die Erde schritten und wo sie immer noch schreiten und warum sie niemand aufhalten kann.",
+        "name": "Flehen nach Macht",
+        "back_name": "Belohnung für treue Dienste",
+        "back_flavor": "Der Gesang erreicht seinen Höhepunkt und auf dem Gipfel des Sentinel Hill bildet sich ein Riss im Himmel, der die Wolken teilt und die Luft durchschneidet.\nDu siehst wie eine unbeschreibliche Entität - bestehend aus schimmernden Kugeln, Augen, Mündern, Schleim - aus dem Riss dringt. Die Zauberer rufen seinen Namen, als die Gestalt den Himmel durchdringt und sich über die Erde ausbreitet.\"Iä! Iä! Yog-Sothoth! Iä! Iä! Yog-Sothoth!\"\nNoch bevor die jubilierenden Gesänge fortgesetzt werden können, werden sie von der wachsenden Masse erdrückt und niemand hört je wieder etwas von ihnen.\nZu deinem Schrecken hört die Masse aber nicht zu wachsen auf.",
+        "back_text": "<b>(?A2)</b>"
     },
     {
         "code": "02277",
-        "flavor": "A vibrant arcane energy fills the air with a bone-rattling chill. The energy swirls along the crushed trail before you, and seeps down several other paths before disappearing.",
-        "name": "The Path to the Hill",
-        "text": "<b>Objective</b> - When the investigators have collected the requisite number of clues, they must immediately spend them and advance.",
-        "back_name": "A Sacrifice Made",
-        "back_flavor": "During your search through the wooded paths around the base of Sentinel Hill, you come across a startling sight. A herd of sheep lays dead upon the ground in a secluded clearing, their bloodied carcasses placed in a strange but careful pattern. Holding your nose against the stench of death, you step over mangled sheep on your way to the center of the odd formation.\nIn the center of the sheep lies the corpse of a man. A clear jewel has been firmly pressed into his forehead, caving in the front of his skull. His eyes are wide, his face contorted in a vision of fear, as if beseeching you for mercy. Though you know better, you check for a pulse. As you touch the man's skin, the jewel in his forehead dissolves, and the woods around you seem to clear.",
-        "back_text": "The arcane presence masking the path further up the hill has faded. Reveal Ascending Path.\nRemove all clues from each location in play."
+        "flavor": "Eine pulsierende arkane Energie erfüllt die Luft mit einer Kälte, die bis in die Knochen dringt. Die Energie wirbelt den zerstörten Weg vor dir entlang und sickert auf einige andere Wege hinunter, bevor sie verschwindet.",
+        "name": "Der Weg zum Hügel",
+        "text": "<b>Ermittlungsziel</b> - Sobald die Ermittler die benötigte Anzahl Hinweise gesammelt haben, müssen sie diese sofort ausgeben und vorrücken.",
+        "back_name": "Ein Opfer wurde gebracht",
+        "back_flavor": "Während der Suche auf den Waldwegen um den Fuß des Sentinel Hill findest du etwas Erschreckendes. Auf einer abgelegenen Lichtung liegt eine Herde Schafe tot auf dem Boden, die blutigen Körper formen ein merkwürdiges, aber anscheinend sorgfältig angelegtes Muster. Du hälst dir die Nase zu, um dem Gestank des Todes zu entgehen, während du über die zerfleischten Schafe in die Mitte des merkwürdigen Musters steigst.\nIn der Mitte findest du den Leichnam eines Mannes. Ein klarer Juwel ist so fest in seine Stirn gepresst worden, dass er in den Schädelknochen eingedrungen ist. Seine Augen sind weit aufgerissen, das Gesicht angstverzerrt, als ob er dich um Gnade anflehen würde. Wider besseres Wissens versuchst du seinen Puls zu fühlen. Als du die Haut des Mannes berührst, löst sich der Juwel auf der Stirn auf und die Wälder um dich herum scheinen aufzuklaren.",
+        "back_text": "Die arkane Präsenz, die den Pfad zum Gipfel des Hügels verborgen hat, ist verschwunden. Enthülle Aufsteigender Pfad.\nEntferne alle Hinweise von allen Orten im Spiel."
     },
     {
         "code": "02278",
-        "flavor": "As you ascend the hill, the environment around you grows increasingly strange and otherworldly. The arcane energy feels even stronger here, crackling in the air and crawling on your skin.",
-        "name": "Ascending the Hill (v. I)",
-        "text": "Clues cannot be placed on non-<i>Altered</i> locations.\n<b>Objective</b> - When an investigator enters Sentinel Peak, advance.",
-        "back_name": "Trip the Pattern",
-        "back_flavor": "Approaching the peak of Sentinel Hill, you are confronted by several citizens of Dunwich. The man in the center of their circle chants in Latin while the others bow their heads in reverence. \"Seth Bishop?\" you ask presumptively. The man in the center raises his gaze in response, confirming your suspicions. You plead with the man to stop this madness, but he doesn't respond. You draw forth the silver constellation pendant you'd found on Silas's body and present it to Seth. \"This is all we found of your brother,\" you shout over the howling wind. \"Is this the fate you want for yourself? For all of us?\" You throw the pendant onto the ground. Staggered by the sight of it, he stumbles backwards and trips over his incantation, eyes widened. As he falls, the altar behind him splits open, and a torrent of energy pours from the stone, swirling into an open gate that swallows the man whole. You barely manage to dig your heels in and grab hold of a nearby rock to resist the pull of the gate.",
-        "back_text": "Remove the set-aside Seth Bishop enemy from the game."
+        "flavor": "Als du den Hügel erklimmst, wird die Umgebung immer seltsamer und unwirklicher. Hier nimmst du die arkane Energie sogar noch deutlicher wahr, sie knistert in der Luft und kribbelt auf deiner Haut.",
+        "name": "Den Hügel besteigen (V. I)",
+        "text": "Auf Nicht-<i>Verändert</i>-Orte können keine Hinweise platziert werden.\n<b>Ermittlungsziel</b> - Sobald ein Ermittler den Gipfel des Sentinel Hill betritt, rücke vor.",
+        "back_name": "Zerstöre das Muster",
+        "back_flavor": "Als du dich dem Gipfel des Sentinel Hill näherst, befinden sich dort bereits einige Einwohner von Dunwich. Der Mann in der Mitte des Kreises singt etwas auf Latein, während die anderen andächtig ihre Köpfe senken. \"Seth Bishop?\", vermutest du. Der Mann in der Mitte schaut dich an und bestätigt damit deinen Verdacht. Du bittest den Mann diesen Wahnsinn zu beenden, aber er antwortet nicht. Dann ziehst du das silberne Kleinod mit den Sternenkonstellationen hervor, das du bei Silas gefunden hast, und zeigst es Seth. \"Das ist alles, was wir von Ihrem Bruder noch gefunden haben\", rufst du über den heulenden Wind hinweg. \"Ist dies das Schicksal, das Sie sich wünschen? Das Sie uns allen wünschen?\" Du wirfst das Schmuckstück auf den Boden. Von dem Anblick überrascht, taumelt er zurück, verhaspelt sich bei seiner Beschwörung und reißt die Augen weit auf. Als er fällt, spaltet sich der Altar hinter ihm, ein Wirbel aus Energie dringt aus dem Stein und formt ein offenes Tor, das den Mann verschluckt. Du shcaffst es mit Mühe, deine Fersen fest auf den Boden zu stemmen und dich an einem Felsen in der Nähe zu klammern, um den Sog des Tores zu entgehen.",
+        "back_text": "Entferne den beiseitegelegten Gegner Seth Bishop aus dem Spiel."
     },
     {
         "code": "02279",
-        "flavor": "As you ascend the hill, the environment around you grows increasingly strange and otherworldly. The arcane energy feels even stronger here, crackling in the air and crawling on your skin.",
-        "name": "Ascending the Hill (v. II)",
-        "text": "Clues cannot be placed on non-<i>Altered</i> locations.\n<b>Objective</b> - When an investigator enters Sentinel Peak, advance.",
-        "back_name": "Turn the Key",
-        "back_flavor": "Approaching the peak of Sentinel Hill, you are confronted by several citizens of Dunwich. The man in the center of their circle lets out a crazed laugh. You recognize the man - Seth Bishop - from the description given to you by the townsfolk earlier. Behind him, several other men and women bow their heads in reverence, chanting in Latin. \"We've done it!\" he cackles. \"We've accomplished what Old Whateley and 'is git couldn't!\" You watch in revulsion as his eyes glaze over and twitch, as though he were reading something invisible. \"I can see now… I can finally see!\" He raises his hands to the sky and the headstone of the altar behind him splits open. A torrent of energy pours out of the stone, coalescing into the form of an open gate. Seth holds onto the stone in front of him to prevent himself from being sucked into the gate, but several of the others are startled and pulled through it. You barely manage to dig your heels in and grab hold of a nearby rock in time to resist the pull of the gate. Seth rises to his feet, wearing an expression of pride.",
-        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak."
+        "flavor": "Als du den Hügel erklimmst, wird die Umgebung immer seltsamer und unwirklicher. Hier nimmst du die arkane Energie sogar noch deutlicher wahr, sie knistert in der Luft und kribbelt auf deiner Haut.",
+        "name": "Den Hügel besteigen (V. II)",
+        "text": "Auf Nicht-<i>Verändert</i>-Orte können keine Hinweise platziert werden.\n<b>Ermittlungsziel</b> - Sobald ein Ermittler den Gipfel des Sentinel Hill betritt, rücke vor..",
+        "back_name": "Drehe den Schlüssel",
+        "back_flavor": "Als du dich dem Gifpel des Sentinel Hill näherst, befinden sich dort bereits einige Einwohner von Dunwich. Der Mann in der Mitte des Kreises stößt ein wahnsinniges Lachen aus. Du erkennst den Mann anhand der Beschreibungen, die du von den Dorfbewohnern erhalten hast: Es ist Seth Bishop. Hinter ihm senken einige Männer und Frauen andächtig ihre Köpfe und singen etwas auf Latein. \"Wir haben es geschafft!\" stößt er kichernd hervor. \"Wir haben das geschafft, was der alte Whateley und seine Leute nicht vollbracht haben!\" Mit Abscheu siehst du seine Augen glasig werden und hin und her zucken, als ob er eine unsichtbare Schrift lesen würde.\"Jetzt kann ich sehen… ich kann endlich sehen!\" Er hebt seine Hände zum Himmel und der Schlussstein auf dem Altar hinter ihm spaltet sich. Ein Energiewirbel dringt aus dem Stein und nimmt die Form eines offenen Tores an- Seth klammert sich an den Stein vor ihm, um zu verhindern, das er hingezogen wird, aber einige der anderen Männer werden von dem Sog überrascht und hineingezogen. Du schaffst es mit Mühe, deine Fersen fest auf den Boden zu stemmen und dich an einen Felsen in der Nähe zu klammern, um dem Sog des Tores zu entgehen. Seth erhebt sich und sieht dich überheblich an. ",
+        "back_text": "Bringe den beiseitegelegten Gegner Seth Bishop auf dem Gipfel des Sentinel Hill ins Spiel."
     },
     {
         "code": "02280",
-        "flavor": "As you ascend the hill, the environment around you grows increasingly strange and otherworldly. The arcane energy feels even stronger here, crackling in the air and crawling on your skin.",
-        "name": "Ascending the Hill (v. III)",
-        "text": "Clues cannot be placed on non-<i>Altered</i> locations.\n<b>Objective</b> - When an investigator enters Sentinel Peak, advance.",
-        "back_name": "Will the Change",
-        "back_flavor": "Approaching the peak of Sentinel Hill, you are confronted by several citizens of Dunwich. The man in the center of their circle is desperately trying to complete a Latin incantation. \"It's not working, Seth!\" one of the other men cries out. \"What're we gonna do?\" The man in the center stops his chant and pulls out a cobbler's knife. \"The father demands a blood sacrifice,\" he declares, and his face twists into a crazed expression. Before you can react, he slits his left wrist with the knife, dropping to his knees in agony. The headstone of the altar behind him splits open. A torrent of energy pours out of the stone, coalescing into the form of an open gate. Seth holds onto the stone in front of him to prevent himself from being sucked into the gate, but several of the others are startled and pulled through it. You barely manage to dig your heels in and grab hold of a nearby rock in time to resist the pull of the gate. Seth rises, wounded but alive. An expression of pride spreads across his pained face.",
-        "back_text": "Put the set-aside Seth Bishop enemy into play at Sentinel Peak, with 1[per_investigator] damage on him."
+        "flavor": "Als du den Hügel erklimmst, wird die Umgebung immer seltsamer und unwirklicher. Hier nimmst du die arkane Energie sogar noch deutlicher wahr, sie knistert in der Luft und kribbelt auf deiner Haut.",
+        "name": "Den Hügel besteigen (V. II)",
+        "text": "Auf Nicht-<i>Verändert</i>-Orte können keine Hinweise platziert werden.\n<b>Ermittlungsziel</b> - Sobald ein Ermittler den Gipfel des Sentinel Hill betritt, rücke vor..",
+        "back_name": "Den Wandel wollen",
+        "back_flavor": "Als du dich dem Gifpel des Sentinel Hill näherst, befinden sich dort bereits einige Einwohner von Dunwich. Der Mann in der Mitte des Kreises versucht verzweifelt einen lateinischen Zauberspruch zu vollenden. \"Es funktioniert nicht, Seth!\", ruft einer der anderen Männer. \"Was sollen wir tun?\" Der Mann in der Mitte unterbricht seinen Gesang und zieht ein Schustermesser. \"Der Vater verlangt ein Blutopfer\", erklärt er mit einem fanatisch wirkenden Gesichtausdruck. Bevor du reagieren kannst, schneidet er sein linkes Handegelenk mit dem Messer auf und sinkt mit starken Schmerzen zu Boden. Der Schlussstein auf dem Altar hinter ihm spaltet sich. Ein Energiewirbel dringt aus dem Stein und nimmt die Form eines offenen Tores an. Seth klammert sich an dem Stein vor ihm, um zu verhindern, dass er hineingesogen wird, aber einige der anderen Männer werden von dem Sog überrascht und hineingezogen. Du schaffst es mit Mühe, deine Fersen fest auf den Boden zu stemmen und dich an einen Felsen in der Nähe zu klammern, um dem Sog des Tores zu entgehen. Dann steht Seth auf, verletzt aber am Leben. Hochmut liegt auf seinem schmerzverzerrten Gesicht.",
+        "back_text": "Bringe den beiseitegelegten Gegner Seth Bishop auf dem Gipfel des Sentinel Hill mit 1 [per_investigator] Schaden darauf ins Spiel."
     },
     {
         "code": "02281",
-        "flavor": "From the ruins of the headstone on the altar at the hill’s peak, a gateway of churning vibrant energy has appeared. A force like a hurricane erupts from the gate, bending trees and pulling debris into it. The howling of the gale drowns out all other sound. Somehow, you must find a way to close the gate.",
-        "name": "The Gate Opens",
-        "text": "<b>Objective</b> - Only investigators at Sentinel Peak may spend the requisite number of clues, as a group, to advance.",
-        "back_name": "Peer Into the Abyss",
-        "back_flavor": "You don't know how to close the swirling gate before you, and with each passing moment, the force from within it grows in strength. You fear that whatever entity the sorcerers have summoned from beyond approaches. With no time to spare, you turn to the open tome on the stone altar, desperate for answers.",
-        "back_text": "<b>(→R1)</b>"
+        "flavor": "Aus den Überresten des Schlusssteins auf dem Altar am Hügelgipfel hat sich ein Tor wirbelnder, pulsierender Energie geöffnet. Eine Macht mit der Stärke eines Orkans bricht aus dem Tor hervor, verbiegt die Bäume und saugt Geröll ein. Das Heulen des Windes übertönt alle anderen Geräusche. Du musst einen Weg finden, dieses Tor zu schließen.",
+        "name": "Das Tor öffnet sich",
+        "text": "<b>Ermittlungsziel</b> - Nur Ermittler auf dem Gipfel des Sentinel Hill können als Gruppe die benötigten Anzahl Hinweise ausgeben, um vorzurücken.",
+        "back_name": "Blick in den Abgrund",
+        "back_flavor": "Du hast keine Ahnung, wie man das wirbelnde Tor vor dir schließen kann, und mit jedem Moment nimmt die Kraft, die von ihm ausgeht, zu. Du fürchtest dich davor, was für eine Wesenheit, von Zauberern aus dem Jenseits beschworen, hinauskommen könnte. Dir bleibt keine Zeit. Du schlägst das Buch auf dem Steinaltar auf und suchst verzweifelt nach Antworten.",
+        "back_text": "<b>(?A1)</b>"
     },
     {
         "code": "02282",
-        "name": "Base of the Hill",
-        "text": "Base of the Hill is connected to each copy of Diverging Path.\n[action]: <b>Investigate.</b> If you succeed, instead of discovering clues, put a random set-aside Diverging Path into play. (Limit once per round.)\n[action]: <b>Resign.</b> \"This is more than I signed up for!\"",
+        "name": "Fuß des Hügels",
+        "text": "Der Fuß des Hügels ist mit jeder Kopie von Verzweigender Weg verbunden.\n[action]: <b>Ermitteln.</b> Falls die Probe gelingt, bringe, statt Hinweise zu entdecken, einen beiseitegelegten Verzweigender Weg ins Spiel. (Nur ein Mal pro Runde.)\n[action]: <b>Aufgeben.</b> \"Das ist schlimmer als alles, auf das ich mich vorbereitet habe!\"",
         "traits": "Dunwich. Sentinel Hill.",
-        "back_flavor": "The long slope of Sentinel Hill rises before you, cresting in the jagged edges of Sentinel Peak."
+        "back_flavor": "Der langgezogene Abhang des Sentinel Hill führt vor dir zu den gezackten Rändern seines Gipfels."
     },
     {
         "code": "02283",
-        "name": "Ascending Path",
-        "text": "Ascending Path is connected to each copy of Altered Path.\n[action]: <b>Investigate.</b> If you succeed, instead of discovering clues, put a random set-aside Altered Path into play. (Limit once per round.)",
+        "name": "Aufsteigender Pfad",
+        "text": "Der Aufsteigende Pfad ist mit jeder Kopie von Veränderter Weg verbunden.\n[action]: <b>Ermitteln.</b> Falls die Probe gelingt, bringe, statt Hinweise zu entdecken, einen beiseitegelegten Veränderter Weg ins Spiel. (Nur ein Mal pro Runde.)",
         "traits": "Dunwich. Sentinel Hill.",
-        "back_flavor": "When you try to follow the path leading further up Sentinel Hill, you somehow end up walking in a perpetual loop. Each time you stop to find your bearings, you find yourself back at the base of the hill again.",
-        "back_text": "The path leading further up the hill is masked. You cannot move into Ascending Path."
+        "back_flavor": "Als du versuchst, dem Weg zum Gipfel des Hügels zu folgen, bewegst du dich nur im Kreis. Jedes Mal, wenn du innehälst, befindest du dich wieder am Fuß des Hügels.",
+        "back_text": "Der Pfad zum Gipfel ist verborgen. Du kannst dich nicht zum Aufsteigenden Pfad bewegen."
     },
     {
         "code": "02284",
-        "flavor": "It is here that the Whateleys used to build their hellish fires and chant their hellish rituals…\n-H.P. Lovecraft, \"The Dunwich Horror\"",
-        "name": "Sentinel Peak",
-        "text": "<b>Forced</b> - When an investigator at this location draws a <i>Hex</i> card: That investigator takes 1 damage.",
+        "flavor": "Es war die Stelle, an der die Whateleys in der Walpurgisnacht und an Halloween ihre höllischen Feuer entzündet und bei dem tischähnlichen Stein ihre teuflischen Rituale durchgeführt hatten.\n-H.P. Lovecraft, \"Das Grauen von Dunwich\"",
+        "name": "Gipfel des Sentinel Hill",
+        "text": "<b>Erzwungen</b> - Sobald ein Ermittler an diesem Ort eine <i>Verwünschung</i>-Karte zieht: Dieser Ermittler nimmt 1 Schaden.",
         "traits": "Dunwich. Sentinel Hill.",
-        "back_flavor": "An arcane wall blocks the path further up the hill, leading towards the peak.",
-        "back_text": "As an additional cost to move to Sentinel Peak, the investigators must spend 2[per_investigator] clues, as a group"
+        "back_flavor": "Eine arkane Barriere versperrt den Weg weiter den Hügel hinauf zum Gipfel.",
+        "back_text": "Als zusätzliche Kosten, um sich auf den Gipfel des Sentinel Hill zu bewegen, müssen die Ermittler als Gruppe 2[per_investigator] Hinweise ausgeben."
     },
     {
         "code": "02285",
-        "name": "Slaughtered Woods",
-        "text": "<b>Forced</b> - After you reveal Slaughtered Woods: Take 2 horror if you have no actions remaining.",
-        "traits": "Dunwich. Woods.",
-        "back_name": "Diverging Path",
-        "back_flavor": "A path off the beaten trail leads deeper into the woods surrounding Sentinel Hill"
+        "name": "Niedergerissene Wälder",
+        "text": "<b>Erzwungen</b> - Nachdem du die Niedergerissenen Wälder enthüllt hast: Nimm 2 Horror, falls du keine verbliebene Aktion mehr hast.",
+        "traits": "Dunwich. Wälder.",
+        "back_name": "Verzweigender Weg",
+        "back_flavor": "Ein Pfad führt von den ausgetretenen Wegen tiefer in die Wälder rund um den Sentinel Hill."
     },
     {
         "code": "02286",
-        "flavor": "There are no sounds here. No leaves rustle, no birds chirp, and not even the wind can be heard.",
-        "name": "Eerie Glade",
-        "text": "<b>Forced</b> - After you reveal Eerie Glade: Discard the top 2 cards of your deck for each action you have remaining.",
-        "traits": "Dunwich. Woods.",
-        "back_name": "Diverging Path",
-        "back_flavor": "A path off the beaten trail leads deeper into the woods surrounding Sentinel Hill"
+        "flavor": "Um dich herum ist alles still. Keine rauschenden Blätter, keine zwitschernden Vögel, nicht einmal der Wind ist zu hören.",
+        "name": "Unheimliche Lichtung",
+        "text": "<b>Erzwungen</b> - Nachdem du die Unheimliche Lichtug enthüllt hast: Lege für jede deiner verbliebenden Aktionen die obersten 2 Karten deines Decks ab.",
+        "traits": "Dunwich. Wälder.",
+        "back_name": "Verzweigender Weg",
+        "back_flavor": "Ein Pfad führt von den ausgetretenen Wegen tiefer in die Wälder rund um den Sentinel Hill"
     },
     {
         "code": "02287",
-        "name": "Destroyed Path",
-        "text": "<b>Forced</b> - After you reveal Destroyed Path: Place 1[per_investigator] doom on it.\n[action]: <b>Investigate.</b> If you succeed, instead of discovering clues, remove 1 doom from Destroyed Path.",
-        "traits": "Dunwich. Woods.",
-        "back_name": "Diverging Path",
-        "back_flavor": "A path off the beaten trail leads deeper into the woods surrounding Sentinel Hill"
+        "name": "Zerstörter Weg",
+        "text": "<b>Erzwungen</b> - Nachdem du den Zerstörten Weg enthüllt hast: Platziere 1[per_investigator] Verderben darauf.\n[action]: <b>Ermitteln.</b> Falls die Probe gelingt, entferne, statt Hinweise zu entdecken, 1 Verderben vom Zerstörten Weg.",
+        "traits": "Dunwich. Wälder.",
+        "back_name": "Verzweigender Weg",
+        "back_flavor": "Ein Pfad führt von den ausgetretenen Wegen tiefer in die Wälder rund um den Sentinel Hill"
     },
     {
         "code": "02288",
-        "name": "Frozen Spring",
-        "text": "<b>Forced</b> - After you reveal Frozen Spring: Lose the remainder of your actions and immediately end your turn.",
-        "traits": "Dunwich. Woods.",
-        "back_name": "Diverging Path",
-        "back_flavor": "A path off the beaten trail leads deeper into the woods surrounding Sentinel Hill"
+        "name": "Gefrorene Quelle",
+        "text": "<b>Erzwungen</b> - Nachdem du die Gefrorene Quelle enthüllt hast: Du verlierst deine verbliebenen Aktionen und beendest sofort deinen Zug.",
+        "traits": "Dunwich. Wälder.",
+        "back_name": "Verzweigender Weg",
+        "back_flavor": "Ein Pfad führt von den ausgetretenen Wegen tiefer in die Wälder rund um den Sentinel Hill"
     },
     {
         "code": "02289",
-        "name": "Dimensional Gap",
-        "text": "<b>Forced</b> - After you reveal Dimensional Gap: Discard cards from the top of the encounter deck until an enemy is discarded. Spawn that enemy here (instead of its normal spawn location).",
-        "traits": "Dunwich. Woods. Altered.",
-        "back_name": "Altered Path",
-        "back_flavor": "A shiver courses up your spine as you step forth onto the path, its route touched by a bizarre arcane power."
+        "name": "Dimensionsriss",
+        "text": "<b>Erzwungen</b> - Nachdem du den Dimensionsriss enthüllt hast: Lege Karten oben vom Begegnungsdeck ab, bis ein gegner abgelegt wird. Dieser Gegner erscheint hier (statt an dem Ort, an dem er normalerweise erscheinen würde).",
+        "traits": "Dunwich. Wälder. Verändert.",
+        "back_name": "Veränderter Weg",
+        "back_flavor": "Ein Schauer läuft dir über den Rücken, als du den von einer bizarren arkanen Macht beleuchteten Pfad betrittst."
     },
     {
         "code": "02290",
-        "name": "A Tear in the Path",
-        "text": "<b>Forced</b> - After you reveal A Tear in the Path: Take 2 damage if you have no actions remaining.",
-        "traits": "Dunwich. Woods. Altered.",
-        "back_name": "Altered Path",
-        "back_flavor": "A shiver courses up your spine as you step forth onto the path, its route touched by a bizarre arcane power."
+        "name": "Ein Riss im Weg",
+        "text": "<b>Erzwungen</b> - Nachdem du Ein Riss im Weg enthüllt hast: Nimm 2 Schaden, falls du keine verbliebene Aktion mehr hast.",
+        "traits": "Dunwich. Wälder. Verändert.",
+        "back_name": "Veränderter Weg",
+        "back_flavor": "Ein Schauer läuft dir über den Rücken, als du den von einer bizarren arkanen Macht beleuchteten Pfad betrittst."
     },
     {
         "code": "02291",
-        "name": "Uprooted Woods",
-        "text": "<b>Forced</b> - After you reveal Uprooted Woods: Discard the top 5 cards of your deck if you have no actions remaining.",
-        "traits": "Dunwich. Woods. Altered.",
-        "back_name": "Altered Path",
-        "back_flavor": "A shiver courses up your spine as you step forth onto the path, its route touched by a bizarre arcane power."
+        "name": "Entwurzelte Wälder",
+        "text": "<b>Erzwungen</b> - Nachdem du die Entwurzelten Wälder enthüllt hast: Lege die obersten 5 Karten deines Decks ab, falls du keine verbliebene Aktion mehr hast.",
+        "traits": "Dunwich. Wälder. Verändert.",
+        "back_name": "Veränderter Weg",
+        "back_flavor": "Ein Schauer läuft dir über den Rücken, als du den von einer bizarren arkanen Macht beleuchteten Pfad betrittst."
     },
     {
         "code": "02292",
-        "flavor": "No… No, this shouldn't be here! This <b>can't</b> he here!",
-        "name": "Lost Memories",
-        "text": "<b>Forced</b> - After you reveal Lost Memories: Take 1 horror for each action you have remaining.",
-        "traits": "Dunwich. Woods. Altered.",
-        "back_name": "Altered Path",
-        "back_flavor": "A shiver courses up your spine as you step forth onto the path, its route touched by a bizarre arcane power."
+        "flavor": "Nein, das sollte nicht hier sein! Das kann nicht hier sein!",
+        "name": "Verlorene Erinnerungen",
+        "text": "<b>Erzwungen</b> - Nachdem du die Verlorenen Erinnerungen enthüllt hast: Nimm 1 Horror für jede deiner verbliebenen Aktionen.",
+        "traits": "Dunwich. Wälder. Verändert.",
+        "back_name": "Veränderter Weg",
+        "back_flavor": "Ein Schauer läuft dir über den Rücken, als du den von einer bizarren arkanen Macht beleuchteten Pfad betrittst."
     },
     {
         "code": "02293",
-        "flavor": "\"An' he says, says he, Mis' Corey, as haow he sot to look fer Seth's caows, frighted ez he was; an' faound 'em in the upper pasture nigh the Devil's Hop Yard in an awful shape. Haff on 'em's clean gone, an' nigh haff o' them that's left is sucked most dry o' blood, with sores on 'em…\n-H.P. Lovecraft, \"The Dunwich Horror\"",
+        "flavor": "\"Und er sagt, Mrs. Corey, dass er, obwohl er ich fürchtete, nach den Kühen gesucht habe und sie auf den oberen Weiden beim Tanzplatz des Teufels in einem schrecklichen Zustand gefunden hat. Die Hälfte von ihnen war schon tot, und der anderen Hälfte war fast das ganze Blut ausgesaugt, und sie hatten Schnitte wie das Vieh der Whateleys, seitdem Lavinia die schwarze Brut geboren hatte.\n-H.P. Lovecraft, \"Das Grauen von Dunwich\"",
         "name": "Seth Bishop",
-        "subname": "Sorcerer of Dunwich",
-        "text": "Retaliate.",
-        "traits": "Humanoid. Sorcerer. Elite."
+        "subname": "Zauberer aus Dunwich",
+        "text": "Zurückschlagen.",
+        "traits": "Humanoid. Zauberer. Elite."
     },
     {
         "code": "02294",
-        "name": "Devotee of the Key",
-        "text": "<b>Spawn</b> - Base of the Hill.\n<b>Forced</b> - At the end of the enemy phase, Devotee of the Key moves once toward Sentinel Peak. If Devotee of the Key is already at Sentinel Peak, discard it and add 2 doom to the current agenda, instead.",
-        "traits": "Humanoid. Sorcerer."
+        "name": "Anhänger des Schlüssels",
+        "text": "<b>Erscheinen</b> - Fuß des Hügels.\n<b>Erzwungen</b> - Am Ende der Gegnerphase bewegt sich Anhänger des Schlüssels ein Mal in Richtung Gipfel des Sentinel Hill. Falls sich Anhänger des Schlüssels bereits auf dem Gipfel des Sentinel Hill befindet, lege ihn ab und füge stattdessen der aktuellen Agenda 2 Verderben hinzu.",
+        "traits": "Humanoid. Zauberer."
     },
     {
         "code": "02295",
-        "name": "Crazed Shoggoth",
-        "text": "<b>Spawn</b> - Nearest <i>Altered</i> location.\n<b>Forced</b> - When Crazed Shoggoth attacks: If this attack would defeat an investigator, that investigator is instead killed.",
-        "traits": "Monster. Shoggoth."
+        "name": "Rasender Shoggothe",
+        "text": "<b>Erscheinen</b> - Nächster <i>Verändert</i>-Ort.\n<b>Erzwungen</b> - Sobald Rasender Shoggothe angreift: Falls dieser Angriff einen Ermittler besiegen würde, wird dieser Ermittler stattdessen getötet.",
+        "traits": "Monster. Shoggothe."
     },
     {
         "code": "02296",
-        "name": "Rites Howled",
-        "text": "<b>Revelation</b> - Discard the top 3 cards of each investigator's deck. Each investigator at an <i>Altered</i> location shuffles each weakness in his or her discard pile into his or her deck.",
-        "traits": "Hex."
+        "name": "Geheulte Rituale",
+        "text": "<b>Enthüllung</b> - Lege die obersten 3 Karten des Decks jedes Ermittlers ab. Jeder Ermittler an einem <i>Verändert</i>-Ort mischt jede Schwäche in seinem Ablagestapel in sein Deck.",
+        "traits": "Verwünschung."
     },
     {
         "code": "02297",
-        "name": "Spaces Between",
-        "text": "<b>Revelation</b> - Flip each non-<i>Sentinel Hill</i> location in play to its unrevealed side, removing all clues from it. Each investigator and enemy at a location flipped in this way immediately moves to the nearest <i>Sentinel Hill</i> location. Shuffle each non-<i>Sentinel Hill </i>location, so the players do not know which is which.",
-        "traits": "Hex. Hazard."
+        "name": "Der Raum dazwischen",
+        "text": "<b>Enthüllung</b> - Drehe jeden Nicht-<i>Sentinel Hill</i>-Ort auf seine verhüllte Seite und entferne dabei alle Hinweise von ihnen. Jeder Ermittler und Gegner an so einem so umgedrehten Ort bewegt sich sofort auf den nächstgelegenen <i>Sentinel Hill</i>-Ort. Mische alle Nicht-<i>Sentinel Hill</i>-Orte, sodass die Spieler nicht erkennen können, welcher Ort welcher ist.",
+        "traits": "Verwünschung. Gefahr."
     },
     {
         "code": "02298",
-        "name": "Vortex of Time",
-        "text": "<b>Revelation</b> - Each investigator at a <i>Sentinel Hill</i> location tests [willpower] (4). Each investigator who fails takes 2 damage.",
-        "traits": "Hex. Hazard."
+        "name": "Zeitwirbel",
+        "text": "<b>Enthüllung</b> - Jeder Ermittler an einem <i>Sentinel Hill</i>-Ort legt eine [willpower]-Probe (4) ab. Jeder Ermittler, dessen Probe misslingt, nimmt 2 Schaden.",
+        "traits": "Verwünschung. Gefahr."
     }
 ]

--- a/translations/de/pack/ptc/bsr.json
+++ b/translations/de/pack/ptc/bsr.json
@@ -1,29 +1,29 @@
 [
     {
         "code": "03266",
-        "name": "Arcane Insight",
-        "text": "Uses (3 charges).\n[free] While an investigator is taking his or her turn, spend 1 charge: Your location gets -2 shroud until the end of this turn. (Limit once per turn.)",
-        "traits": "Spell.",
-        "slot": "Arcane"
+        "name": "Arkane Einsicht",
+        "text": "Anwendungen (3 Ladungen).\n[free] Solange ein Ermittler seinen Zug nimmt, gib 1 Ladung aus: Dein Ort bekommt bis zum Ende dieses Zuges -2 Schleier. (Nur ein Mal pro Zug.)",
+        "traits": "Zauber.",
+        "slot": "Arkan"
     },
     {
         "code": "03268",
         "name": "Suggestion",
-        "text": "Uses (3 charges).\n[action] Exhaust Suggestion: <b>Evade.</b> Add your [willpower] value to your skill value for this evasion attempt. If you do not succeed by at least 2, remove 1 charge from Suggestion.\n[reaction] When a non-<i>Elite</i> enemy would attack you, spend 1 charge: Cancel that attack.",
-        "traits": "Spell.",
-        "slot": "Arcane"
+        "text": "Anwendungen (3 Ladungen).\n[action] Erschöpfe Suggestion: <b>Entkommen.</b> Füge deinem Fertigkeitswert für diesen Entkommen-Versuch deinen  [willpower]-Wert hinzu. Falls die Probe nicht um mindestens 2 gelingt, entferne 1 Ladung von Suggestion.\n[reaction] Sobald dich ein Nicht-<i>Elite</i> Gegner angreifen würde, gib 1 Ladung aus: Hebe diesen Angriff auf.",
+        "traits": "Zauber.",
+        "slot": "Arkan"
     },
     {
         "code": "03271",
-        "name": "Arcane Initiate",
-        "text": "<b>Forced</b> - After Arcane Initiate enters play: Place 1 doom or 2 horror on it.\n[free] Exhaust Arcane Initiate: Search the top 3 cards of your deck for a <i>Spell</i> card and draw it. Shuffle your deck.",
-        "traits": "Ally. Sorcerer.",
-        "slot": "Ally"
+        "name": "Eingeweihte der arkanen Künste",
+        "text": "<b>Erzwungen</b> - Nachdem Eingeweihte der arkanen Künste ins Spiel gekommen ist: Platziere 1 Verderben oder 2 Horror auf sie.\n[free] Erschöpfe Eingeweihte der arkanen Künste: Durchsuche die obersten 3 Karten deines Decks nach einer <i>Zauber</i>-Karte und ziehe sie. Mische dein Deck.",
+        "traits": "Verbündeter. Zauberer.",
+        "slot": "Verbündeter"
     },
     {
         "code": "03272",
-        "name": "\"Not without a fight!\"",
-        "text": "Commit to a skill test only if you are engaged with an enemy.\nFor each enemy engaged with you, \"Not without a fight!\" gains [willpower] [combat] [agility].",
-        "traits": "Innate."
+        "name": "\"Nicht ohne einen Kampf!\"",
+        "text": "Trage diese Karte nur zu einer Fertigkeitsprobe bei, falls du mit einem Gegner in einem Kampf verwickelt bist.\nFür jeden Gegner, der mit dir in einen Kampf verwickelt ist, erhält \"Nicht ohne einen Kampf!\" [willpower] [combat] [agility].",
+        "traits": "Angeboren."
     }
 ]

--- a/translations/de/pack/ptc/eotp.json
+++ b/translations/de/pack/ptc/eotp.json
@@ -1,92 +1,92 @@
 [
     {
         "code": "03106",
-        "name": "Heroic Rescue",
-        "text": "Fast. Play when a non-<i>Elite</i> enemy would attack another investigator at your location.\nEngage that enemy and resolve its attack against you instead. Then, deal it 1 damage.",
-        "traits": "Spirit. Tactic."
+        "name": "Heldenhafte Rettung",
+        "text": "Schnell. Spiele diese Karte, sobald ein Nicht-<i>Elite</i>-Gegner einen anderen Ermittler an deinem Ort angreifen würde.\nVerwickel diesen Gegner in einen Kampf und handle diesen Angriff stattdessen gegen dich ab. Füge ihm dann 1 Schaden zu.",
+        "traits": "Geist. Taktik."
     },
     {
         "code": "03107",
-        "name": "Combat Training",
-        "text": "Fast. Limit 1 <i>Composure</i> in play.\nNon-direct horror must be assigned to Combat Training before it can be assigned to your investigator card.\n[free] Spend 1 resource: You get +1 [combat] for this skill test.\n[free] Spend 1 resource: You get +1 [agility] for this skill test.",
-        "traits": "Talent. Composure."
+        "name": "Kampftraining",
+        "text": "Schnell. Nur 1 <i>Gelassenheit</i> im Spiel.\nNicht-direkter Horror muss Kampftraining zugewiesen werden, bevor er deiner Ermittlerkarte zugewiesen werden kann.\n[free] Gib 1 Ressource aus: Du bekommst +1 [combat] für diese Fertigkeitsprobe.\n[free] Gib 1 Ressource aus: Du bekommst +1 [agility] für diese Fertigkeitsprobe.",
+        "traits": "Talent. Gelassenheit."
     },
     {
         "code": "03108",
-        "flavor": "They are just animals like any other. Or so we thought.",
-        "name": "Anatomical Diagrams",
-        "text": "Fast. Play during any investigator's turn. Play only if you have 5 or more remaining sanity.\nChoose a non-<i>Elite</i> enemy at your location. Until the end of the active investigator's turn, that enemy gets -2 fight and -2 evade.",
-        "traits": "Insight."
+        "flavor": "Sie sind nur ganz normale Tiere. Zumindest dachten wir das.",
+        "name": "Anatomisches Schaubild",
+        "text": "Schnell. Spiele diese Karte im Zug eines beliebigen Ermittlers. Spiele diese Karte nur, falls du 5 oder mehr verbliebene geistige Gesundheit hast.\nWähle einen Nicht-<i>Elite</i>-Gegner an deinem Ort. Bis zum Ende des Zuges des aktiven Ermittlers bekommt dieser Gegner -2 Kampf und -2 Entkommen.",
+        "traits": "Erkenntnis."
     },
     {
         "code": "03109",
-        "name": "Scientific Theory",
-        "text": "Fast. Limit 1 <i>Composure</i> in play.\nNon-direct horror must be assigned to Scientific Theory before it can be assigned to your investigator card.\n[free] Spend 1 resource: You get +1 [intellect] for this skill test.\n[free] Spend 1 resource: You get +1 [combat] for this skill test.",
-        "traits": "Talent. Composure."
+        "name": "Wissenschaftliche Theorie",
+        "text": "Schnell. Nur 1 <i>Gelassenheit</i> im Spiel.\nNicht-direkter Horror muss Wissenschaftliche Theorie zugewiesen werden, bevor er deiner Ermittlerkarte zugewiesen werden kann.\n[free] Gib 1 Ressource aus: Du bekommst +1 [intellect] für diese Fertigkeitsprobe.\n[free] Gib 1 Ressource aus: Du bekommst +1 [combat] für diese Fertigkeitsprobe.",
+        "traits": "Talent. Gelassenheit."
     },
     {
         "code": "03110",
-        "flavor": "Up close and personal:\njust the way Naomi liked it.",
-        "name": "Knuckleduster",
-        "text": "[action]: <b>Fight.</b> This attack deals +1 damage. The attacked enemy gains retaliate for this attack.",
-        "traits": "Item. Weapon. Melee. Illicit.",
+        "flavor": "Aus nächster Nähe und persönlich:\nGenau wie Naomi es mag.",
+        "name": "Schlagring",
+        "text": "[action]: <b>Kampf.</b> Dieser Angriff fügt +1 Schaden zu. Der angegriffene Gegner erhält für diesen Angriff Zurückschlagen.",
+        "traits": "Gegenstand. Waffe. Nahkampf. Illegal.",
         "slot": "Hand"
     },
     {
         "code": "03111",
-        "name": "Moxie",
-        "text": "Fast. Limit 1 <i>Composure</i> in play.\nNon-direct horror must be assigned to Moxie before it can be assigned to your investigator card.\n[free] Spend 1 resource: You get +1 [willpower] for this skill test.\n[free] Spend 1 resource: You get +1 [agility] for this skill test.",
-        "traits": "Talent. Composure."
+        "name": "Tatkraft",
+        "text": "Schnell. Nur 1 <i>Gelassenheit</i> im Spiel.\nNicht-direkter Horror muss Tatkraft zugewiesen werden, bevor er deiner Ermittlerkarte zugewiesen werden kann.\n[free] Gib 1 Ressource aus: Du bekommst +1 [willpower] für diese Fertigkeitsprobe.\n[free] Gib 1 Ressource aus: Du bekommst +1 [agility] für diese Fertigkeitsprobe.",
+        "traits": "Talent. Gelassenheit."
     },
     {
         "code": "03112",
         "name": "David Renfield",
-        "subname": "Esteemed Eschatologist",
-        "text": "While David Renfield has at least 1 doom on him, you get +1 [willpower].\n[fast] Exhaust David Renfield: You may place 1 doom on David Renfield. Gain 1 resource for each doom on David Renfield.",
-        "traits": "Ally. Patron.",
-        "slot": "Ally"
+        "subname": "Angesehender Eschatologe",
+        "text": "Solange sich mindestens 1 Verderben auf David Renfield befindet, bekommst du +1  [willpower].\n[free] Erschöpfe David Renfield: Du darfst 1 Verderben auf David Renfield platzieren. Du erhälst 1 Ressource für jedes Verderben auf David Renfield.",
+        "traits": "Verbündeter. Mäzen.",
+        "slot": "Verbündeter"
     },
     {
         "code": "03113",
-        "name": "Grounded",
-        "text": "Fast. Limit 1 <i>Composure</i> in play.\nNon-direct horror must be assigned to Grounded before it can be assigned to your investigator card.\n[free] During a skill test on a <i>Spell</i> card, spend 1 resource: You get +1 skill value for this test.",
-        "traits": "Talent. Composure."
+        "name": "In sich ruhend",
+        "text": "Schnell. Nur 1 <i>Gelassenheit</i> im Spiel.\nNicht-direkter Horror muss In sich ruhend zugewiesen werden, bevor er deiner Ermittlerkarte zugewiesen werden kann.\n[free] Gib während einer Fertigkeitsprobe auf einer  <i>Zauber</i>-Karte 1 Ressource aus: Du bekommst +1 auf deinen Fertigkeitswert für diese Probe.",
+        "traits": "Talent. Gelassenheit."
     },
     {
         "code": "03114",
-        "flavor": "Mr. Pawterson always told Wendy things would turn out okay. But then again, Mr. Pawterson was a teddy bear, and he didn't know any better.",
-        "name": "Cherished Keepsake",
-        "traits": "Item. Charm.",
-        "slot": "Accessory"
+        "flavor": "Mr. Pawterson hatte Wendy immer gesagt, dass alles gut werden würde. Aber Mr. Pawterson war auch nur ein Teddybär und wusste es nicht besser.",
+        "name": "Geschätztes Andenken",
+        "traits": "Gegenstand. Glücksbringer.",
+        "slot": "Zubehör"
     },
     {
         "code": "03115",
-        "name": "Plucky",
-        "text": "Fast. Limit 1 <i>Composure</i> in play.\nNon-direct horror must be assigned to Plucky before it can be assigned to your investigator card.\n[free] Spend 1 resource: You get +1 [willpower] for this skill test.\n[free] Spend 1 resource: You get +1 [intellect] for this skill test.",
-        "traits": "Talent. Composure."
+        "name": "Beherzt",
+        "text": "Fast. Limit 1 <i>Gelassenheit</i> im Spiel.\nNicht-direkter Horror muss Beherzt zugewiesen werden, bevor er deiner Ermittlerkarte zugewiesen werden kann.\n[free] Gib 1 Ressource aus: Du bekommst +1 [willpower] für diese Fertigkeitsprobe.\n[free] Gib 1 Ressource aus: Du bekommst +1 [intellect] für diese Fertigkeitsprobe.",
+        "traits": "Talent. Gelassenheit."
     },
     {
         "code": "03116",
-        "name": "Say Your Prayers",
-        "text": "Max 1 committed per skill test.\nCommit to a skill test only if you have 3 or fewer remaining sanity.",
-        "traits": "Desperate."
+        "name": "Sprich dein Gebet",
+        "text": "Max. 1 pro Fertigkeitsprobe beitragen.\nTrage diese Karte nur zu einer Fertigkeitsprobe bei, falls du 3 oder weniger verbliebene geistige Gesundheit hast.",
+        "traits": "Verzweifelt."
     },
     {
         "code": "03117",
-        "name": "Desperate Search",
-        "text": "Max 1 committed per skill test.\nCommit to a skill test only if you have 3 or fewer remaining sanity.",
-        "traits": "Desperate."
+        "name": "Verzweifelte Suche",
+        "text": "Max. 1 pro Fertigkeitsprobe beitragen.\nTrage diese Karte nur zu einer Fertigkeitsprobe bei, falls du 3 oder weniger verbliebene geistige Gesundheit hast.",
+        "traits": "Verzweifelt."
     },
     {
         "code": "03118",
-        "name": "Reckless Assault",
-        "text": "Max 1 committed per skill test.\nCommit to a skill test only if you have 3 or fewer remaining sanity.",
-        "traits": "Desperate."
+        "name": "Waghalsiger Angriff",
+        "text": "Max. 1 pro Fertigkeitsprobe beitragen.\nTrage diese Karte nur zu einer Fertigkeitsprobe bei, falls du 3 oder weniger verbliebene geistige Gesundheit hast.",
+        "traits": "Verzweifelt."
     },
     {
         "code": "03119",
-        "name": "Run For Your Life",
-        "text": "Max 1 committed per skill test.\nCommit to a skill test only if you have 3 or fewer remaining sanity.",
-        "traits": "Desperate."
+        "name": "Lauf um dein Leben",
+        "text": "Max. 1 pro Fertigkeitsprobe beitragen.\nTrage diese Karte nur zu einer Fertigkeitsprobe bei, falls du 3 oder weniger verbliebene geistige Gesundheit hast.",
+        "traits": "Verzweifelt."
     }
 ]


### PR DESCRIPTION
Added a German translation of the Dunwich cycle and a bit of Carcosa. Also fixed German slot names for core box.

This translation is the effort of a few committed players from the German Asmodee forum. I only volunteered for the GitHub part of the project. We hope this will be accepted soon, so ArkhamDB will be of more use to the German AH TCG community.