### PR TITLE
LITAS act 2 was not marked as double sided

### DIFF
--- a/pack/dwl/litas_encounter.json
+++ b/pack/dwl/litas_encounter.json
@@ -115,6 +115,7 @@
 		"back_name": "The World's Edge",
 		"clues": null,
 		"code": "02317",
+		"double_sided": true,
 		"encounter_code": "lost_in_time_and_space",
 		"encounter_position": 7,
 		"faction_code": "mythos",


### PR DESCRIPTION
Back side not showing up, this should fix
https://arkhamdb.com/card/02317