### PR TITLE
Fix Expeditious Retreat Typo

### DIFF
--- a/pack/tde/pnr.json
+++ b/pack/tde/pnr.json
@@ -228,7 +228,7 @@
 		"position": 246,
 		"quantity": 2,
 		"skill_agility": 1,
-		"text": "Max 1 committed per skill test.\nWhile Expeditious Retreat is committed during a basic evade action, it gains [agility][agility] and the text: \"If this test is successful by 2 or more, you m ay automatically evade another enemy at your location.\"",
+		"text": "Max 1 committed per skill test.\nWhile Expeditious Retreat is committed during a basic evade action, it gains [agility][agility] and the text: \"If this test is successful by 2 or more, you may automatically evade another enemy at your location.\"",
 		"traits": "Innate. Developed.",
 		"type_code": "skill",
 		"xp": 1

--- a/translations/ko/pack/tde/pnr.json
+++ b/translations/ko/pack/tde/pnr.json
@@ -91,7 +91,7 @@
     {
         "code": "06246",
         "name": "Expeditious Retreat",
-        "text": "Max 1 committed per skill test.\nWhile Expeditious Retreat is committed during a basic evade action, it gains [agility][agility] and the text: \"If this test is successful by 2 or more, you m ay automatically evade another enemy at your location.\"",
+        "text": "Max 1 committed per skill test.\nWhile Expeditious Retreat is committed during a basic evade action, it gains [agility][agility] and the text: \"If this test is successful by 2 or more, you may automatically evade another enemy at your location.\"",
         "traits": "Innate. Developed."
     }
 ]

--- a/translations/uk/pack/tde/pnr.json
+++ b/translations/uk/pack/tde/pnr.json
@@ -91,7 +91,7 @@
     {
         "code": "06246",
         "name": "Expeditious Retreat",
-        "text": "Max 1 committed per skill test.\nWhile Expeditious Retreat is committed during a basic evade action, it gains [agility][agility] and the text: \"If this test is successful by 2 or more, you m ay automatically evade another enemy at your location.\"",
+        "text": "Max 1 committed per skill test.\nWhile Expeditious Retreat is committed during a basic evade action, it gains [agility][agility] and the text: \"If this test is successful by 2 or more, you may automatically evade another enemy at your location.\"",
         "traits": "Innate. Developed."
     }
 ]


### PR DESCRIPTION
Removed erroneous space in the text value for Expeditious Retreat across all found instances. 