### PR TITLE
Fix veiled locations

### DIFF
--- a/pack/tde/dsm_encounter.json
+++ b/pack/tde/dsm_encounter.json
@@ -152,6 +152,7 @@
 		"type_code": "act"
 	},
 	{
+		"back_link": "06214b",
 		"clues": 1,
 		"clues_fixed": true,
 		"code": "06214",
@@ -169,7 +170,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06214",
 		"code": "06214b",
 		"faction_code": "mythos",
 		"hidden": true,

--- a/pack/tde/pnr_encounter.json
+++ b/pack/tde/pnr_encounter.json
@@ -133,6 +133,7 @@
 		"type_code": "act"
 	},
 	{
+		"back_link": "06254b",
 		"clues": 1,
 		"code": "06254",
 		"encounter_code": "point_of_no_return",
@@ -150,7 +151,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06254",
 		"code": "06254b",
 		"faction_code": "mythos",
 		"flavor": "Hisses and uncanny voices pursue you throughout this web of darkened, intersecting tunnels. You believe the myriad paths might lead all the way to the surface of the Dreamlands, considering the vastness of this network of caverns. It is a wonder you can even find your way back to where you started. However, you are not alone when you emerge...",
@@ -163,6 +163,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06255b",
 		"clues": 1,
 		"code": "06255",
 		"encounter_code": "point_of_no_return",
@@ -180,7 +181,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06255",
 		"code": "06255b",
 		"faction_code": "mythos",
 		"flavor": "The kingdom of the Gugs is surrounded by a colossal wall. Inside, cylindrical towers rise high into the mist, each one windowless and made of grey stone, with large looming doorways at the bottom. One black tower stands paramount among the others, rising into the very ceiling of the Underworld. You do not make it very far before you spot the sentry standing guard outside the city's walls: a tremendous creature with huge furry arms and an obscene toothy maw extending vertically through its head.",
@@ -193,6 +193,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06256b",
 		"clues": 0,
 		"code": "06256",
 		"encounter_code": "point_of_no_return",
@@ -209,7 +210,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06256",
 		"code": "06256b",
 		"faction_code": "mythos",
 		"flavor": "Step after step, you scale the tower until you reach the heavy trapdoor at the top. When you push the stone aside, a column of bright light pierces through the shaft, blinding you. The surface! You emerge in an area thick with trees and mystical fog. After so many hours spent underground, the cool breeze feels wonderful. Many curious eyes watch you from the surrounding woods. Though you long to stay and explore more of these wilds, you know your true goal lies back down in the caverns below the surface.",
@@ -222,6 +222,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06257b",
 		"clues": 1,
 		"code": "06257",
 		"encounter_code": "point_of_no_return",
@@ -240,7 +241,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06257",
 		"code": "06257b",
 		"faction_code": "mythos",
 		"hidden": true,
@@ -252,6 +252,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06258b",
 		"clues": 2,
 		"code": "06258",
 		"double_sided": true,
@@ -271,7 +272,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06258",
 		"code": "06258b",
 		"faction_code": "mythos",
 		"flavor": "Looking out over the barren vale, you get a sense for the threats that dwell below. Underneath the plateau upon which you stand, a forest of obscene, pale fungi extends for miles. Beyond that is a great heap of bones, like an ocean pouring forth in all directions. You swear you can see something crawling or worming its way along the surface of the bones, but perhaps it's just your imagination. In the distance, great sharp peaks of stone loom over the vale. Black, winged creatures fly around the summits, searching for prey. You see no sign of this \"ocean of pitch\" Pickman described, though you do notice a wide cavern opening along a wall of stone to the right of the vale below...",
@@ -284,6 +284,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06259",
 		"clues": 1,
 		"code": "06259",
 		"encounter_code": "point_of_no_return",
@@ -302,7 +303,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06259",
 		"code": "06259b",
 		"faction_code": "mythos",
 		"flavor": "Traversing this canyon of cadavers and monstrous remains is laborious enough, but it is the churning and digging below the surface that causes you to hate this awful place. What sort of monstrosity could span the entirety of this ocean of bones? Your answer presents itself as you come across a great pit in the ravine. It is swallowing the bones and scraps of rotten meat like a whirlpool. When you reach the base of the tunnel and realize its true purpose, a shudder courses through you. It was made by an enormous creature: the thing that dwells below the sea of bones.",
@@ -315,6 +315,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06260b",
 		"clues": 0,
 		"code": "06260",
 		"encounter_code": "point_of_no_return",
@@ -331,7 +332,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06260",
 		"code": "06260b",
 		"faction_code": "mythos",
 		"flavor": "You climb to the top of the hazardous peaks to survey the lands below. From this vantage point, you are able to see the movements of the various creatures that live in the vale. Soaring all around the peaks are black, winged things that somehow scowl at you with empty, expressionless faces. Upon the cliff that hangs over the vale, ghoul eyes watch your progress with morbid curiosity. The mound of bones and detritus below the precipice is home to nothing but the churning and dredging of something massive under the surface. To your left, the misty vale extends for miles until it reaches an enormous stone wall. Opposite the wall, far in the distance, you barely make out the shape of a city in the darkness. Incomprehensible whispers and mocking laughter seep into your ears. You dare no further study.",
@@ -344,6 +344,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06261b",
 		"clues": 1,
 		"code": "06261",
 		"encounter_code": "point_of_no_return",
@@ -361,7 +362,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06261",
 		"code": "06261b",
 		"faction_code": "mythos",
 		"hidden": true,
@@ -373,6 +373,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06262b",
 		"clues": 1,
 		"code": "06262",
 		"encounter_code": "point_of_no_return",
@@ -390,7 +391,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06262",
 		"code": "06262b",
 		"faction_code": "mythos",
 		"flavor": "From the depths of the pitch-black ocean, the creatures suddenly emerge. They are similar to spiders in shape, but that is where the similarities end. Their bodies appear to be made from the same tarry substance as the ocean itself, and their eyes glow crimson red in the dark fog over the sea. The spiders surround your vessel and attempt to pull it - and you - into the depths.",
@@ -403,6 +403,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06263b",
 		"clues": 1,
 		"code": "06263",
 		"encounter_code": "point_of_no_return",
@@ -420,7 +421,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06263",
 		"code": "06263b",
 		"faction_code": "mythos",
 		"flavor": "The ocean's waves are steady and slow, like rolling pits of sludge, but eventually you find a spot where the ocean is eerily still, and all is silent. You peer over the edge of your boat and gaze into the depths. Somewhere in the black vastness below is your destination...",
@@ -433,6 +433,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06264b",
 		"clues": 1,
 		"code": "06264",
 		"encounter_code": "point_of_no_return",
@@ -450,7 +451,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06264",
 		"code": "06264b",
 		"faction_code": "mythos",
 		"flavor": "Though there is no wind in the dark caverns of the Underworld, enormous maelstroms of pitch attack your vessel from all sides. You struggle to remain in control of your boat as the whirlpools hurl you into pandemonium.",
@@ -463,6 +463,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06265b",
 		"clues": 1,
 		"code": "06265",
 		"encounter_code": "point_of_no_return",
@@ -480,7 +481,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06265",
 		"code": "06265b",
 		"faction_code": "mythos",
 		"hidden": true,

--- a/pack/tde/sfk_encounter.json
+++ b/pack/tde/sfk_encounter.json
@@ -154,6 +154,7 @@
 		"type_code": "act"
 	},
 	{
+		"back_link": "06127b",
 		"clues": 1,
 		"code": "06127",
 		"encounter_code": "the_search_for_kadath",
@@ -171,7 +172,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06127",
 		"code": "06127b",
 		"faction_code": "mythos",
 		"flavor": "As you walk the streets of the town, a horde of cats slowly congregates around you, following you everywhere you go.",
@@ -184,6 +184,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06128b",
 		"clues": 0,
 		"code": "06128",
 		"encounter_code": "the_search_for_kadath",
@@ -201,7 +202,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06128",
 		"code": "06128b",
 		"faction_code": "mythos",
 		"flavor": "The wilds of the Skai region may appear peaceful, but they are far from safe. You are compelled to travel slowly and take in the beauty and tranquility of this realm, but your dawdling makes you a target for the vicious creatures that call the wetlands home.",
@@ -214,6 +214,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06129b",
 		"clues": 1,
 		"code": "06129",
 		"encounter_code": "the_search_for_kadath",
@@ -231,7 +232,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06129",
 		"code": "06129b",
 		"faction_code": "mythos",
 		"flavor": "In the port city of Dylath-Leen, you consult with the elders of the city. They believe that the truth of Kadath was hidden for a reason, and they call you a fool for searching for it. Even so, they tell you what little they know of the forsaken peak. Though you are far from finding Kadath, it is clear now that it cannot be in this region. \"We'll need to find a ship captain,\" Randolph muses. \"This journey will be much longer still. The isle of Oriab lies to the south, and I have heard of a great mountain there. To the west lies the ancient land of Mnar, where many secrets lie hidden. To the east is the Timeless Realm ruled by the wise King Kuranes. North of there is a forbidden land where none dare tread...\"",
@@ -244,6 +244,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06130b",
 		"clues": 1,
 		"code": "06130",
 		"encounter_code": "the_search_for_kadath",
@@ -261,7 +262,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06130",
 		"code": "06130b",
 		"faction_code": "mythos",
 		"flavor": "You study the pillars within Kadatheron for many hours, losing yourself in the vast, storied histories of the Dreamlands. What was first a focused search for the whereabouts of the castle of the gods soon becomes an obsession with all things inscribed upon the cylinders. Hours, days, weeks; who knows how much time you lose to your research. Though you learn much, the time you spend here is a boon to those who pursue you. You are only able to pry yourself free from the cylinders when you feel the ominous gaze of something sinister watching you from afar...",
@@ -274,6 +274,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06131b",
 		"clues": 1,
 		"code": "06131",
 		"encounter_code": "the_search_for_kadath",
@@ -292,7 +293,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06131",
 		"code": "06131b",
 		"faction_code": "mythos",
 		"flavor": "Although this city-state was founded ages ago and stood for over a thousand years, it is no more. The tales tell of a single night in which Sarnath fell. Now very little of it remains: only a vast marsh where the city once stood tall and proud. Among the ruins you find no standing buildings, but rubble of marble, brick, and chalcedony. But as you approach the remains, lightning splits the sky. There is a blinding flash. As you blink your eyes, everything changes. Where before no city stood, now there looms a ghostly image of Sarnath as it once was. Near the lake, where the lightning struck, you find a curious and ancient idol of green stone. It is coated with seaweed and chiseled in the likeness of a great water lizard. One of the gods of this realm, perhaps?",
@@ -305,6 +305,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06132b",
 		"clues": 1,
 		"code": "06132",
 		"encounter_code": "the_search_for_kadath",
@@ -323,7 +324,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06132",
 		"code": "06132b",
 		"faction_code": "mythos",
 		"flavor": "It is said that the people of Sarnath were the ones who destroyed the city of Ib thousands of years ago. From what you can gather, the inhabitants of Ib had committed no crime other than possessing a disturbing appearance and carving strange sculptures upon the grey monoliths within their city. However, the retribution Sarnath faced was far greater than their own sin. Even now, long after the destruction of Ib, creatures resembling the city's inhabitants still haunt the Nameless Lake, hunting down intruders like the warriors of Sarnath who destroyed their civilization so long ago. Intruders such as yourself.",
@@ -336,6 +336,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06133b",
 		"clues": 1,
 		"code": "06133",
 		"encounter_code": "the_search_for_kadath",
@@ -354,7 +355,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06133",
 		"code": "06133b",
 		"faction_code": "mythos",
 		"flavor": "High above the walls of Ilek-Vad stands the marvelous Palace of Rainbows, its towers faceted so the sunlight forms bright rainbows when it strikes the palace each dawn. You are surprised to learn that the citizenry of Ilek-Vad - people of all stations and, indeed, even outsiders such as yourself - are free to visit the palace grounds and walk its smooth glass streets lined with fragrant gardens. You are able to meet with the king of Ilek-Vad, who is said to know the music of the Moon, and he is happy to share with you his knowledge of the Dreamlands. You never, ever want to leave.",
@@ -367,6 +367,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06134b",
 		"clues": 0,
 		"code": "06134",
 		"encounter_code": "the_search_for_kadath",
@@ -383,7 +384,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06134",
 		"code": "06134b",
 		"faction_code": "mythos",
 		"flavor": "Throughout these perilous and hellish lands, you are beset by nameless beasts, hazardous terrain, and creatures too bizarre to describe. Even so, you press onward in the hope that you might learn something of the gods in this forsaken place. On the third evening you spend here, you find a shrine beside a lake of fire. Tucked away among a range of volcanoes, the shrine bears a statue carved in the face of the volcanic rock, long forgotten by ancient dreamers and outsiders alike. A mark of the Dreamlands' gods, perhaps? You draw the statue's likeness in your journal and hope that it might hold some significance.",
@@ -396,6 +396,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06135b",
 		"clues": 1,
 		"code": "06135",
 		"encounter_code": "the_search_for_kadath",
@@ -413,7 +414,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06135",
 		"code": "06135b",
 		"faction_code": "mythos",
 		"flavor": "The greatest structure within the ruined city is its crypt. Beyond its massive stone door lies a labyrinth of lightless passages wherein sleep the dead of Zulan-Thek: decaying bones of those both important and inconsequential, from simple farmers and laborers to wizards, witches, and necromancers executed for practicing their magical arts. As you traverse the shrouded halls, the only signs of life you come across are a sobbing voice whose owner you cannot ever seem to find, and the scraping of claws along the inside of a sealed stone door that you dare not open. You cannot wait to leave this ominous pit, and yet you know there may be many secrets hidden within.",
@@ -426,6 +426,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06136b",
 		"clues": 1,
 		"code": "06136",
 		"encounter_code": "the_search_for_kadath",
@@ -444,7 +445,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06136",
 		"code": "06136b",
 		"faction_code": "mythos",
 		"flavor": "The city of Baharna is a thriving and bustling harbor where you can find all manner of trade goods, provisions, and other wares. In the marketplace, you find supplies that may aid you in your expedition to lands farther south, as well as beasts of burden to carry your belongings. It should not surprise you that the most common of these creatures are zebras, and yet you are stunned nonetheless. You could spend days perusing the bazaar and still find oddities to spark your imagination. Truly this is a land of wonders.",
@@ -457,6 +457,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06137b",
 		"clues": 1,
 		"code": "06137",
 		"encounter_code": "the_search_for_kadath",
@@ -474,7 +475,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06137",
 		"code": "06137b",
 		"faction_code": "mythos",
 		"flavor": "As you begin your perilous climb, you realize that you are the only ones who dare to scale the mountain. Although woodsmen and lava gatherers explore its lower slopes, few brave the cliffs higher up on the northern face, and certainly none along the southern face of the mountain, which cannot be seen from the city below.\nYou eventually reach a valley of still lava, solid as rock. At the far end, a twisting, narrow path ascends the southern slope. When you reach the top, you find what you have been searching for: a face carved into the side of the mountain, hundreds of feet tall: the face of one of the Great Ones, or so it is told.",
@@ -487,6 +487,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06138b",
 		"clues": 1,
 		"code": "06138",
 		"encounter_code": "the_search_for_kadath",
@@ -505,7 +506,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06138",
 		"code": "06138b",
 		"faction_code": "mythos",
 		"flavor": "The ruins of this settlement are vast, but it is the caverns that lie beneath that draw your interest. Deep underground, you become lost in a forbidden maze of wildly complex corridors, impossible to map. For days you scour the maze, unable to find the path to its core. Finally, you notice a dark shape, like a hazy shadow, watching you from around a corner. You pursue it until it leads you to a tomb in the center of the gargantuan cavern, surrounded by ancient tapestries depicting the once great kingdom of Tyrrhia. You wonder about the intentions of the shadow that led you here. Was it aiding you, or manipulating you? You record the story of Tyrrhia's fall before fleeing to the surface. You have no wish to stay any longer.",
@@ -518,6 +518,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06139b",
 		"clues": 1,
 		"code": "06139",
 		"encounter_code": "the_search_for_kadath",
@@ -536,7 +537,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06139",
 		"code": "06139b",
 		"faction_code": "mythos",
 		"flavor": "Randolph stops in one of the streets of Celephaïs to meet with the old chief of the city's cats, and you recall that your companion once told you that Ulthar is not the only city of the Dreamlands in which these curious creatures dwell. The cat informs Randolph where he can find \"his old friend,\" and you are surprised when your companion leads you to a rose-crystal palace in the center of the city. Here you meet with King Kuranes, who rules this region. When you tell Kuranes of your quest, he indicates that you may find what you are looking for in the great temple that lies in the center of Hazuth-Kleg, a city beyond his Timeless Realm. But this advice comes with a warning: Once you enter the Temple of Unattainable Desires, you might never leave.",
@@ -549,6 +549,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06140b",
 		"clues": 1,
 		"code": "06140",
 		"encounter_code": "the_search_for_kadath",
@@ -567,7 +568,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06140",
 		"code": "06140b",
 		"faction_code": "mythos",
 		"flavor": "The beautiful city of Serannian is a refuge from all the world's ills. In these turreted cloud-castles that hang in a heavenly sky, time slows to a halt. The allure of this city is ageless. You could lose yourself for years within its marbled streets and perfect gardens and never notice the difference. It is so peaceful that you nearly forget your quest, as well as the fact that your physical body still sleeps in the real world. Even so, you cannot help but wonder: Would it be better to simply stay in this tranquil realm and let your mind remain at peace, even while your body ages and withers away?",
@@ -580,6 +580,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06141b",
 		"clues": 1,
 		"code": "06141",
 		"encounter_code": "the_search_for_kadath",
@@ -597,7 +598,6 @@
 		"type_code": "location"
 	},
 	{
-		"back_link": "06141",
 		"code": "06141b",
 		"faction_code": "mythos",
 		"flavor": "Deep within the run-down city of Hazuth-Kleg, along the street of the pantheon, lies the Temple of Unattainable Desires. It is a grand temple of onyx, its iron gate fashioned to look like a mass of twisted and intermingled serpents with amethyst eyes. Lanterns cast a baleful red glow at the entrance. You shudder at the thought of what profane rituals might transpire within its unhallowed halls, and yet, your gut tells you this awful place may hold the answers you seek.",
@@ -610,6 +610,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06142b",
 		"clues": 1,
 		"code": "06142",
 		"encounter_code": "the_search_for_kadath",
@@ -628,7 +629,6 @@
 		"victory": 1
 	},
 	{
-		"back_link": "06142",
 		"code": "06142b",
 		"faction_code": "mythos",
 		"flavor": "In the deepest section of the temple lies its greatest hall and its greatest curse. The moment you pass under its low, narrow doorway, you find yourself in another realm altogether: a twisted, hellish version of the city outside. The streets are lined with tottering houses that lean together so that they almost form tunnels, blotting out what passes for the sky in this nightmare realm. Only a single baleful star shines in the perpetual twilight, visible between the leaning basalt towers and twisted streets.",
@@ -641,6 +641,7 @@
 		"type_code": "story"
 	},
 	{
+		"back_link": "06143b",
 		"clues": 2,
 		"code": "06143",
 		"encounter_code": "the_search_for_kadath",
@@ -658,7 +659,6 @@
 		"victory": 2
 	},
 	{
-		"back_link": "06143",
 		"code": "06143b",
 		"faction_code": "mythos",
 		"flavor": "You traverse the tangled streets of this dark, abandoned realm for what seems like many hours. You cannot tell the passage of time, for the star that hangs above you never moves, and the rest of the sky is empty and devoid of all light. Finally you reach the square in the center of town, directly below the baleful star. Its red glare shines down on a statue depicting an otherworldly abomination. The inscription in the stone before the statue is riddled with astrological symbols and strange names, but nothing more. The moment you read one of the names, the city begins to collapse, and you are whisked away by an incomprehensible force. You awaken several hours later, your head spinning. Your arms and legs are covered in thin, bloody incisions.",


### PR DESCRIPTION
back links were pointing in wrong direction, making story card backs not
show up