### PR TITLE
Play data on scenario cards missing easy/standard/hard/expert text

### DIFF
--- a/pack/dwl/bota_encounter.json
+++ b/pack/dwl/bota_encounter.json
@@ -1,6 +1,6 @@
 [
     {
-	"back_text": "[skull]: -1 for each location in play with no encounter card underneath it.\n[cultist]: -4. If you fail, add 1 clue from the token pool to your location.\n[tablet]: -3. Reveal another token.\n[elder_thing]: -3. Place 1 doom on the current agenda.",
+	"back_text": "<b>Hard / Expert</b>\n[skull]: -1 for each location in play with no encounter card underneath it.\n[cultist]: -4. If you fail, add 1 clue from the token pool to your location.\n[tablet]: -3. Reveal another token.\n[elder_thing]: -3. Place 1 doom on the current agenda.",
 	"code": "02195",
 	"double_sided": true,
 	"encounter_code": "blood_on_the_altar",
@@ -9,7 +9,7 @@
 	"pack_code": "bota",
 	"position": 195,
 	"quantity": 1,
-	"text": "[skull]: -1 for each location in play with no encounter card underneath it (max -4).\n[cultist]: -2. If you fail, add 1 clue from the token pool to your location.\n[tablet]: -2. If you are in the Hidden Chamber, reveal another token.\n[elder_thing]: -3. If you fail, place 1 doom on the current agenda.",
+	"text": "<b>Easy / Standard</b>\n[skull]: -1 for each location in play with no encounter card underneath it (max -4).\n[cultist]: -2. If you fail, add 1 clue from the token pool to your location.\n[tablet]: -2. If you are in the Hidden Chamber, reveal another token.\n[elder_thing]: -3. If you fail, place 1 doom on the current agenda.",
 	"type_code": "scenario"
     },
     {

--- a/pack/dwl/tece_encounter.json
+++ b/pack/dwl/tece_encounter.json
@@ -1,6 +1,6 @@
 [
     {
-        "back_text": "[skull]: -X. X is 1 more than the current Agenda #. \n[cultist]: Reveal another token. If you fail and it is your turn, lose all remaining actions and end your turn immediately.\n[tablet]: -4. Add 1 doom token to each Cultist enemy in play.\n[elder_thing]: -3. If you fail, choose and discard a card from your hand for each point you failed by.",
+        "back_text": "<b>Hard / Expert</b>\n[skull]: -X. X is 1 more than the current Agenda #. \n[cultist]: Reveal another token. If you fail and it is your turn, lose all remaining actions and end your turn immediately.\n[tablet]: -4. Add 1 doom token to each Cultist enemy in play.\n[elder_thing]: -3. If you fail, choose and discard a card from your hand for each point you failed by.",
         "code": "02159",
         "double_sided": true,
         "encounter_code": "essex_county_express",
@@ -10,7 +10,7 @@
         "pack_code": "tece",
         "position": 159,
         "quantity": 1,
-        "text": "[skull]: -X. X is the current Agenda #.\n[cultist]: -1. If you fail and it is your turn, lose all remaining actions and end your turn immediately.\n[tablet]: -2. Add 1 doom token to the nearest Cultist enemy.\n[elder_thing]: -3. If you fail, choose and discard a card from your hand.",
+        "text": "<b>Easy / Standard</b>\n[skull]: -X. X is the current Agenda #.\n[cultist]: -1. If you fail and it is your turn, lose all remaining actions and end your turn immediately.\n[tablet]: -2. Add 1 doom token to the nearest Cultist enemy.\n[elder_thing]: -3. If you fail, choose and discard a card from your hand.",
         "type_code": "scenario"
     },
     {

--- a/pack/dwl/tmm_encounter.json
+++ b/pack/dwl/tmm_encounter.json
@@ -1,6 +1,6 @@
 [
     {
-        "back_text": "[skull]: -2 (-4 instead if Hunting Horror is at your location.)\n[cultist]: -3. If you fail, search the encounter deck, discard pile, and the void for Hunting Horror and spawn it at your location, if able.\n[tablet]: -4. If Hunting Horror is at your location, it immediately attacks you.\n[elder_thing]: -5. If you fail, discard an asset you control.",
+        "back_text": "<b>Hard / Expert</b>\n[skull]: -2 (-4 instead if Hunting Horror is at your location.)\n[cultist]: -3. If you fail, search the encounter deck, discard pile, and the void for Hunting Horror and spawn it at your location, if able.\n[tablet]: -4. If Hunting Horror is at your location, it immediately attacks you.\n[elder_thing]: -5. If you fail, discard an asset you control.",
         "code": "02118",
         "double_sided": true,
         "encounter_code": "the_miskatonic_museum",
@@ -10,7 +10,7 @@
         "pack_code": "tmm",
         "position": 118,
         "quantity": 1,
-        "text": "[skull]: -1 (-3 instead if Hunting Horror is at your location.)\n[cultist]: -1. If you fail, search the encounter deck, discard pile, and the void for Hunting Horror and spawn it at your location, if able.\n[tablet]: -2. Return 1 of your clues to your current location.\n[elder_thing]: -3. If you fail, discard an asset you control.",
+        "text": "<b>Easy / Standard</b>\n[skull]: -1 (-3 instead if Hunting Horror is at your location.)\n[cultist]: -1. If you fail, search the encounter deck, discard pile, and the void for Hunting Horror and spawn it at your location, if able.\n[tablet]: -2. Return 1 of your clues to your current location.\n[elder_thing]: -3. If you fail, discard an asset you control.",
         "type_code": "scenario"
     },
     {

--- a/pack/dwl/uau_encounter.json
+++ b/pack/dwl/uau_encounter.json
@@ -1,6 +1,6 @@
 [
 	{
-		"back_text": "[skull]: -2 for each Brood of Yog-Sothoth in play.\n[cultist]: Reveal another token. If you fail this test, take 1 horror and 1 damage.\n[tablet]: 0. You must either remove all clue tokens from a Brood of Yog-Sothoth in play, or this test automatically fails.\n[elder_thing]: -5. If this token is revealed during an attack or evasion attempt against a Brood of Yog-Sothoth, it immediately attacks you.",
+		"back_text": "<b>Hard / Expert</b>\n[skull]: -2 for each Brood of Yog-Sothoth in play.\n[cultist]: Reveal another token. If you fail this test, take 1 horror and 1 damage.\n[tablet]: 0. You must either remove all clue tokens from a Brood of Yog-Sothoth in play, or this test automatically fails.\n[elder_thing]: -5. If this token is revealed during an attack or evasion attempt against a Brood of Yog-Sothoth, it immediately attacks you.",
 		"code": "02236",
 		"double_sided": true,
 		"encounter_code": "undimensioned_and_unseen",
@@ -10,7 +10,7 @@
 		"pack_code": "uau",
 		"position": 236,
 		"quantity": 1,
-		"text": "[skull]: -1 for each Brood of Yog-Sothoth in play.\n[cultist]: Reveal another token. If you fail this test, take 1 horror.\n[tablet]: 0. You must either remove all clue tokens from a Brood of Yog-Sothoth in play, or this token's modifier is -4 instead.\n[elder_thing]: -3. If this token is revealed during an attack or evasion attempt against a Brood of Yog-Sothoth, it immediately attacks you.",
+		"text": "<b>Easy / Standard</b>\n[skull]: -1 for each Brood of Yog-Sothoth in play.\n[cultist]: Reveal another token. If you fail this test, take 1 horror.\n[tablet]: 0. You must either remove all clue tokens from a Brood of Yog-Sothoth in play, or this token's modifier is -4 instead.\n[elder_thing]: -3. If this token is revealed during an attack or evasion attempt against a Brood of Yog-Sothoth, it immediately attacks you.",
 		"type_code": "scenario"
 	},
 	{


### PR DESCRIPTION
Found 4 scenarios cards that were missing the Easy/Standard + Hard/Expert designations in their play data.  All the other scenario cards seemed to follow this pattern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kamalisk/arkhamdb-json-data/267)
<!-- Reviewable:end -->
