### PR TITLE
Add back_name and back_flavor to bota/tece encounters

### DIFF
--- a/pack/dwl/bota_encounter.json
+++ b/pack/dwl/bota_encounter.json
@@ -14,6 +14,7 @@
     },
     {
 	"back_flavor": "Whippoorwills gather along the gambrel roofs of Dunwich and begin to shriek in jubilation. The people of Dunwich believe that the presence of whippoorwills foreshadows somebody’s imminent death. Do they long for your death? Or is the victim someone else?",
+	"back_name": "First Blood",
 	"back_text": "If there are 3 or more potential sacrifices, choose one of them at random and place it underneath the agenda deck, without looking at it.",
 	"code": "02196",
 	"doom": 6,
@@ -31,13 +32,14 @@
 	"type_code": "agenda"
     },
     {
-	"back_flavor": "More whippoorwills flock to Dunwich village as the night progresses. The other townsfolk, notoriously superstitious, are terrified by the birds’ presence. With the doors around you shut and locked, you find yourself alone in the streets of Dunwich.",	
+	"back_flavor": "More whippoorwills flock to Dunwich village as the night progresses. The other townsfolk, notoriously superstitious, are terrified by the birds’ presence. With the doors around you shut and locked, you find yourself alone in the streets of Dunwich.",
+  "back_name": "Abandoned Streets",
 	"back_text": "\nIf there are 2 or more potential sacrifices, choose one of them at random and place it underneath the agenda deck, without looking at it.",
 	"code": "02197",
 	"doom": 6,
 	"double_sided": true,
 	"encounter_code": "blood_on_the_altar",
-	"encounter_position": 3,	
+	"encounter_position": 3,
 	"faction_code": "mythos",
 	"flavor": "As the sun sets, the frightened townsfolk retreat into their homes and lock their doors. It is clear to you that many of them know more than they are letting on. A sickening feeling turns over in your stomach as the village’s true nature becomes clear.",
 	"illustrator": "Rafał Hrynkiewicz",
@@ -50,6 +52,7 @@
     },
     {
 	"back_flavor": "The whippoorwills that have been cawing through the night scatter in unison, as if they are somehow satisfied with the turn of events.",
+  "back_name": "Blood on the Altar",
 	"back_text": "Each investigator must immediately resign.",
 	"code": "02198",
 	"doom": 7,
@@ -68,8 +71,9 @@
     },
     {
 	"back_flavor": "You find your way into the hidden chamber where you believe the missing folk are being held, but the horrors that confront you there fray the edges of your sanity. Bound by chains in a secluded corner of the room is an unspeakable creature with the face of a man. It wheezes and wrestles to free itself as it notices your entrance. The many mouths covering the creature’s body are covered in blood and gristles of meat, as though it were feeding recently.\nWith a hideous croak, the creature speaks with seven mouths.\"Ss... se... eth...?\" Then it lurches forward as though to grab you, and several of its chains snap.",
+  "back_name": "What Was Hidden",
 	"back_text": "Reveal each unrevealed location. \nMove all clues in play (including those on each investigator) to The Hidden Chamber.\nSpawn the set-aside Silas Bishop enemy in The Hidden Chamber.",
-	"clues": null, 
+	"clues": null,
 	"code": "02199",
 	"double_sided": true,
 	"encounter_code": "blood_on_the_altar",
@@ -87,8 +91,9 @@
     },
     {
 	"back_flavor": "Despite the danger, you brave the beast's horrifying presence and investigate further before killing it. What you find confirms your worst suspicions. Several journal entries written by a \"Seth Bishop\" describe the process of feeding the creature in horrifying detail - tomatoes at first, then small game, then cattle, and then finally 'human sacrifices'. But the most disturbing part is that Seth calls the creature by name: 'Silas.'",
+  "back_name": "Banishing the Creature",
 	"back_text": "If The Necronomicon is in play: <b>(→R2)\n</b>Otherwise: <b>(→R3)</b>",
-	"clues": null, 
+	"clues": null,
 	"code": "02200",
 	"double_sided": true,
 	"encounter_code": "blood_on_the_altar",
@@ -486,7 +491,7 @@
     {
 	"code": "02221",
 	"encounter_code": "blood_on_the_altar",
-	"encounter_position": 29,    
+	"encounter_position": 29,
 	"faction_code": "mythos",
 	"illustrator": "Stanislav Dikolenko",
 	"name": "Psychopomp's Song",

--- a/pack/dwl/tece_encounter.json
+++ b/pack/dwl/tece_encounter.json
@@ -14,6 +14,8 @@
         "type_code": "scenario"
     },
     {
+        "back_flavor": "The rearmost car of the train detaches as it is pulled backwards. To your horror, it rises off the tracks and is consumed by the gate above you.",
+        "back_name": "Keep Moving!",
         "back_text": "Remove the leftmost location from the game (or place it in the victory display if it has Victory X and no clues on it). Each investigator at that location is defeated. Each enemy and asset at that location is discarded.\nDiscard all clues controlled by the investigators.",
         "code": "02160",
         "doom": 4,
@@ -31,6 +33,8 @@
         "type_code": "agenda"
     },
     {
+        "back_flavor": "The next rain car is ripped backwards with violent foce. A middle-aged man hangs from his fingertips as the car flies unhindered toward the rift. In moments, the car is consumed whole, and the man lets go rather than be pulled into the void. He starts to fall, but is caught by the rift's force and pulled inside it anyway.",
+        "back_name": "Don't Stop!",
         "back_text": "Remove the leftmost location from the game (or place it in the victory display if it has Victory X and no clues on it). Each investigator at that location is defeated. Each enemy and asset at that location is discarded.\nDiscard all clues controlled by the investigators.",
         "code": "02161",
         "doom": 3,
@@ -47,6 +51,8 @@
         "type_code": "agenda"
     },
     {
+        "back_flavor": "Two of the train cars closest to the gate are severed from the rest of the train by a sheet of impossibly hot steam, which slices through metal like a knife through butter. The cars are sucked upwards and fly into the gate. Something above the train lets out a terrible screech, though to your ears it is like the shrill sound of a broken steam pipe.",
+        "back_name": "It's Getting Faster!",
         "back_text": "Remove each of the two leftmost locations from the game (or place it in the victory display if either one has Victory X and no clues on it). Each investigator at those locations is defeated. Each enemy and asset at those locations is discarded.\nDiscard all clues controlled by the investigators.",
         "code": "02162",
         "doom": 4,
@@ -63,6 +69,8 @@
         "type_code": "agenda"
     },
     {
+        "back_flavor": "The two rearmost train cars begin to melt as they are filled with superheated steam. The metal warps, and the passengers inside sream in agony. The cars are ripped from the train tracks along with rail slats and chunks of the bridge behind you.",
+        "back_name": "Nowhere is Safe",
         "back_text": "Remove each of the two leftmost locations from the game (or place it in the victory display if either one has Victory X and no clues on it). Each investigator at those locations is defeated. Each enemy and asset at those locations is discarded.\nDiscard all clues controlled by the investigators.",
         "code": "02163",
         "doom": 3,
@@ -79,6 +87,8 @@
         "type_code": "agenda"
     },
     {
+        "back_flavor": "The entire bridge cracks under the pressure of the gate, and breaks apart. Instead of plummeting into the river, the remaining train cars are pulled into the sky, toward the rift. You hang on for dear life and scream in horror as you are pulled into the gate. Then, everything goes black.",
+        "back_name": "Sucked In",
         "back_text": "Each investigator is immediately defeated and takes 1 mental trauma. <b>(&rarr;R2)</b>",
         "code": "02164",
         "doom": 3,
@@ -95,6 +105,8 @@
         "type_code": "agenda"
     },
     {
+        "back_flavor": "A tender car filled with coal blocks your way to the engine cab. Swallowing your fear, you climb out of the nearby window and clamber onto the roof of the train, making your way across the tender car. The steady backward motion of the train makes it difficult for you to keep your footing. As you get close, a winged creature swoops down from aboe, its body composed of piping hot steam.",
+        "back_name": "Wings of Steam",
         "back_text": "<b>The investigator entering the Engine Car reads the following (out loud):\n</b>You must decide (choose one):\n- Test [agility] (3) to attempt to dodge the creature. If you fail, you leap too far and barely grip the side of the train, hanging on for dear life. Although you manage to pull yourself up, the experience is terrifying. You suffer 1 mental trauma.\n- Test [combat] (3) to attempt to endure the creature's extreme heat. If you fail, the creature flies through you and the heat burns you. You suffer 1 physical trauma.",
         "clues": null,
         "code": "02165",
@@ -113,6 +125,8 @@
         "type_code": "act"
     },
     {
+        "back_flavor": "The engine roars to life and kicks into motion. You shovel coal into the engine's firebox and are relieved to see that the train is moving forward along the tracks once again.",
+        "back_name": "Forward Motion",
         "back_text": "<b>(&rarr;R1)</b>",
         "clues": null,
         "code": "02166",


### PR DESCRIPTION
bota/tece were missing back_name and back_flavor on the act/agenda cards.