### PR TITLE
Fix inconsistent usage of word 'three'

### DIFF
--- a/pack/return/rtdwl.json
+++ b/pack/return/rtdwl.json
@@ -47,7 +47,7 @@
         "quantity": 2,
         "skill_intellect": 1,
         "skill_willpower": 1,
-        "text": "Play only if there is a clue on your location.\nDraw three cards.",
+        "text": "Play only if there is a clue on your location.\nDraw 3 cards.",
         "traits": "Insight.",
         "type_code": "event",
         "xp": 2

--- a/translations/pl/pack/return/rtdwl.json
+++ b/translations/pl/pack/return/rtdwl.json
@@ -16,7 +16,7 @@
     {
         "code": "51003",
         "name": "Preposterous Sketches",
-        "text": "Play only if there is a clue on your location.\nDraw three cards.",
+        "text": "Play only if there is a clue on your location.\nDraw 3 cards.",
         "traits": "Insight."
     },
     {


### PR DESCRIPTION
Other versions of Preposterous Sketches use the numeral 3.