### PR TITLE
Add leaked story asset from RTTFA that can go in decks

### DIFF
--- a/pack/return/rttfa_encounter.json
+++ b/pack/return/rttfa_encounter.json
@@ -1,0 +1,26 @@
+[
+	{
+		"code": "53037",
+		"cost": 1,
+		"deck_limit": 1,
+		"encounter_code": "return_to_threads_of_fate",
+		"encounter_position": 10,
+		"faction_code": "neutral",
+		"health": 3,
+		"illustrator": "Aleksander Karcz",
+		"is_unique": true,
+		"name": "Veda Whitsley",
+		"pack_code": "rttfa",
+		"position": 37,
+		"quantity": 1,
+		"sanity": 3,
+		"skill_agility": 1,
+		"skill_wild": 2,
+		"skill_willpower": 1,
+		"slot": "Ally",
+		"subname": "Skilled Botanist",
+		"text": "[fast] Exhaust Veda Whitsley: Look at the top card of the exploration deck or encounter deck. If it is an enemy, you may deal 1 damage to Veda Whitsley to discard it. If it is a treachery, you may deal 1 horror to Veda Whitsley to discard it. Otherwise, return it to the top of its deck.",
+		"traits": "Ally. Wayfarer.",
+		"type_code": "asset"
+	}
+]


### PR DESCRIPTION
This PR contains a leaked card for RTTFA. 

We should wait to merge it until the street date for RTTFA, but since it goes in decks it would be nice to merge it close to launch.

Requires this PR to be merged first, which adds the encounter_set it references: https://github.com/Kamalisk/arkhamdb-json-data/pull/666