### PR TITLE
Fix guardian story cards on enemies

### DIFF
--- a/pack/side/blob_encounter.json
+++ b/pack/side/blob_encounter.json
@@ -64,7 +64,7 @@
 		"encounter_code": "migo_incursion",
 		"encounter_position": 12,
 		"faction_code": "neutral",
-		"health": "2",
+		"health": 2,
 		"illustrator": "James Ives",
 		"is_unique": true,
 		"name": "Lt. Wilson Stewart",

--- a/pack/side/guardians_encounter.json
+++ b/pack/side/guardians_encounter.json
@@ -632,6 +632,7 @@
 		"type_code": "enemy"
 	},
 	{
+		"back_link": "83031b",
 		"code": "83031a",
 		"encounter_code": "brotherhood_of_the_beast",
 		"encounter_position": 1,
@@ -653,9 +654,9 @@
 		"victory": 1
 	},
 	{
-		"back_link": "83031a",
+		"back_link": null,
 		"code": "83031b",
-		"faction_code": "mythos",
+		"faction_code": "neutral",
 		"flavor": "\"I didn't have a choice!\" Layla cries. \"The things I've read… The records I've translated… They all point to one thing,\" she claims. \"Destruction. Ruin. We can't stop it. All we can do is forge a place for our loved ones in the rubble.\" You tell her that you will do everything in your power to stop this 'destruction', but she shakes her head, tears in her eyes. \"It's a fool's errand. But… \" Layla takes a deep breath as she considers her options. \"Promise you'll keep my daughter and my son safe, and I'll help you in any way I can.\"",
 		"hidden": true,
 		"name": "The Translator's Evidence",
@@ -668,6 +669,7 @@
 		"victory": 1
 	},
 	{
+		"back_link": "83032b",
 		"code": "83032a",
 		"encounter_code": "brotherhood_of_the_beast",
 		"encounter_position": 2,
@@ -690,9 +692,9 @@
 		"victory": 1
 	},
 	{
-		"back_link": "83032a",
+		"back_link": null,
 		"code": "83032b",
-		"faction_code": "mythos",
+		"faction_code": "neutral",
 		"flavor": "Despite your best efforts, Dr. Moore slips away while you are occupied by his 'bodyguard'. With the creature defeated, and you hot on his trail, you suspect he will try to escape the city while he has the chance.",
 		"hidden": true,
 		"name": "The Supplicant's Evidence",
@@ -705,6 +707,7 @@
 		"victory": 1
 	},
 	{
+		"back_link": "83033b",
 		"code": "83033a",
 		"encounter_code": "brotherhood_of_the_beast",
 		"encounter_position": 3,
@@ -726,9 +729,9 @@
 		"victory": 1
 	},
 	{
-		"back_link": "83033a",
+		"back_link": null,
 		"code": "83033b",
-		"faction_code": "mythos",
+		"faction_code": "neutral",
 		"flavor": "Nadia's faith is shaken. Scared and confused, she finally gives in. \"There is only one residence in Cairo they told us to spare,\" she explains. \"None of us know why, or what their connection is to the Brotherhood. All we know is they were not to be disturbed.\" She hesitantly gives you a small brass key. \"… So maybe it's time to disturb them. The building's door is marked with lamb's blood.\"",
 		"hidden": true,
 		"name": "The Priestess's Evidence",
@@ -741,6 +744,7 @@
 		"victory": 1
 	},
 	{
+		"back_link": "83034b",
 		"code": "83034a",
 		"encounter_code": "brotherhood_of_the_beast",
 		"encounter_position": 4,
@@ -762,9 +766,9 @@
 		"victory": 1
 	},
 	{
-		"back_link": "83034a",
+		"back_link": null,
 		"code": "83034b",
-		"faction_code": "mythos",
+		"faction_code": "neutral",
 		"flavor": "\"All right, all right,\" Farid relents, \" I'm a businessman, not a soldier. Strike a deal with me, and I'll tell you what I know. Then I'll skip out of town and be out of your hair.\" You ask what he wants. \"There's a vault in the abandoned temple to the east. Word is, there are a lot of old, valuable artifacts in there. The kind that would fetch a high price on the black market.\" He grins toothily. \"Get me into that temple, and I'm all yours. Deal?\"",
 		"hidden": true,
 		"name": "The Salesman's Evidence",
@@ -777,6 +781,7 @@
 		"victory": 1
 	},
 	{
+		"back_link": "83035b",
 		"code": "83035a",
 		"encounter_code": "brotherhood_of_the_beast",
 		"encounter_position": 5,
@@ -797,9 +802,9 @@
 		"victory": 1
 	},
 	{
-		"back_link": "83035a",
+		"back_link": null,
 		"code": "83035b",
-		"faction_code": "mythos",
+		"faction_code": "neutral",
 		"flavor": "Despite his mortal wounds, the assassin grins wickedly. \"The Day is coming,\" he says between a fit of coughs. \"You think killing me will stop it? Fools! The Beast will devour you all!\" He cackles with his final breath, then falls silent.\nYou are quick to search his belongings before any bystanders spot the body. Among the many strange curios on his person, you find a small leather-bound journal with a cryptic inscription:\nOur tribute soaks the abyssal blade\nA thousand souls never to wake\nWith this our Chosen shall arise\nAnd the day is ever nigh!",
 		"hidden": true,
 		"name": "The Assassin's Evidence",
@@ -812,6 +817,7 @@
 		"victory": 1
 	},
 	{
+		"back_link": "83036b",
 		"code": "83036a",
 		"encounter_code": "brotherhood_of_the_beast",
 		"encounter_position": 6,
@@ -833,9 +839,9 @@
 		"victory": 1
 	},
 	{
-		"back_link": "83036a",
+		"back_link": null,
 		"code": "83036b",
-		"faction_code": "mythos",
+		"faction_code": "neutral",
 		"flavor": "\"I'll be dead soon anyway,\" Professor Taylor admits with a deep sigh. \"If it's not you, or the Brotherhood, it'll be the tumor in my lung.\" He dumps the ashes in his pipe and sets it on his table before turning back towards you. \"Fine. I'm certain it'll be the death of both of us, but I'll help you out. Don't know what you expect of me, exactly. I suppose if you found one of the Brotherhood's artifacts, I could study it for you.\"",
 		"hidden": true,
 		"name": "The Professor's Evidence",

--- a/pack/side/guardians_encounter.json
+++ b/pack/side/guardians_encounter.json
@@ -656,7 +656,7 @@
 	{
 		"back_link": null,
 		"code": "83031b",
-		"faction_code": "neutral",
+		"faction_code": "mythos",
 		"flavor": "\"I didn't have a choice!\" Layla cries. \"The things I've read… The records I've translated… They all point to one thing,\" she claims. \"Destruction. Ruin. We can't stop it. All we can do is forge a place for our loved ones in the rubble.\" You tell her that you will do everything in your power to stop this 'destruction', but she shakes her head, tears in her eyes. \"It's a fool's errand. But… \" Layla takes a deep breath as she considers her options. \"Promise you'll keep my daughter and my son safe, and I'll help you in any way I can.\"",
 		"hidden": true,
 		"name": "The Translator's Evidence",
@@ -694,7 +694,7 @@
 	{
 		"back_link": null,
 		"code": "83032b",
-		"faction_code": "neutral",
+		"faction_code": "mythos",
 		"flavor": "Despite your best efforts, Dr. Moore slips away while you are occupied by his 'bodyguard'. With the creature defeated, and you hot on his trail, you suspect he will try to escape the city while he has the chance.",
 		"hidden": true,
 		"name": "The Supplicant's Evidence",
@@ -731,7 +731,7 @@
 	{
 		"back_link": null,
 		"code": "83033b",
-		"faction_code": "neutral",
+		"faction_code": "mythos",
 		"flavor": "Nadia's faith is shaken. Scared and confused, she finally gives in. \"There is only one residence in Cairo they told us to spare,\" she explains. \"None of us know why, or what their connection is to the Brotherhood. All we know is they were not to be disturbed.\" She hesitantly gives you a small brass key. \"… So maybe it's time to disturb them. The building's door is marked with lamb's blood.\"",
 		"hidden": true,
 		"name": "The Priestess's Evidence",
@@ -768,7 +768,7 @@
 	{
 		"back_link": null,
 		"code": "83034b",
-		"faction_code": "neutral",
+		"faction_code": "mythos",
 		"flavor": "\"All right, all right,\" Farid relents, \" I'm a businessman, not a soldier. Strike a deal with me, and I'll tell you what I know. Then I'll skip out of town and be out of your hair.\" You ask what he wants. \"There's a vault in the abandoned temple to the east. Word is, there are a lot of old, valuable artifacts in there. The kind that would fetch a high price on the black market.\" He grins toothily. \"Get me into that temple, and I'm all yours. Deal?\"",
 		"hidden": true,
 		"name": "The Salesman's Evidence",
@@ -804,7 +804,7 @@
 	{
 		"back_link": null,
 		"code": "83035b",
-		"faction_code": "neutral",
+		"faction_code": "mythos",
 		"flavor": "Despite his mortal wounds, the assassin grins wickedly. \"The Day is coming,\" he says between a fit of coughs. \"You think killing me will stop it? Fools! The Beast will devour you all!\" He cackles with his final breath, then falls silent.\nYou are quick to search his belongings before any bystanders spot the body. Among the many strange curios on his person, you find a small leather-bound journal with a cryptic inscription:\nOur tribute soaks the abyssal blade\nA thousand souls never to wake\nWith this our Chosen shall arise\nAnd the day is ever nigh!",
 		"hidden": true,
 		"name": "The Assassin's Evidence",
@@ -841,7 +841,7 @@
 	{
 		"back_link": null,
 		"code": "83036b",
-		"faction_code": "neutral",
+		"faction_code": "mythos",
 		"flavor": "\"I'll be dead soon anyway,\" Professor Taylor admits with a deep sigh. \"If it's not you, or the Brotherhood, it'll be the tumor in my lung.\" He dumps the ashes in his pipe and sets it on his table before turning back towards you. \"Fine. I'm certain it'll be the death of both of us, but I'll help you out. Don't know what you expect of me, exactly. I suppose if you found one of the Brotherhood's artifacts, I could study it for you.\"",
 		"hidden": true,
 		"name": "The Professor's Evidence",


### PR DESCRIPTION
The back links were backwards. I tried fixing it initially, but it seems like setting the incorrect ones to `null` might be necessary to break the link, since I'm not sure the import script properly breaks links?

I ended up having to drop my cards database and reimporting from scratch locally for this to work.