### PR TITLE
Fix perseverance, trench knife and tennessee sour mash spanish translations

### DIFF
--- a/translations/es/pack/ptc/tuo.json
+++ b/translations/es/pack/ptc/tuo.json
@@ -2,7 +2,7 @@
     {
         "code": "03147",
         "flavor": "Ha visto más violencia de la que la mayoría de la gente ve en toda su vida.",
-        "name": "Cuchillo de trinchero",
+        "name": "Cuchillo de trinchera",
         "text": "Las acciones de enfrentarse que realices no provocan ataques de oportunidad.\n[action]: <b>Combatir.</b> Recibes +X [combat] para este ataque. X es la cantidad de Enemigos enfrentados a ti.",
         "traits": "Objeto. Arma. Cuerpo a cuerpo.",
         "slot": "Mano"

--- a/translations/es/pack/tcu/fgg.json
+++ b/translations/es/pack/tcu/fgg.json
@@ -30,7 +30,7 @@
     {
         "code": "05190",
         "name": "Whisky de mosto ácido",
-        "text": "Rápido. Usos (2 suministros).\n[free] Agota el Whisky de mosto ácido y gasta 1 suministro. Recibes +3 [willpower] para una prueba de habilidad de una carta de Traición.\n[action] Descarta el Whisky de mosto ácido: <b>Combatir.</b> Recibes +3 e infliges +1 de daño para este ataque.",
+        "text": "Rápido. Usos (2 suministros).\n[free] Agota el Whisky de mosto ácido y gasta 1 suministro. Recibes +3 [willpower] para una prueba de habilidad de una carta de Traición.\n[action] Descarta el Whisky de mosto ácido: <b>Combatir.</b> Recibes +3 [combat] e infliges +1 de daño para este ataque.",
         "traits": "Objeto. Ilegal."
     },
     {

--- a/translations/es/pack/tcu/tsn.json
+++ b/translations/es/pack/tcu/tsn.json
@@ -58,7 +58,7 @@
     {
         "code": "05117",
         "name": "Whisky de mosto ácido",
-        "text": "Usos (2 suministros).\n[free] Agota el Whisky de mosto ácido y gasta 1 suministro: Recibes +2 [willpower] para una prueba de habilidad de una carta de Traición.\n[action] Descarta el Whisky de mosto ácido: <b>Combatir.</b> Recibes +3 para este ataque.",
+        "text": "Usos (2 suministros).\n[free] Agota el Whisky de mosto ácido y gasta 1 suministro: Recibes +2 [willpower] para una prueba de habilidad de una carta de Traición.\n[action] Descarta el Whisky de mosto ácido: <b>Combatir.</b> Recibes +3 [combat] para este ataque.",
         "traits": "Objeto. Ilegal."
     },
     {

--- a/translations/es/pack/tfa/tof.json
+++ b/translations/es/pack/tfa/tof.json
@@ -55,7 +55,7 @@
         "code": "04111",
         "flavor": "Unas manos encallecidas y un corazón decidido eran todo lo que necesitaba.",
         "name": "Perseverancia",
-        "text": "Rápido. Juega esta carta cuando se te asigne daño y/u horror que fuese a derrotarte.",
+        "text": "Rápido. Juega esta carta cuando se te asigne daño y/u horror que fuese a derrotarte.\nCancela hasta 4 puntos de ese daño y/u horror.",
         "traits": "Espíritu."
     },
     {


### PR DESCRIPTION
More spanish translation fixes:
- Missing perseverance text.
- Fixed trench knife name.
- Missing tennessee sour mash combat icons.