### PR TITLE
Remove deck_limit from cards that can't go in decks

### DIFF
--- a/pack/dwl/bota_encounter.json
+++ b/pack/dwl/bota_encounter.json
@@ -372,7 +372,6 @@
     {
 	"code": "02215",
 	"cost": 0,
-	"deck_limit": 1,
 	"encounter_code": "blood_on_the_altar",
 	"encounter_position": 21,
 	"faction_code": "neutral",

--- a/pack/dwl/tece_encounter.json
+++ b/pack/dwl/tece_encounter.json
@@ -369,7 +369,6 @@
     {
         "code": "02179",
         "cost": 0,
-        "deck_limit": 1,
         "encounter_code": "essex_county_express",
         "encounter_position": 24,
         "faction_code": "neutral",

--- a/pack/dwl/tmm_encounter.json
+++ b/pack/dwl/tmm_encounter.json
@@ -394,7 +394,6 @@
     {
         "code": "02138",
         "cost": 0,
-        "deck_limit": 0,
         "encounter_code": "the_miskatonic_museum",
         "encounter_position": 21,
         "faction_code": "neutral",
@@ -414,7 +413,6 @@
     {
         "code": "02139",
         "cost": 0,
-        "deck_limit": 0,
         "encounter_code": "the_miskatonic_museum",
         "encounter_position": 22,
         "faction_code": "neutral",

--- a/pack/ptc/tuo_encounter.json
+++ b/pack/ptc/tuo_encounter.json
@@ -457,7 +457,6 @@
 	{
 		"code": "03182a",
 		"cost": null,
-		"deck_limit": 1,
 		"encounter_code": "the_unspeakable_oath",
 		"encounter_position": 24,
 		"faction_code": "neutral",


### PR DESCRIPTION
Helpless Passenger from TECE
Key to the Chamber from BOTA
Daniel Chesterfield from TUO

This seems to be the best way to tell if a card is allowed to go in a player deck (after a scenario)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kamalisk/arkhamdb-json-data/298)
<!-- Reviewable:end -->
