### PR TITLE
Fix some typo

### DIFF
--- a/pack/parallel/aon.json
+++ b/pack/parallel/aon.json
@@ -35,7 +35,6 @@
 		"cost": 0,
 		"deck_limit": 1,
 		"faction_code": "neutral",
-		"flavor": "I ain't going to the pen a second time.",
 		"illustrator": "John Pacer",
 		"name": "On the Lam",
 		"pack_code": "aon",

--- a/pack/parallel/aon.json
+++ b/pack/parallel/aon.json
@@ -2,7 +2,7 @@
 	{
 		"alternate_of": "01003",
 		"back_flavor": "Skids hadn't planned on a life of crime. But sometimes doing the right thing means getting your hands dirty. His cellmate, Brad Hollins, would rant and rave about the \"Old Ones\". Skids didn't give it much thought until the night he woke to the sight of his cellmate bursting into flames. When Skids was finally released, he returned to Arkham, looking for answers.",
-		"back_text": "<b>Deck size</b>: 25.\n<b>Deckbuilding Options</b>: Rogue cards ([rogue]) level 0-3, [[Fortune]] cards level 0-3, [[Gambit]] cards level 0-3, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): On the Lam, Hospital Debts, 1 random basic weakness.\n<b>Additional Options</b>: When you upgrade a [[Fortune]] or [[Gambit]] card, you may instead pay the full experience cost on the higher level version and leave the lower level version in your deck (it does not count towards your deck size or the number of copies of that card in your deck).",
+		"back_text": "<b>Deck size</b>: 25.\n<b>Deckbuilding Options</b>: Rogue cards ([rogue]) level 0-5, [[Fortune]] cards level 0-3, [[Gambit]] cards level 0-3, Neutral cards level 0-5.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): On the Lam, Hospital Debts, 1 random basic weakness.\n<b>Additional Options</b>: When you upgrade a [[Fortune]] or [[Gambit]] card, you may instead pay the full experience cost on the higher level version and leave the lower level version in your deck (it does not count towards your deck size or the number of copies of that card in your deck).",
 		"code": "90008",
 		"deck_limit": 1,
 		"deck_options": [

--- a/pack/tde/pnr.json
+++ b/pack/tde/pnr.json
@@ -187,6 +187,7 @@
 		"flavor": "\"Sometimes, this world... I wish I never came back.\"",
 		"health": 1,
 		"illustrator": "Sacha Diener",
+		"is_unique": true,
 		"name": "Twila Katherine Price",
 		"pack_code": "pnr",
 		"position": 244,

--- a/pack/tde/sfk.json
+++ b/pack/tde/sfk.json
@@ -141,6 +141,7 @@
 		"flavor": "I warned you to stay away from me. Now we're both in this together.",
 		"health": 3,
 		"illustrator": "Andreia Ugrai",
+		"is_unique": true,
 		"name": "Jessica Hyde",
 		"pack_code": "sfk",
 		"position": 118,

--- a/translations/ko/pack/tic/tic.json
+++ b/translations/ko/pack/tic/tic.json
@@ -21,7 +21,7 @@
     {
         "code": "07006",
         "name": "Guardian Angel",
-        "text": "Sister Mary deck only.\n<b>This card has not yet been announced and is a placeholder.</b>",
+		"text": "Sister Mary deck only.\nGuardian Angel may be assigned damage dealt to other investigators at your location and connecting locations.\n[reaction] When any amount of damage is assigned to Guardian Angel: Add that many [bless] tokens to the chaos bag.",
         "traits": "본성."
     },
     {
@@ -33,13 +33,13 @@
     {
         "code": "07008",
         "name": "Obscure Studies",
-        "text": "Amanda Sharpe deck only.\n<b>This card has not yet been announced and is a placeholder.</b>",
+		"text": "Amanda Sharpe deck only.\nFast. Play when you initiate a skill test.\nReturn the card beneath Amanda Sharpe to your hand and place Obscure Studies beneath her.",
         "traits": "본성."
     },
     {
         "code": "07009",
         "name": "Whispers from the Deep",
-        "text": "<b>This card has not yet been announced and is a placeholder.</b>",
+		"text": "This skill's icons subtract from your skill value instead of adding to it.\n<b>Forced</b> - When choosing a card to place beneath Amanda Sharpe, if Whispers from the Deep is in your hand: You must choose it.",
         "traits": "정신이상."
     },
     {


### PR DESCRIPTION
Here is the list of typo fixed.
 * remove flavor for 90009 (advanced On the Lam) -- unlike original one, advanced one does not have flavor
 * add unique for 06244 (Twila Katherine Price)
 * add unique for 06118 (Jessica Hyde)

The last one is only for korean language. This problem may cause for all translated server with no translation, but I only fix korean one to avoid conflict issue.
* [KO] replace **This card has not yet been announced and is a placeholder.** into original text in tic.