### PR TITLE
Three story weaknesses were missing the subtype_code

### DIFF
--- a/pack/ptc/ptc_encounter.json
+++ b/pack/ptc/ptc_encounter.json
@@ -371,6 +371,7 @@
 		"pack_code": "ptc",
 		"position": 59,
 		"quantity": 1,
+    "subtype_code": "weakness",
 		"text": "<b>Spawn</b> - Location farthest from all investigators.\nAloof.\n[action]: <b>Investigate.</b> Your location gets +2 shroud for this investigation. If you succeed, instead of discovering clues, defeat The Man in the Pallid Mask.",
 		"traits": "Humanoid. Elite.",
 		"type_code": "enemy"

--- a/pack/side/cotr_encounter.json
+++ b/pack/side/cotr_encounter.json
@@ -536,7 +536,7 @@
         "pack_code": "cotr",
         "position": 29,
         "quantity": 1,
-        "subtype": "weakness",
+        "subtype_code": "weakness",
         "text": "<b>Revelation</b> - Put Curse of the Rougarou into play in your threat area.\n<b>Forced</b> - At the end of your turn, if you have not dealt any damage this turn: Take 1 horror.",
         "traits": "Curse.",
         "type_code": "treachery"

--- a/pack/tfa/tcoa_encounter.json
+++ b/pack/tfa/tcoa_encounter.json
@@ -520,6 +520,7 @@
         "pack_code": "tcoa",
         "position": 264,
         "quantity": 4,
+        "subtype_code": "weakness",
         "text": "<b>Revelation</b> - Shuffle each card from your hand into your deck and draw an equal number of cards. Shuffle Out of Body Experience into your deck.",
         "traits": "Madness. Paradox.",
         "type_code": "treachery"


### PR DESCRIPTION
Looks like cotr had the wrong json code, the other two were just missing
it