### PR TITLE
Fix deck publish button with TDOY release date

### DIFF
--- a/packs.json
+++ b/packs.json
@@ -183,7 +183,7 @@
 	"cgdb_id": 24,
         "code": "tdoy",
         "cycle_code": "tfa",
-        "date_release": null,
+        "date_release": "2018-10-11",
         "name": "The Depths of Yoth",
         "position": 6,
         "size": 60


### PR DESCRIPTION
Deck publishing is currently broken because the Depths of Yoth is out and people are including cards from it.  The site ensures that unpublished cards aren't in decks before allowing them to publish, and errors out with "You cannot publish this deck yet, because it has unreleased cards" when they have depths of yoth cards. 

This patch only adds a depths of yoth release date.  It will restore deck publishing. 