### PR TITLE
Overzealous was being overridden by this encounter card

### DIFF
--- a/translations/es/pack/ptc/tpm_encounter.json
+++ b/translations/es/pack/ptc/tpm_encounter.json
@@ -1,18 +1,5 @@
 [
     {
-        "code": "03040",
-        "name": "The Pallid Mask",
-        "text": "[skull]: -X. X is the number of locations away from the starting location you are (max -5).\n[cultist]: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.\n[tablet]: -2. If there is a ready [[Ghoul]] or [[Geist]] enemy at your location, it attacks you (if there is more than one, choose one).\n[elder_thing]: -2. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it.",
-        "back_text": "[skull]: -X. X is the number of locations away from the starting location you are.\n[cultist]: -3. If this token is revealed during an attack and this skill test is successful, this attack deals no damage.\n[tablet]: -3. If there is a [[Ghoul]] or [[Geist]] enemy at your location, it readies and attacks you (if there is more than one, choose one).\n[elder_thing]: -4. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it."
-    },
-    {
-        "code": "03041",
-        "flavor": "The dank, chill air of the catacombs penetrates your clothes and causes you to shiver. Everywhere you look, the remains of the dead greet you—a grim reminder of your own mortality.",
-        "name": "Empire of the Dead",
-        "text": "Each location is connected to each location adjacent to it.",
-        "back_text": "<b>Spawn</b> - The starting location.\nHunter. Retaliate.\nWhile Specter of Death is exhausted, it takes 1 less damage from each attack made against it.\n<b>Forced</b> - After you fail a skill test while attempting to evade Specter of Death: It attacks you."
-    },
-    {
         "code": "03240",
         "name": "The Pallid Mask",
         "text": "Easy / Standard\n[skull]: -X. X is the number of locations away from the starting location you are (max 5).\n[cultist]: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.\n[tablet]: -2. If there is a ready [[Ghoul]] or [[Geist]] enemy at your location, it attacks you (if there is more than one, choose one).\n[elder_thing]: -3. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it.",

--- a/translations/it/pack/ptc/tpm_encounter.json
+++ b/translations/it/pack/ptc/tpm_encounter.json
@@ -1,18 +1,5 @@
 [
     {
-        "code": "03040",
-        "name": "The Pallid Mask",
-        "text": "[skull]: -X. X is the number of locations away from the starting location you are (max -5).\n[cultist]: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.\n[tablet]: -2. If there is a ready [[Ghoul]] or [[Geist]] enemy at your location, it attacks you (if there is more than one, choose one).\n[elder_thing]: -2. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it.",
-        "back_text": "[skull]: -X. X is the number of locations away from the starting location you are.\n[cultist]: -3. If this token is revealed during an attack and this skill test is successful, this attack deals no damage.\n[tablet]: -3. If there is a [[Ghoul]] or [[Geist]] enemy at your location, it readies and attacks you (if there is more than one, choose one).\n[elder_thing]: -4. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it."
-    },
-    {
-        "code": "03041",
-        "flavor": "The dank, chill air of the catacombs penetrates your clothes and causes you to shiver. Everywhere you look, the remains of the dead greet you—a grim reminder of your own mortality.",
-        "name": "Empire of the Dead",
-        "text": "Each location is connected to each location adjacent to it.",
-        "back_text": "<b>Spawn</b> - The starting location.\nHunter. Retaliate.\nWhile Specter of Death is exhausted, it takes 1 less damage from each attack made against it.\n<b>Forced</b> - After you fail a skill test while attempting to evade Specter of Death: It attacks you."
-    },
-    {
         "code": "03240",
         "name": "The Pallid Mask",
         "text": "Easy / Standard\n[skull]: -X. X is the number of locations away from the starting location you are (max 5).\n[cultist]: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.\n[tablet]: -2. If there is a ready [[Ghoul]] or [[Geist]] enemy at your location, it attacks you (if there is more than one, choose one).\n[elder_thing]: -3. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it.",

--- a/translations/pl/pack/ptc/tpm_encounter.json
+++ b/translations/pl/pack/ptc/tpm_encounter.json
@@ -1,18 +1,5 @@
 [
     {
-        "code": "03040",
-        "name": "The Pallid Mask",
-        "text": "[skull]: -X. X is the number of locations away from the starting location you are (max -5).\n[cultist]: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.\n[tablet]: -2. If there is a ready [[Ghoul]] or [[Geist]] enemy at your location, it attacks you (if there is more than one, choose one).\n[elder_thing]: -2. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it.",
-        "back_text": "[skull]: -X. X is the number of locations away from the starting location you are.\n[cultist]: -3. If this token is revealed during an attack and this skill test is successful, this attack deals no damage.\n[tablet]: -3. If there is a [[Ghoul]] or [[Geist]] enemy at your location, it readies and attacks you (if there is more than one, choose one).\n[elder_thing]: -4. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it."
-    },
-    {
-        "code": "03041",
-        "flavor": "The dank, chill air of the catacombs penetrates your clothes and causes you to shiver. Everywhere you look, the remains of the dead greet you—a grim reminder of your own mortality.",
-        "name": "Empire of the Dead",
-        "text": "Each location is connected to each location adjacent to it.",
-        "back_text": "<b>Spawn</b> - The starting location.\nHunter. Retaliate.\nWhile Specter of Death is exhausted, it takes 1 less damage from each attack made against it.\n<b>Forced</b> - After you fail a skill test while attempting to evade Specter of Death: It attacks you."
-    },
-    {
         "code": "03240",
         "name": "The Pallid Mask",
         "text": "Easy / Standard\n[skull]: -X. X is the number of locations away from the starting location you are (max 5).\n[cultist]: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.\n[tablet]: -2. If there is a ready [[Ghoul]] or [[Geist]] enemy at your location, it attacks you (if there is more than one, choose one).\n[elder_thing]: -3. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it.",

--- a/translations/ru/pack/ptc/tpm_encounter.json
+++ b/translations/ru/pack/ptc/tpm_encounter.json
@@ -1,18 +1,5 @@
 [
     {
-        "code": "03040",
-        "name": "The Pallid Mask",
-        "text": "[skull]: -X. X is the number of locations away from the starting location you are (max -5).\n[cultist]: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.\n[tablet]: -2. If there is a ready [[Ghoul]] or [[Geist]] enemy at your location, it attacks you (if there is more than one, choose one).\n[elder_thing]: -2. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it.",
-        "back_text": "[skull]: -X. X is the number of locations away from the starting location you are.\n[cultist]: -3. If this token is revealed during an attack and this skill test is successful, this attack deals no damage.\n[tablet]: -3. If there is a [[Ghoul]] or [[Geist]] enemy at your location, it readies and attacks you (if there is more than one, choose one).\n[elder_thing]: -4. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it."
-    },
-    {
-        "code": "03041",
-        "flavor": "The dank, chill air of the catacombs penetrates your clothes and causes you to shiver. Everywhere you look, the remains of the dead greet you—a grim reminder of your own mortality.",
-        "name": "Empire of the Dead",
-        "text": "Each location is connected to each location adjacent to it.",
-        "back_text": "<b>Spawn</b> - The starting location.\nHunter. Retaliate.\nWhile Specter of Death is exhausted, it takes 1 less damage from each attack made against it.\n<b>Forced</b> - After you fail a skill test while attempting to evade Specter of Death: It attacks you."
-    },
-    {
         "code": "03240",
         "name": "The Pallid Mask",
         "text": "Easy / Standard\n[skull]: -X. X is the number of locations away from the starting location you are (max 5).\n[cultist]: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.\n[tablet]: -2. If there is a ready [[Ghoul]] or [[Geist]] enemy at your location, it attacks you (if there is more than one, choose one).\n[elder_thing]: -3. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it.",

--- a/translations/zh/pack/ptc/tpm_encounter.json
+++ b/translations/zh/pack/ptc/tpm_encounter.json
@@ -1,18 +1,5 @@
 [
     {
-        "code": "03040",
-        "name": "The Pallid Mask",
-        "text": "[skull]: -X. X is the number of locations away from the starting location you are (max -5).\n[cultist]: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.\n[tablet]: -2. If there is a ready [[Ghoul]] or [[Geist]] enemy at your location, it attacks you (if there is more than one, choose one).\n[elder_thing]: -2. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it.",
-        "back_text": "[skull]: -X. X is the number of locations away from the starting location you are.\n[cultist]: -3. If this token is revealed during an attack and this skill test is successful, this attack deals no damage.\n[tablet]: -3. If there is a [[Ghoul]] or [[Geist]] enemy at your location, it readies and attacks you (if there is more than one, choose one).\n[elder_thing]: -4. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it."
-    },
-    {
-        "code": "03041",
-        "flavor": "The dank, chill air of the catacombs penetrates your clothes and causes you to shiver. Everywhere you look, the remains of the dead greet you—a grim reminder of your own mortality.",
-        "name": "Empire of the Dead",
-        "text": "Each location is connected to each location adjacent to it.",
-        "back_text": "<b>Spawn</b> - The starting location.\nHunter. Retaliate.\nWhile Specter of Death is exhausted, it takes 1 less damage from each attack made against it.\n<b>Forced</b> - After you fail a skill test while attempting to evade Specter of Death: It attacks you."
-    },
-    {
         "code": "03240",
         "name": "The Pallid Mask",
         "text": "Easy / Standard\n[skull]: -X. X is the number of locations away from the starting location you are (max 5).\n[cultist]: -2. If this token is revealed during an attack, and this skill test is successful, this attack deals 1 less damage.\n[tablet]: -2. If there is a ready [[Ghoul]] or [[Geist]] enemy at your location, it attacks you (if there is more than one, choose one).\n[elder_thing]: -3. If you fail, search the encounter deck and discard pile for a [[Ghoul]] or [[Geist]] enemy and draw it.",


### PR DESCRIPTION
Looks like two cards with incorrect codes were put in the spanish
translation file, causing Overzealous to lose its card data.