### PR TITLE
Update `back_flavor` text for TIC investigators

### DIFF
--- a/pack/tic/tic.json
+++ b/pack/tic/tic.json
@@ -30,7 +30,7 @@
 		"type_code": "investigator"
 	},
 	{
-		"back_flavor": "Amanda Sharpe was on track to become one of Miskatonic University's most accomplished graduates. However, ever since she saw a strange painting on an enormous creature's emergence from the depths of the ocean, her classwork has suffered. Her dreams are overwhelmed by images of a vast submerged city and whispers in a language she does not understand. She remains dedicated to her studies, but her goal is no longer to graduate at the top of her class; rather, she seeks to discover the meaning behind the occult secrets concealed between the lines of reality.",
+		"back_flavor": "Amanda Sharpe was on track to become one of Miskatonic University's most accomplished graduates. However, ever since she saw a strange painting of an enormous creature's emergence from the depths of the ocean, her classwork has suffered. Her dreams are overwhelmed by images of a vast submerged city and whispers in a language she does not understand. She remains dedicated to her studies, but her goal is no longer to graduate at the top of her class; rather, she seeks to discover the meaning behind the occult secrets concealed between the lines of reality.",
 		"back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Seeker cards ([seeker]) level 0-5, Neutral cards level 0-5, [[Practiced]] skills level 0-3.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Obscure Studies, Whispers from the Deep, 1 random basic weakness.",
 		"code": "07002",
 		"deck_limit": 1,
@@ -88,7 +88,7 @@
 		"type_code": "investigator"
 	},
 	{
-		"back_flavor": "For Dexter Drake, the magic of fairy tales and myth has been a lifelong fascination. The chance discovery of an old book page during the Great War opened Drake's eyes to the possibility that magic might truly exist. Years later, the promise of arcane tomes locked away in Miskatonic University's special collection draws the successful stage magician to the quiet town of Arkham. Lured to an auction of occult items, \"Drake the Great\" and his assistant, Molly Maxwell, find themselves targeted by the depraved servants of an otherwordly force of disease and corruption. To save Molly, Arkham, and perhaps the world from a horrific transformation, Drake needs more than his wits and quick hands. He must turn to real magic, even if it risks his mind, body, and spirit.",
+		"back_flavor": "Dexter Drake returned from the Great War to become a successful magician, enthralling audiences with his elaborate illusions and cunning stage tricks. Despite his meteoric success, Dexter longed to discover true magic. He was intrigued by the burnt and torn scraps of occult writing he had found during the war—fragments of the infamous Necronomicon. Dexter used his wealth to search for the truth about this ancient lore, and what he found horrified him. He knows that he may well be the only person with the ability to stop evil from swallowing the entire world.",
 		"back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Mystic cards ([mystic]) level 0-5, Rogue cards ([rogue]) level 0-2, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Showmanship, Occult Scraps, 1 random basic weakness.",
 		"code": "07004",
 		"deck_limit": 1,
@@ -118,7 +118,7 @@
 		"type_code": "investigator"
 	},
 	{
-		"back_flavor": "Silas Marsh has always felt called to the sea. As a young lad, he left his family in fear-shadowed Innsmouth and made a name for himself sailing the seven seas. But after the death of his parents, the sea's call has only grown stronger. Silas has dreams - nightmares - of pointed teeth grinning, webbed hands reaching, and eyes glowing in the darkness of the ocean deeps. No one in his family is able to offer an explanation for his dreams, or at least, no one is willing. So when desperate librarian Abigail Foreman comes to Silas with questions of her own, he cannot turn her away. Her ancient and mysterious tome, the <u>Profesiae Profana</u>, points to a stellar event foretelling the end of the world, and painted in its margins are the very same creatures that haunt Silas's nightmares...",
+		"back_flavor": "Silas Marsh has loved the sea ever since he was old enough to toddle through its briny shallows. Becoming a sailor was the easiest decision he ever made, and his sturdy frame and excellent sense for the weather have given him a good reputation aboard any vessel. There is only one thing troubling Silas: over and over again, he dreams of unsettling cities hidden beneath the waves and inhabited by bizarre creatures. These dreams call to him, stirring something deep within him that he thought he had left behind in his hometown of Innsmouth.",
 		"back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Survivor cards ([survivor]) level 0-5, Neutral cards level 0-5, [[Innate]] skills level 0-2.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Sea Change Harpoon, Silas's Net, Siren Call, 1 random basic weakness.",
 		"code": "07005",
 		"deck_limit": 1,


### PR DESCRIPTION
Dexter Drake and Silas Marsh had (presumably placeholder) `back_flavor` text from their novella variants. This updates their TIC variants to have TIC flavor-text. 
Fixed typo in Trish Scarborough `back_flavor`.