### PR TITLE
fix traits of Daredevil2 (06240)

### DIFF
--- a/pack/tde/pnr.json
+++ b/pack/tde/pnr.json
@@ -118,7 +118,7 @@
 		"quantity": 2,
 		"skill_wild": 1,
 		"text": "After you commit Daredevil to a skill test, reveal cards from the top of your deck until you reveal a [rogue] skill you can commit to this test. Commit it. Shuffle each other revealed card back into your deck.",
-		"traits": "Fortune. Practiced",
+		"traits": "Fortune. Practiced.",
 		"type_code": "skill",
 		"xp": 2
 	},


### PR DESCRIPTION
from https://github.com/Kamalisk/arkhamdb/issues/292

I found that daredevil's _practiced_ trait has missing punctuation.
I add punctuation mark in daredevil's _practiced_ trait.

The search will be fine; I checked in my local one.