### PR TITLE
Adjust names of encounter sets

### DIFF
--- a/encounters.json
+++ b/encounters.json
@@ -305,7 +305,7 @@
     },
     {
         "code": "in_the_labyrinths_of_lunacy",
-        "name": "In The Labyrinths of Lunacy"
+        "name": "The Labyrinths of Lunacy"
     },
     {
         "code": "epic_multiplayer",
@@ -313,7 +313,7 @@
     },
     {
         "code": "single_group",
-        "name": "Single"
+        "name": "Single Group"
     },
     {
         "code": "return_to_the_gathering",
@@ -337,6 +337,6 @@
     },
     {
         "code": "return_cult",
-        "name": "Return Cult"
+        "name": "Return Cult of Umôrdhoth",
     }
 ]


### PR DESCRIPTION
Took the LOL names from the setup guide.
The cult on RNOTZ is technically written as: "Cult of Umordoth (new)"
but that seems kind of weird?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kamalisk/arkhamdb-json-data/312)
<!-- Reviewable:end -->
