### PR TITLE
Update ste.json - allow 2 Quick Learners per deck

### DIFF
--- a/pack/investigator/ste.json
+++ b/pack/investigator/ste.json
@@ -169,7 +169,7 @@
 	{
 		"code": "60530",
 		"cost": null,
-		"deck_limit": 1,
+		"deck_limit": 2,
 		"faction_code": "survivor",
 		"illustrator": "Julepe",
 		"name": "Quick Learner",


### PR DESCRIPTION
There's no ability or anything I can see that would suggest that Quick Learner is limited to be a one-of.