### PR TITLE
Fix [action] in Shrivelling (3)

### DIFF
--- a/pack/dwl/tece.json
+++ b/pack/dwl/tece.json
@@ -138,7 +138,7 @@
         "skill_combat": 1,
         "skill_willpower": 1,
         "slot": "Arcane",
-        "text": "<b>Uses</b>: 4 charges.\n[Action] Spend one charge: <b>Fight.</b> This attack uses [willpower] instead of [combat]. You get +2 [willpower] and deal +1 damage for this attack. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this attack, take 1 horror. ",
+        "text": "<b>Uses</b>: 4 charges.\n[action] Spend one charge: <b>Fight.</b> This attack uses [willpower] instead of [combat]. You get +2 [willpower] and deal +1 damage for this attack. If a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol is revealed during this attack, take 1 horror. ",
         "traits": "Spell.",
         "type_code": "asset",
         "xp": 3


### PR DESCRIPTION
Shrivelling (3) had a capital A in [Action], so it wasn't parsing correctly and turning into an action arrow. Corrected that.