### PR TITLE
Fix survivor grisly totem and improvised weapon spanish translations

### DIFF
--- a/translations/es/pack/tcu/fgg.json
+++ b/translations/es/pack/tcu/fgg.json
@@ -66,7 +66,7 @@
         "flavor": "Deberíamos haberlo tirado inmediatamente. Pero ¿cómo podríamos haberlo sabido?",
         "name": "Tótem macabro",
         "text": "[reaction] Después de que asignes una carta a una prueba de habilidad, agota el Tótem macabro: Esa carta obtiene otra copia de uno de sus iconos de habilidad, a tu elección. Si esa prueba de habilidad fracasa, devuelve esa carta a tu mano.",
-        "traits": "Objeto. Amuleto. Maldito.",
+        "traits": "Objeto. Amuleto. Bendecido.",
         "slot": "Accesorio"
     },
     {

--- a/translations/es/pack/tfa/tfa.json
+++ b/translations/es/pack/tfa/tfa.json
@@ -243,7 +243,7 @@
     {
         "code": "04033",
         "name": "Arma improvisada",
-        "text": "Puedes jugar el Arma improvisada desde tu pila de descartes. Si lo haces, añádela a tu mazo y bara éste después de resolver sus efectos.\n<b>Combatir.</b> El Enemigo atacado recibe -1 a combate para este ataque. Si has jugado el Arma improvisada desde tu pila de descartes, este ataque inflige +1 de daño.",
+        "text": "Puedes jugar el Arma improvisada desde tu pila de descartes. Si lo haces, añádela a tu mazo y baraja éste después de resolver sus efectos.\n<b>Combatir.</b> El Enemigo atacado recibe -1 a combate para este ataque. Si has jugado el Arma improvisada desde tu pila de descartes, este ataque inflige +1 de daño.",
         "traits": "Táctica. Improvisado."
     },
     {


### PR DESCRIPTION
Some spanish translation fixes:

- Survivor grisly totem trait should read "blessed" instead of "cursed" as described [here](https://github.com/Kamalisk/arkhamdb/issues/252).
- Minor improvised weapon fix.