### PR TITLE
packs italian translation update

### DIFF
--- a/translations/it/packs.json
+++ b/translations/it/packs.json
@@ -33,7 +33,7 @@
     },
     {
         "code": "cotr",
-        "name": "La Maledizione dei Rougarou"
+        "name": "La Maledizione del Rougarou"
     },
     {
         "code": "dca",
@@ -41,7 +41,7 @@
     },
     {
         "code": "def",
-        "name": "Devil Reef"
+        "name": "Lo Scoglio del Diavolo"
     },
     {
         "code": "dsm",
@@ -69,7 +69,7 @@
     },
     {
         "code": "hhg",
-        "name": "Horror in High Gear"
+        "name": "Orrore ad Alta Velocità"
     },
     {
         "code": "hote",
@@ -85,11 +85,11 @@
     },
     {
         "code": "itd",
-        "name": "In Too Deep"
+        "name": "Con l'Acqua alla Gola"
     },
     {
         "code": "itm",
-        "name": "Into the Maelstrom"
+        "name": "Nel Maelstrom"
     },
     {
         "code": "jac",
@@ -97,7 +97,7 @@
     },
     {
         "code": "lif",
-        "name": "A Light in the Fog"
+        "name": "Una Luce nella Nebbia"
     },
     {
         "code": "litas",
@@ -105,7 +105,7 @@
     },
     {
         "code": "lod",
-        "name": "The Lair of Dagon"
+        "name": "Il Covo di Dagon"
     },
     {
         "code": "lol",
@@ -133,7 +133,7 @@
     },
     {
         "code": "rtdwl",
-        "name": "Return to the Dunwich Legacy"
+        "name": "Ritorno a... l'Eredità di Dunwich"
     },
     {
         "code": "rtnotz",
@@ -141,11 +141,11 @@
     },
     {
         "code": "rtptc",
-        "name": "Return to the Path to Carcosa"
+        "name": "Ritorno a... la Strada per Carcosa"
     },
     {
         "code": "rttfa",
-        "name": "Return to the Forgotten Age"
+        "name": "Ritorno a... l'Era Dimenticata"
     },
     {
         "code": "sfk",
@@ -238,6 +238,10 @@
     {
         "code": "woc",
         "name": "La Tessitrice del Cosmo"
+    },
+    {
+        "code": "wog",
+        "name": "La Guerra degli Dèi Esterni"
     },
     {
         "code": "wos",


### PR DESCRIPTION
- fix wrong translation in Curse of the Rougarou pack (should be singular)
- translated missing innsmouth cycle packs
- translated missing return to packs
- added missing wog standalone pack