### PR TITLE
TOF Act 3 has improper hidden flag

### DIFF
--- a/pack/tfa/tof_encounter.json
+++ b/pack/tfa/tof_encounter.json
@@ -703,7 +703,6 @@
         "clues": null,
         "code": "04140",
         "double_sided": true,
-        "hidden": true,
         "encounter_code": "threads_of_fate",
         "encounter_position": 28,
         "faction_code": "mythos",


### PR DESCRIPTION
Typical Act cards don't have `hidden: true` flage, so take it out to prevent extra spoiler protection