### PR TITLE
Fix type of poison so it can be added to decks

### DIFF
--- a/pack/tfa/tfa_encounter.json
+++ b/pack/tfa/tfa_encounter.json
@@ -1030,7 +1030,7 @@
 		"deck_limit": 1,
 		"encounter_code": "poison",
 		"encounter_position": 3,
-		"faction_code": "mythos",
+		"faction_code": "neutral",
 		"illustrator": "Rafał Hrynkiewicz",
 		"name": "Poisoned",
 		"pack_code": "tfa",


### PR DESCRIPTION
Was marked as mythos, but seems like it should be neutral.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kamalisk/arkhamdb-json-data/269)
<!-- Reviewable:end -->
