### PR TITLE
fix quoting for card 06113

### DIFF
--- a/pack/tde/sfk.json
+++ b/pack/tde/sfk.json
@@ -50,7 +50,7 @@
 		"xp": 0
 	},
 	{
-		"bonded_to": 06112,
+		"bonded_to": "06112",
 		"code": "06113",
 		"faction_code": "seeker",
 		"illustrator": "Ethan Patrick Harris",


### PR DESCRIPTION
The sfk.json was missing quotes for the bonded_to field on card 06113