### PR TITLE
Little corrections

### DIFF
--- a/pack/ptc/ptc.json
+++ b/pack/ptc/ptc.json
@@ -312,7 +312,7 @@
 		"skill_wild": 1,
 		"skill_willpower": 1,
 		"subname": "Envoy of the Alusi",
-		"text": "Akachi Onyele deck only.\n[free] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <b>(as resources)</b> and discard that asset.",
+		"text": "Akachi Onyele deck only.\n[free] Exhaust Spirit-Speaker: Choose an asset you control with \"uses (charges).\" Either return that asset to your hand, or move all charges from that asset to your resource pool <i>(as resources)</i> and discard that asset.",
 		"traits": "Ritual.",
 		"type_code": "asset"
 	},
@@ -327,7 +327,7 @@
 		"quantity": 1,
 		"restrictions": "investigator:03004",
 		"subtype_code": "weakness",
-		"text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[free] Exhaust a <b>Spell</b> asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
+		"text": "<b>Revelation</b> - Put Angered Spirits into play in your threat area.\n[free] Exhaust a [[Spell]] asset: Move 1 charge from that asset to Angered Spirits.\n<b>Forced</b> - When the game ends, if Angered Spirits has fewer than 4 charges on it: You suffer 1 physical trauma.",
 		"traits": "Task.",
 		"type_code": "treachery"
 	},
@@ -345,7 +345,7 @@
 		"skill_combat": 1,
 		"skill_wild": 1,
 		"skill_willpower": 1,
-		"text": "William Yorick deck only.\nFast. Play after a non-<b>Elite</b> enemy at your location is defeated.\nAdd that enemy <i>(and this card)</i> to the victory display.",
+		"text": "William Yorick deck only.\nFast. Play after a non-[[Elite]] enemy at your location is defeated.\nAdd that enemy <i>(and this card)</i> to the victory display.",
 		"traits": "Task.",
 		"type_code": "event",
 		"victory": 1
@@ -568,7 +568,7 @@
 		"quantity": 2,
 		"skill_agility": 1,
 		"skill_intellect": 1,
-		"text": "Fast. Play only during your turn.\nPut an <b>Item</b> asset into play from your hand. At the end of your turn, if that asset is still in play, return it to your hand.",
+		"text": "Fast. Play only during your turn.\nPut an [[Item]] asset into play from your hand. At the end of your turn, if that asset is still in play, return it to your hand.",
 		"traits": "Trick.",
 		"type_code": "event",
 		"xp": 0
@@ -636,7 +636,7 @@
 		"position": 33,
 		"quantity": 2,
 		"skill_willpower": 2,
-		"text": "Play a <b>Spell</b> or <b>Ritual</b> card from your hand, reducing its resource cost by 3.",
+		"text": "Play a [[Spell]] or [[Ritual]] card from your hand, reducing its resource cost by 3.",
 		"traits": "Spirit.",
 		"type_code": "event",
 		"xp": 0
@@ -654,7 +654,7 @@
 		"quantity": 2,
 		"skill_agility": 1,
 		"skill_willpower": 1,
-		"text": "<b>Move.</b> Move to any revealed location and reveal a random token from the chaos bag. If you reveal a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, you must discard an <b>Item</b> or <b>Ally</b> asset you control (if you cannot, take 1 damage).",
+		"text": "<b>Move.</b> Move to any revealed location and reveal a random token from the chaos bag. If you reveal a [skull], [cultist], [tablet], [elder_thing], or [auto_fail] symbol, you must discard an [[Item]] or [[Ally]] asset you control (if you cannot, take 1 damage).",
 		"traits": "Spell.",
 		"type_code": "event",
 		"xp": 0
@@ -671,7 +671,7 @@
 		"quantity": 2,
 		"skill_combat": 1,
 		"slot": "Hand",
-		"text": "[free] During a skill test on a <b>Spell</b> card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
+		"text": "[free] During a skill test on a [[Spell]] card, exhaust Spirit Athame: You get +2 skill value for this test.\n[action] Exhaust Spirit Athame: <b>Fight.</b> You get +2 [combat] for this attack.",
 		"traits": "Item. Relic. Weapon. Melee.",
 		"type_code": "asset",
 		"xp": 1
@@ -723,7 +723,7 @@
 		"position": 38,
 		"quantity": 2,
 		"skill_agility": 2,
-		"text": "Fast. Attach Hiding Spot to any location.\nEach non-<b>Elite</b> enemy at attached location gains aloof.\n<b>Forced</b> - At the end of the enemy phase, if a ready enemy is at attached location: Discard Hiding Spot.",
+		"text": "Fast. Attach Hiding Spot to any location.\nEach non-[[Elite]] enemy at attached location gains aloof.\n<b>Forced</b> - At the end of the enemy phase, if a ready enemy is at attached location: Discard Hiding Spot.",
 		"traits": "Tactic. Trick.",
 		"type_code": "event",
 		"xp": 0


### PR DESCRIPTION
It looks like some of the changes from <b> to [[ for traits hadn't come through, so just correcting that.