### PR TITLE
Fix name on A Test of Will

### DIFF
--- a/pack/investigator/ste.json
+++ b/pack/investigator/ste.json
@@ -205,7 +205,7 @@
 		"faction_code": "survivor",
 		"flavor": "With or without hope, all you can do is resist.",
 		"illustrator": "Stanislav Dikolenko",
-		"name": "Test of Will",
+		"name": "A Test of Will",
 		"pack_code": "ste",
 		"position": 13,
 		"quantity": 2,


### PR DESCRIPTION
Reported issue with Investigator Decks, got the name wrong of one card.