### PR TITLE
Fix summoned hound and Twila spanish translations

### DIFF
--- a/translations/es/pack/tde/pnr.json
+++ b/translations/es/pack/tde/pnr.json
@@ -78,7 +78,7 @@
         "flavor": "\"Este mundo a veces… Ojalá no regresara nunca.\"",
         "name": "Twila Katherine Price",
         "subname": "Perdida en un sueño",
-        "text": "[reaction] Después de que gastes 1 o más cargas de un Apoyo [[Hechizo]], agota a Twila Katherine Price: Coloca 1 carta sobre ese Apoyo.",
+        "text": "[reaction] Después de que gastes 1 o más cargas de un Apoyo [[Hechizo]], agota a Twila Katherine Price: Coloca 1 carga sobre ese Apoyo.",
         "traits": "Aliado. Artista. Soñador.",
         "slot": "Aliado"
     },

--- a/translations/es/pack/tde/wgd.json
+++ b/translations/es/pack/tde/wgd.json
@@ -47,7 +47,7 @@
     {
         "code": "06282",
         "name": "Perro invocado",
-        "text": "Como coste adicional para jugar el Perro invocado, debes buscar 1 copia de la Bestia desatada entre tus cartas enlazadas, añadirla a tu mazo y barajar éste.",
+        "text": "Como coste adicional para jugar el Perro invocado, debes buscar 1 copia de la Bestia desatada entre tus cartas enlazadas, añadirla a tu mazo y barajar éste.\n[free] Durante tu turno, excepto durante una acción, agota el Perro invocado: <b>Combatir/Investigar.</b> Ataca con una habilidad [combat] básica de 5, o bien investiga con una habilidad [intellect] básica de 5.",
         "traits": "Aliado. Invocación.",
         "slot": "Aliado. Arcano"
     },


### PR DESCRIPTION
Two spanish translation fixes here:

- Missing summoned hound fast action text.
- "charge" instead of "card" on Twila's text.