### PR TITLE
Fix Cost X cards to use -2

### DIFF
--- a/pack/dwl/dwl.json
+++ b/pack/dwl/dwl.json
@@ -220,7 +220,7 @@
     },
     {
         "code": "02010",
-        "cost": null,
+        "cost": -2,
         "deck_limit": 1,
         "faction_code": "neutral",
         "flavor": "\"...Say, are those Mr. Donohue's guns?\" Jenny held a pistol over her shoulder and struck a pose. \"I think they suit me better than him. Don't you agree?\"",

--- a/pack/ptc/ptc.json
+++ b/pack/ptc/ptc.json
@@ -194,7 +194,7 @@
 		"text": "Mark Harrigan deck only.\nIf this skill test is successful during an attack, move 1 damage from Mark Harrigan to the attacked enemy.",
 		"traits": "Practiced. Expert.",
 		"type_code": "skill"
-	},		
+	},
 	{
 		"code": "03008",
 		"deck_limit": 1,
@@ -333,6 +333,7 @@
 	},
 	{
 		"code": "03016",
+		"cost": 0,
 		"deck_limit": 1,
 		"faction_code": "neutral",
 		"flavor": "\"Though this be madness, yet there is method in 't.\"\n- William Shakespeare, Hamlet.",
@@ -386,7 +387,7 @@
 		"text": "Lola Hayes deck only.\nFast. Play only during your turn.\nSwitch your role. Until the end of your turn, reduce the resource cost of the next card you play of your role by 3. Draw 1 card.",
 		"traits": "Insight.",
 		"type_code": "event"
-	},		
+	},
 	{
 		"code": "03019",
 		"deck_limit": 2,
@@ -489,7 +490,7 @@
 		"traits": "Talent.",
 		"type_code": "asset",
 		"xp": 0
-	},		
+	},
 	{
 		"code": "03025",
 		"cost": 0,
@@ -523,7 +524,7 @@
 		"traits": "Insight.",
 		"type_code": "event",
 		"xp": 0
-	},		
+	},
 	{
 		"code": "03027",
 		"cost": 3,

--- a/pack/ptc/tpm.json
+++ b/pack/ptc/tpm.json
@@ -173,7 +173,7 @@
 	},
 	{
 		"code": "03238",
-		"cost": null,
+		"cost": -2,
 		"deck_limit": 2,
 		"faction_code": "survivor",
 		"illustrator": "David Auden Nash",


### PR DESCRIPTION
Precedent set with Fortuitous Discovery, and this would let me remove some
hacks to differentiate between - and X cost.

Bury them deep also was missing cost, so set it to 0.