### PR TITLE
Fix maghan_arkat

### DIFF
--- a/pack/side/wog_encounter.json
+++ b/pack/side/wog_encounter.json
@@ -746,7 +746,7 @@
     },
     {
         "code": "86041",
-        "double_sided": true,
+        "double_sided": false,
         "encounter_code": "children_of_paradise",
         "encounter_position": 2,
         "enemy_damage": 3,


### PR DESCRIPTION
It shouldn't be double sided. Normally we would omit this, but need to set it to false
so it gets corrected in next import