### PR TITLE
italian packs update + italian "tic/tic", "tic/def", "tic/itd", "tic/hhg" investigator cards

### DIFF
--- a/translations/it/pack/tic/def.json
+++ b/translations/it/pack/tic/def.json
@@ -45,7 +45,7 @@
     {
         "code": "07159",
         "name": "Tomo Abissale",
-        "text": "[action] Esaurisci il Tomo Abissale: <b>Combatti.</b> Puoi usare [intellect] oppure [willpower] invece di [combat]. Quando lanci questo attacco, puoi collocare 1 destino sul Tomo Abissale (massimo 3 sul Tomo Abissale). Per ogni destino sul Tomo Abissale, ricevi +1 al valore di abillità e infliggi +1 danno in questo attacco.",
+        "text": "[action] Esaurisci il Tomo Abissale: <b>Combatti.</b> Puoi usare [intellect] oppure [willpower] invece di [combat]. Quando lanci questo attacco, puoi collocare 1 destino sul Tomo Abissale (massimo 3 sul Tomo Abissale). Per ogni destino sul Tomo Abissale, ricevi +1 al valore di abilità e infliggi +1 danno in questo attacco.",
         "traits": "Oggetto. Tomo.",
         "slot": "Mano"
     },

--- a/translations/it/pack/tic/def.json
+++ b/translations/it/pack/tic/def.json
@@ -1,0 +1,70 @@
+[
+    {
+        "code": "07152",
+        "name": "Occhio di Falco",
+        "text": "[free] Spendi 2 risorse: Ricevi +1 [intellect] fino alla fine della fase.\n[free] Spendi 2 risorse: Ricevi +1 [combat] fino alla fine della fase.",
+        "traits": "Talento."
+    },
+    {
+        "code": "07153",
+        "name": "Punizione Radiante",
+        "text": "<b>Combatti.</b> Puoi usare [willpower] invece di [combat]. Quando lanci questo attacco, cerca nel sacchetto del caos fino a 3 segnalini [bless] e sigillali su questa carta. Per ogni segnalino [bless] sigillato sulla Punizione Radiante, ricevi +1 al valore di abilità e infliggi +1 danno in questo attacco. Se questo attacco sconfigge il nemico attaccato, rimetti i segnalini sigillati su questa carta nella riserva dei segnalini. Altrimenti, liberali.",
+        "traits": "Incantesimo. Spirito. Benedetto."
+    },
+    {
+        "code": "07154",
+        "name": "Richiamo della Verità",
+        "text": "Gioca solo se non sei impegnato con alcun nemico.\n<b>Muovi.</b> Scegli 1 luogo chiuso. Muoviti di un luogo alla volta verso quel luogo lungo il percorso più breve finché non entri in quel luogo. Termina questo effetto se apri un luogo, se un nemico ti impegna o se il tuo movimento è bloccato.",
+        "traits": "Intuizione."
+    },
+    {
+        "code": "07155",
+        "name": "Sguardo di Ouraxsh",
+        "text": "Rivela 7 segnalini caos. Infliggi un totale di 1 danno +1 danno aggiuntivo per ogni segnalino [curse] o [auto_fail] rivelato, divisi come preferisci tra i nemici nel tuo luogo. Questa azione non provoca attacchi di opportunità.",
+        "traits": "Incantesimo. Maledetto."
+    },
+    {
+        "code": "07156",
+        "name": "Sacerdote di Due Fedi",
+        "text": "[reaction] Dopo che il Sacerdote di Due Fedi è antrato in gioco: Aggiungi 3 segnalini [bless] al sacchetto del caos.\n<b>Obbligo</b> - Alla fine della Fase di Gestione: Scegli se aggiungere 1 segnalino [curse] al sacchetto del caos oppure scartare il Sacerdote di Due Fedi.",
+        "traits": "Alleato. Benedetto. Maledetto.",
+        "slot": "Alleato"
+    },
+    {
+        "code": "07157",
+        "name": "Sotto Sorveglianza",
+        "text": "Assegna Sotto Sorveglianza al tuo luogo. Limite di 1 per luogo.\n<b>Obbligo</b> - Dopo che un nemico non [[Elite]] è entrato nel luogo con questo evento, scarta Sotto Sorveglianza: Eludi automaticamente quel nemico e scopri 1 indizio nel luogo con questo evento. Quel nemico non è ripristinato durante la Fase di Gestione successiva.",
+        "traits": "Tattica. Trappola."
+    },
+    {
+        "code": "07158",
+        "name": "Patto di Sangue",
+        "text": "[free] Colloca 1 destino sul Patto di Sangue: Ricevi +2 [willpower] in questa prova di abilità. (Limite di una volta per prova.)\n[free] Colloca 1 destino sul Patto di Sangue: Ricevi +2 [combat] in questa prova di abilità. (Limite di una volta per prova.)",
+        "traits": "Incantesimo. Patto."
+    },
+    {
+        "code": "07159",
+        "name": "Tomo Abissale",
+        "text": "[action] Esaurisci il Tomo Abissale: <b>Combatti.</b> Puoi usare [intellect] oppure [willpower] invece di [combat]. Quando lanci questo attacco, puoi collocare 1 destino sul Tomo Abissale (massimo 3 sul Tomo Abissale). Per ogni destino sul Tomo Abissale, ricevi +1 al valore di abillità e infliggi +1 danno in questo attacco.",
+        "traits": "Oggetto. Tomo.",
+        "slot": "Mano"
+    },
+    {
+        "code": "07160",
+        "name": "Effetto Farfalla",
+        "text": "Veloce. Gioca solo quando viene rivelato un segnalino caos con un simbolo durante una prova di abilità nel tuo luogo <i>(prima di risolverne gli effetti)</i>.\nTu oppure l'investigatore che sta effettuando la prova potete scegliere se investire 1 carta in questa prova di abilità oppure rimettere nella mano del proprietario 1 carta che avete investito in questa prova.",
+        "traits": "Paradosso. Benedetto. Maledetto."
+    },
+    {
+        "code": "07161",
+        "name": "Buona la Terza",
+        "text": "Veloce. Gioca solo quando una prova di abilità nel tuo luogo inizia.\nPer due volte durante questa prova, quando un investigatore rivela un segnalino caos, può annullarlo, rimetterlo nel sacchetto del caos e rivelare 1 altro segnalino.",
+        "traits": "Spirito."
+    },
+    {
+        "code": "07162",
+        "name": "Manipolare il Destino",
+        "text": "Rivela segnalini dal sacchetto del caos finché non riveli un segnalino [curse], [auto_fail], [bless] o [elder_sign]. Se hai rivelato:\n- Un segnalino [curse] o [auto_fail], infliggi 2 danni a un nemico nel tuo luogo.\n- Un segnalino [bless] o [elder_sign], cura 2 danni a un investigatore o supporto [[Alleato]] nel tuo luogo.\nQuesta azione non provoca attacchi di opportunità.",
+        "traits": "Incantesimo."
+    }
+]

--- a/translations/it/pack/tic/hhg.json
+++ b/translations/it/pack/tic/hhg.json
@@ -1,0 +1,64 @@
+[
+    {
+        "code": "07189",
+        "name": "Armatura Incantata",
+        "text": "Gioca l'Armatura Incantata sotto il controllo di un qualsiasi investigatore nel tuo luogo.\n<b>Obbligo</b> - Dopo che 1 o più danni e/o orrori sono stati collocati sull'Armatura Incantata: Il proprietario dell'Armatura Incantata effettua una prova [willpower] (X), dove X è l'ammontare totale di danni e orrori su di essa. Se la prova fallisce, scarta l'Armatura Incantata e assegna i danni e/o orrori appena collocati ad altre carte.",
+        "traits": "Rituale. Armatura.",
+        "slot": "Corpo. Arcano"
+    },
+    {
+        "code": "07190",
+        "name": "Benedizione di Iside",
+        "text": "[reaction] Quando viene rivelato un secondo segnalino [bless] durante una singola prova di abilità nel tuo luogo, esaurisci la Benedizione di Iside: Annulla quel segnalino e consideralo invece come se fosse un segnalino [elder_sign]. Dopo che questa prova è terminata, rimetti quei due segnalini nel sacchetto del caos.",
+        "traits": "Rituale. Benedetto."
+    },
+    {
+        "code": "07191",
+        "name": "Grimorio Criptico",
+        "subname": "Testo dell'Araldo Antico",
+        "text": "Puoi includere questo supporto nel tuo mazzo solo migliorandolo dal Grimorio Criptico <i>(Non Tradotto)</i>, e solo se \"il grimorio è stato tradotto\".\n[reaction]: Dopo che hai risolto 1 o più segnalini [curse] durante una prova di abilità: Colloca un pari ammontare di segreti sul Grimorio Criptico.\n[reaction] Quando giochi un evento [[Intuizione]] durante il tuo turno, spendi 2 segreti: Quell'evento ottiene Veloce. Riduci di 1 il suo costo.",
+        "traits": "Oggetto. Tomo. Maledetto.",
+        "slot": "Mano"
+    },
+    {
+        "code": "07192",
+        "name": "Grimorio Criptico",
+        "subname": "Testo del Guardiano Antico",
+        "text": "Puoi includere questo supporto nel tuo mazzo solo migliorandolo dal Grimorio Criptico <i>(Non Tradotto)</i>, e solo se \"il grimorio è stato tradotto\".\n[reaction]: Dopo che hai risolto 1 o più segnalini [curse] durante una prova di abilità: Colloca un pari ammontare di segreti sul Grimorio Criptico.\n[reaction] Quando stai per pescare 1 carta dalla cima del mazzo degli incontri, spendi 5 segreti: Pesca invece 1 carta dal tuo mazzo.",
+        "traits": "Oggetto. Tomo. Benedetto.",
+        "slot": "Mano"
+    },
+    {
+        "code": "07193",
+        "name": "Ríastrad",
+        "text": "<b>Combatti.</b> Quando lanci questo attacco, aggiungi fino a 3 segnalini [curse] al sacchetto del caos. Per ogni segnalino [curse] aggiunto al sacchetto del caos in questo modo, ricevi +1 [combat] e infliggi +1 danno in questo attacco.",
+        "traits": "Incantesimo. Spirito. Maledetto."
+    },
+    {
+        "code": "07194",
+        "flavor": "\"Niente sarà più come prima, Vito.\"",
+        "name": "Tristan Botley",
+        "subname": "Risolutore a Pagamento",
+        "text": "[reaction] Dopo che il tuo turno è iniziato: Scegli 2 abilità. Fino all'inizio del tuo prossimo turno, ricevi +1 a ognuna di quelle abilità.\n[reaction] Dopo che una prova di abilità in cui è stato rivelato un totale di 3 o più segnalini [curse] o [bless] è terminata: Gioca Tristan Botley dalla tua mano, senza pagarne il costo.",
+        "traits": "Alleato. Criminale. Maledetto.",
+        "slot": "Alleato"
+    },
+    {
+        "code": "07195",
+        "name": "Maledizione degli Eoni",
+        "text": "[reaction] Quando viene rivelato un secondo segnalino [curse] durante una singola prova di abilità nel tuo luogo, esaurisci la Maledizione degli Eoni: Annulla quel segnalino e consideralo invece come se fosse un segnalino [skull]. Dopo che la prova è terminata, puoi scegliere di rimuovere quei due segnalini dal sacchetto del caos.",
+        "traits": "Rituale. Maledetto."
+    },
+    {
+        "code": "07196",
+        "name": "Accanimento",
+        "text": "Massimo 1 investimento per prova di abilità.\nDopo che hai investito l'Accanimento in una prova di abilità, cerca nel sacchetto del caos fino a 3 segnalini non [auto_fail] a tua scelta e sigillali sull'Accanimento. Se ci sono 3 segnalini \"+1,\", \"0,\" [bless], e/o [elder_sign] sigillati sull'Accanimento, pesca 2 carte. Dopo che questa prova è terminata, libera tutti i segnalini sigillati su questa carta.",
+        "traits": "Allenamento."
+    },
+    {
+        "code": "07197",
+        "name": "Signum Crucis",
+        "text": "Investi solo in una prova di abilità che stai effettuando e solo se la difficoltà di quella prova è superiore al tuo valore di abilità base.\nDopo che hai investito il Signum Crucis in una prova di abilità, aggiungi X segnalini [bless] al sacchetto del caos dove X è la differenza tra la difficoltà della prova e il tuo valore di abilità base.",
+        "traits": "Allenamento. Benedetto."
+    }
+]

--- a/translations/it/pack/tic/itd.json
+++ b/translations/it/pack/tic/itd.json
@@ -1,36 +1,104 @@
 [
     {
+        "code": "07108",
+        "flavor": "\"Se ti sento soffiare di nuovo in quell'affare, te lo faccio ingoiare.\"",
+        "name": "Fischietto Antisommossa",
+        "text": "Durante il tuo turno, puoi effettuare 1 azione di impegno aggiuntiva.",
+        "traits": "Oggetto. Strumento.",
+        "slot": "Accessorio"
+    },
+    {
+        "code": "07109",
+        "flavor": "Gli occhi di Lita si fecero piccoli, la sua stretta più salda. Non le sarebbero sfuggiti. Né ora, né mai più.",
+        "name": "Caccia del Giusto",
+        "text": "<b>Impegna.</b> Scegli 1 nemico entro un massimo di 2 luoghi di distanza. Muoviti di un luogo alla volta fino al luogo di quel nemico, impegnalo e aggiungi un ammontare di segnalini [bless] al sacchetto del caos pari al valore di Orrore di quel nemico.",
+        "traits": "Tattica. Benedetto."
+    },
+    {
+        "code": "07110",
+        "name": "Sodalizio Sacro",
+        "text": "Permanente. Limite di 1 carta [[Sodalizio]] per mazzo.\n[reaction] Dopo che un investigatore in un qualsiasi luogo ha effettuato il passo \"rivelare il segnalino caos\" di una prova di abilità, esaurisci il Sodalizio Sacro: Rimetti un qualsiasi numero di segnalini [bless] rivelati durante questa prova nel sacchetto del caos, ignorandone i modificatori in questa prova.",
+        "traits": "Sodalizio. Benedetto."
+    },
+    {
         "code": "07111",
-        "flavor": "Once you let go of your assumptions, anything is possible",
-        "name": "Eldritch Sophist",
-        "text": "Uses (3 secrets).\n[fast]: Exhaust Eldritch Sophist: Move 1 secret or charge from an asset you control to another asset controlled by an investigator at your location.",
-        "traits": "Ally. Miskatonic",
-        "slot": "Ally"
+        "flavor": "Una volta abbandonate le proprie convinzioni, tutto è possibile.",
+        "name": "Sofista Esoterico",
+        "text": "Utilizzo (3 segreti).\n[fast]: Esaurisci il Sofista Esoterico: Sposta 1 segreto o 1 carica da un supporto che controlli a un altro supporto controllato da un investigatore nel tuo luogo.",
+        "traits": "Alleato. Miskatonic",
+        "slot": "Alleato"
+    },
+    {
+        "code": "07112",
+        "flavor": "Quando cominci a seguire una pista, è difficile dire a cosa possa condurre.",
+        "name": "Guai in Vista",
+        "text": "Come costo aggiuntivo per giocare Guai in Vista, aggiungi un ammontare di segnalini [curse] al sacchetto del caos pari al valore di Oscurità del tuo luogo.\nScopri 2 indizi nel tuo luogo.",
+        "traits": "Intuizione. Maledetto."
     },
     {
         "code": "07113",
-        "name": "Blasphemous Covenant",
-        "text": "Permanent. Limit 1 [[Covenant]] per deck.\n[reaction] When an investigator at your location reveals a [curse] token during a skill test, exhaust Blasphemous Covenant: Treat that token's modifier as +1 instead of its normal modifier. After this test ends, return that token to the chaos bag.",
-        "traits": "Covenant. Cursed."
+        "name": "Sodalizio Blasfemo",
+        "text": "Permanente. Limite di 1 carta [[Sodalizio]] per mazzo.\n[reaction] Quando un investigatore nel tuo luogo rivela un segnalino [curse] durante una prova di abilità, esaurisci il Sodalizio Blasfemo: Considera il modificatore di quel segnalino come se fosse \"+1\", invece del suo normale modificatore. Dopo che questa prova è terminata, rimetti quel segnalino nel sacchetto del caos.",
+        "traits": "Sodalizio. Maledetto."
+    },
+    {
+        "code": "07114",
+        "flavor": "Con un po' di cautela, può diventare semplicemente \"intrusione\".",
+        "name": "Effrazione",
+        "text": "<b>Indaga.</b> Aggiungi il tuo valore di [agility] al tuo valore di abilità in questa indagine. Se hai successo di 2 o più punti, puoi eludere automaticamente 1 nemico in questo luogo. Questa azione non provoca attacchi di opportunità.",
+        "traits": "Trucchetto."
     },
     {
         "code": "07115",
-        "flavor": "\"Oh, hooey. What's the worst that could happen?\"",
-        "name": "Skeptic",
-        "text": "During this skill test, treat the modifier of each [bless] and each [curse] token as +1 instead of its normal modifier.",
-        "traits": "Practiced."
+        "flavor": "\"Balle. Cosa potrebbe succedere di così grave?\"",
+        "name": "Scetticismo",
+        "text": "Durante questa prova di abilità, considera il modificatore di ogni segnalino [bless] e [curse] come se fosse \"+1\", invece del suo normale modificatore.",
+        "traits": "Allenamento."
+    },
+    {
+        "code": "07116",
+        "name": "Sodalizio Contraffatto",
+        "text": "Permanente. Limite di 1 carta [[Sodalizio]] per mazzo.\n[reaction] Quando un investigatore nel tuo luogo rivela un segnalino [curse] durante una prova di abilità, esaurisci il Sodalizio Contraffatto: Annulla quel segnalino caos, rimettilo nella riserva dei segnalini e rivela 1 altro segnalino.",
+        "traits": "Sodalizio. Maledetto."
+    },
+    {
+        "code": "07117",
+        "name": "Armageddon",
+        "text": "Utilizzo (3 cariche).\n[action] Spendi 1 carica: <b>Combatti.</b> Usa [willpower] invece di [combat]. Infliggi +1 danno in questo attacco. Se viene rivelato un segnalino [curse], puoi infliggere 1 danno a un nemico nel tuo luogo oppure collocare 1 carica sull'Armageddon.",
+        "traits": "Incantesimo. Maledetto.",
+        "slot": "Arcano"
     },
     {
         "code": "07118",
-        "name": "Eye of Chaos",
-        "text": "Uses (3 charges).\n[action] Spend 1 charge: <b>Investigate.</b> Investigate using [willpower] instead of [intellect] If you succeed, discover 1 additional clue at this location. If a [curse] token is revealed during this investigation, you may discover 1 clue at a connecting location or place 1 charge on Eye of Chaos.",
-        "traits": "Spell. Cursed.",
-        "slot": "Arcane"
+        "name": "Occhio del Caos",
+        "text": "Utilizzo (3 cariche).\n[action] Spendi 1 carica: <b>Indaga.</b> Usa [willpower] invece di [intellect]. Se hai successo, scopri 1 indizio aggiuntivo in questo luogo. Se viene rivelato un segnalino [curse], puoi scoprire 1 indizio in un luogo collegato al tuo oppure collocare 1 carica sull'Occhio del Caos.",
+        "traits": "Incantesimo. Maledetto.",
+        "slot": "Arcano"
+    },
+    {
+        "code": "07119",
+        "name": "Velo delle Ombre",
+        "text": "Utilizzo (3 cariche).\n[action] Spendi 1 carica: <b>Eludi.</b> Usa [willpower] invece di [agility]. Se hai successo e il nemico eluso è non [[Elite]], puoi muovere quel nemico fino a un luogo collegato al suo. Se viene rivelato un segnalino [curse], puoi muoverti fino a un luogo collegato al tuo oppure collocare 1 carica sul Velo delle Ombre.",
+        "traits": "Incantesimo. Maledetto.",
+        "slot": "Arcano"
+    },
+    {
+        "code": "07120",
+        "name": "Sodalizio Paradossale",
+        "text": "Permanente. Limite di 1 carta [[Sodalizio]] per mazzo.\n[reaction] Dopo che un investigatore nel tuo luogo ha effettuato il passo \"rivelare il segnalino caos\" di una prova di abilità, se hai rivelato sia un segnalino [bless] che un segnalino [curse], esaurisci il Sodalizio Paradossale: Questa prova ha successo automaticamente <i>(dopo che questa prova è terminata, rimuovi dal sacchetto del caos tutti i segnalini [bless] e [curse] rivelati)</i>.",
+        "traits": "Sodalizio. Benedetto. Maledetto."
+    },
+    {
+        "code": "07121",
+        "name": "Bussola da Marinaio",
+        "text": "[action] Esaurisci la Bussola da Marinaio: <b>Indaga.</b> Se hai successo e non hai risorse nella tua riserva delle risorse, scopri 1 indizio aggiuntivo nel tuo luogo.\n[fast] Durante un'indagine che usa la Bussola da Marinaio, spendi 1 risorsa: Ricevi +1 [intellect] in questa prova di abilità. (Limite di 3 volte per indagine).",
+        "traits": "Oggetto. Strumento.",
+        "slot": "Mano"
     },
     {
         "code": "07122",
-        "name": "Ancient Covenant",
-        "text": "Permanent. Limit 1 [[Covenant]] per deck.\n[reaction] When an investigator at your location resolves a [bless] token during a skill test, exhaust Ancient Covenant: Do not reveal another token as part of this [bless] token's effect.",
-        "traits": "Covenant. Blessed."
+        "name": "Sodalizio Antico",
+        "text": "Permanente. Limite di 1 carta [[Sodalizio]] per mazzo.\n[reaction] Quando un investigatore nel tuo luogo risolve un segnalino [bless] durante una prova di abilità, esaurisci il Sodalizio Antico: Non rivelare un altro segnalino come parte dell'effetto di questo segnalino [bless].",
+        "traits": "Sodalizio. Benedetto."
     }
 ]

--- a/translations/it/pack/tic/tic.json
+++ b/translations/it/pack/tic/tic.json
@@ -33,7 +33,7 @@
         "name": "Dexter Drake",
         "subname": "L'Illusionista",
         "text": "[free] Durante il tuo turno, scarta 1 supporto che controlli: Gioca 1 supporto con un nome diverso dalla tua mano, riducendone di 1 il costo. (Limite di una volta per round.)\n<b>Effetto di </b>[elder_sign]<b>:</b> +2. Puoi rimettere 1 supporto dalla tua area di gioco nella tua mano. Poi pesca 1 carta.",
-        "traits": "Stregone. Veteranp.",
+        "traits": "Stregone. Veterano.",
         "back_flavor": "Tornato dalla Grande Guerra, Dexter Drake diventò un mago di grande successo, in grado di estasiare il pubblico con le sue sofisticate illusioni e i suoi ingegnosi trucchi di scena. Nonostante il successo folgorante, Dexter ha però sempre desiderato conoscere la vera magia, e a questo proposito i ritagli bruciacchiati e strappati che aveva trovato durante la guerra lo intrigavano: erano estratti del famigerato Necronomicon. Dexter sfruttò le sue ricchezze per cercare la verità riguardo questo antico sapere, e ciò che trovò lo fece inorridire: sapeva di essere, con ogni probabilità, l'unica persona munita delle capacità necessarie per impedire al male di inghiottire il mondo intero.",
         "back_text": "<b>Dimensione del Mazzo</b>: 30 carte.\n<b>Opzioni del Mazzo</b>: Carte Mistico ([mystic]) di livello 0-5, carte Canaglia ([rogue]) di livello 0-2, carte neutrali di livello 0-5.\n<b>Requisiti del Mazzo </b>(non considerati nella dimensione del mazzo)<b>:</b> Presenza Scenica, Ritagli Occulti, 1 debolezza base casuale."
     },
@@ -98,7 +98,7 @@
     {
         "code": "07014",
         "name": "Arpione della Controcorrente",
-        "text": "Sol mazzo di Silas Marsh.\n[action]: <b>Combatti.</b> Ricevi +1 [combat] in questo attacco. Se hai investito 1 o più abilità in questa prova di abilità, infliggi +1 danno in questo attacco. Quando questa prova di abilità termina, puoi rimettere l'Arpione della Controcorrente nella tua mano per rimettere tutte le tue abilità investite nela tua mano invece di scartarle.",
+        "text": "Sol mazzo di Silas Marsh.\n[action]: <b>Combatti.</b> Ricevi +1 [combat] in questo attacco. Se hai investito 1 o più abilità in questa prova di abilità, infliggi +1 danno in questo attacco. Quando questa prova di abilità termina, puoi rimettere l'Arpione della Controcorrente nella tua mano per rimettere tutte le tue abilità investite nella tua mano invece di scartarle.",
         "traits": "Oggetto. Arma. Mischia.",
         "slot": "Mano"
     },
@@ -258,7 +258,7 @@
         "code": "07038",
         "name": "Seguace Maledetto",
         "text": "<b>Generazione</b> - Il luogo più lontano da te.\nSfuggente.\n<b>Obbligo</b> - Alla fine della Fase dei Nemici: Aggiungete 1 segnalino [curse] al sacchetto del caos.",
-        "traits": "Humanoid. Cultist. Maledetto."
+        "traits": "Umanoide. Cultista. Maledetto."
     },
     {
         "code": "07039",

--- a/translations/it/pack/tic/tic.json
+++ b/translations/it/pack/tic/tic.json
@@ -1,126 +1,276 @@
 [
     {
         "code": "07001",
-        "flavor": "\"The Lord watches over my path. I am armored in faith.\"",
-        "name": "Sister Mary",
-        "subname": "The Nun",
-        "text": "During setup, add 2 [bless] tokens to the chaos bag.\n[reaction] When the round ends: Add 1 [bless] token to the chaos bag.\n[elder_sign] effect: +1. If you succeed, add 1 [bless] token to the chaos bag.",
-        "traits": "Believer. Blessed.",
-        "back_flavor": "The more Sister Mary learns of the strange and arcane forces that sometimes manifest in this world, the more certain she is that she has been set upon a path to ward off these forces and protect the innocent wherever possible. Armed only with the trappings of her church and an unshakeable faith, Sister Mary seeks out every supernatural threat she hears of through her fellow priests and nuns. Other members of her church may dismiss such things as medieval nonsense, but Sister Mary knows the real evils that exist in the shadows - and she knows that if such evils are left untouched, they will bring ruin and horror to all of creation.",
-        "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Guardian cards ([guardian]) level 0-5, Neutral cards level 0-5, Mystic cards ([mystic]) level 0-2.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Guardian Angel, Crisis of Faith, 1 random basic weakness."
+        "flavor": "\"Il Signore veglia sul mio cammino. La fede è la mia armatura.\"",
+        "name": "Sorella Mary",
+        "subname": "La Suora",
+        "text": "Durante la preparazione, aggiungi 2 segnalini [bless] al sacchetto del caos.\n[reaction] Quando il round termina: Aggiungi 1 segnalino [bless] al sacchetto del caos.\n<b>Effetto di </b>[elder_sign]<b>:</b> +1. Se hai successo, aggiungi 1 segnalino [bless] al sacchetto del caos.",
+        "traits": "Credente. Benedetto.",
+        "back_flavor": "Più cose Sorella Mary scopre sulle strane forze arcane che a volte si manifestano in questo mondo e più si convince di essere stata messa su questa strada per proteggere gli innocenti e respingere quelle forze, quando le è possibile. Armata soltanto dei paramenti della sua chiesa e della sua fede incrollabile, Sorella Mary si mette in cerca di ogni minaccia soprannaturale di cui sente parlare dai preti e dalle altre suore. Gli altri membri della sua chiesa tendono a ignorare questi fenomeni e a bollarli come superstizioni medievali, ma Sorella Mary sa fin troppo bene che il male esiste in senso fin troppo letterale, e che se sarà lasciato libero di agire indisturbato seminerà rovina e orrore in tutto il creato.",
+        "back_text": "<b>Dimensione del Mazzo</b>: 30 carte.\n<b>Opzioni del Mazzo</b>: Carte Guardiano ([guardian]) di livello 0-5, carte Mistico ([mystic]) di livello 0-2, carte neutrali di livello 0-5.\n<b>Requisiti del Mazzo </b>(non considerati nella dimensione del mazzo)<b>:</b> Angelo Custode, Crisi di Fede, 1 debolezza base casuale."
     },
     {
         "code": "07002",
         "name": "Amanda Sharpe",
-        "subname": "The Student",
-        "text": "<b>Forced</b> - At the start of the investigation phase: Draw 1 card. Discard the card beneath Amanda Sharpe. Choose a card from your hand and place it beneath her.\n[reaction] At the start of a skill test you are performing: Commit the card beneath Amanda Sharpe, if able. Do not discard it when the test ends.\n[elder_sign] effect: +0. For this test, you may double the number of skill icons on the card beneath Amanda Sharpe.",
-        "traits": "Miskatonic. Scholar",
-        "back_flavor": "Amanda Sharpe was on track to become one of Miskatonic University's most accomplished graduates. However, ever since she saw a strange painting on an enormous creature's emergence from the depths of the ocean, her classwork has suffered. Her dreams are overwhelmed by images of a vast submerged city and whispers in a language she does not understand. She remains dedicated to her studies, but her goal is no longer to graduate at the top of her class; rather, she seeks to discover the meaning behind the occult secrets concealed between the lines of reality.",
-        "back_text": "<b>Deck Size</b>: 30.\n<b>Deckbuilding Options</b>: Seeker cards ([seeker]) level 0-5, Neutral cards level 0-5, [[Practiced]] skills level 0-3.\n<b>Deckbuilding Requirements</b> (do not count toward deck size): Obscure Studies, Whispers from the Deep, 1 random basic weakness."
+        "subname": "La Studentessa",
+        "text": "<b>Obbligo</b> - All'inizio della Fase degli Investigatori: Pesca 1 carta. Scarta la carta sotto Amanda Sharpe. Scegli 1 carta nella tua mano e collocala sotto di lei.\n[reaction] All'inizio di una prova di abilità che stai effettuando: Investi la carta sotto Amanda Sharpe, se possibile. Non scartarla quando la prova termina.\n<b>Effetto di </b>[elder_sign]<b>:</b> +0. In questa prova, puoi raddoppiare il numero di icone abilità sulla carta sotto Amanda Sharpe.",
+        "traits": "Miskatonic. Accademico.",
+        "back_flavor": "Amanda Sharpe era sulla buona strada per diventare una delle laureate più promettenti della Miskatonic University. Tuttavia, dopo aver visto uno strano dipinto raffigurante un'enorme creatura che emergeva dagli abissi dell'oceano, il suo rendimento scolastico ne ha risentito. Da quel momento, ogni volta che Amanda chiude gli occhi è tormentata dai sogni di una vasta città sommersa e da inquietanti sussurri in una lingua che non comprende. Amanda resta dedita al suo impegno universitario, ma il suo obiettivo non è più quello di laurearsi con il massimo dei voti; piuttosto, ora cerca di scoprire il significato che si cela dietro i segreti occulti nascosti fra le linee della realtà.",
+        "back_text": "<b>Dimensione del Mazzo</b>: 30 carte.\n<b>Opzioni del Mazzo</b>: Carte Studioso ([seeker]) di livello 0-5, carte neutrali di livello 0-5, abilità [[Allenamento]] di livello 0-3.\n<b>Requisiti del Mazzo </b>(non considerati nella dimensione del mazzo)<b>:</b> Studi Oscuri, Sussurri dal Profondo, 1 debolezza base casuale."
+    },
+    {
+        "code": "07003",
+        "name": "Trish Scarborough",
+        "subname": "La Spia",
+        "text": "[reaction] Dopo che hai scoperto 1 o più indizi in un luogo con 1 o più nemici: Puoi scegliere se scoprire 1 indizio aggiuntivo in quel luogo oppure eludere automaticamente 1 di quei nemici. (Limite di una volta per round.)\n<b>Effetto di </b>[elder_sign]<b>:</b> +2. Se stai indagando, puoi scegliere un qualsiasi luogo aperto; ora indaghi come se ti trovassi invece in quel luogo.",
+        "traits": "Agency. Detective.",
+        "back_flavor": "Trish aveva sempre primeggiato tanto nelle prove fisiche quanto in quelle mentali, grazie a una combinazione infallibile di determinazione e coraggio. Dati i suoi stellari risultati accademici e sportivi, tutti si aspettavano di vederle compiere grandi cose. Invece, Trish accettò un lavoro in una compagnia di codici commerciali. Quando lo sorpresa iniziale causata dal suo umile impiego svanì, la straordinaria Trish Scarborough finì nel dimenticatoio: non avrebbe potuto chiedere di meglio. In questo modo, nessuno avrebbe scoperto facilmente la verità: il suo lavoro non era che una copertura per il suo vero incarico come spia della Camera Nera, l'agenzia di decodificazione dell'FBI.",
+        "back_text": "<b>Dimensione del Mazzo</b>: 30 carte.\n<b>Opzioni del Mazzo</b>: Carte Canaglia ([rogue]) di livello 0-5, carte Studioso ([seeker]) di livello 0-2, carte neutrali di livello 0-5.\n<b>Requisiti del Mazzo </b>(non considerati nella dimensione del mazzo)<b>:</b> Tra le Ombre, Agenti dell'Ombra, 1 debolezza base casuale."
+    },
+    {
+        "code": "07004",
+        "flavor": "\"Vuoi vedere una vera magia?\"",
+        "name": "Dexter Drake",
+        "subname": "L'Illusionista",
+        "text": "[free] Durante il tuo turno, scarta 1 supporto che controlli: Gioca 1 supporto con un nome diverso dalla tua mano, riducendone di 1 il costo. (Limite di una volta per round.)\n<b>Effetto di </b>[elder_sign]<b>:</b> +2. Puoi rimettere 1 supporto dalla tua area di gioco nella tua mano. Poi pesca 1 carta.",
+        "traits": "Stregone. Veteranp.",
+        "back_flavor": "Tornato dalla Grande Guerra, Dexter Drake diventò un mago di grande successo, in grado di estasiare il pubblico con le sue sofisticate illusioni e i suoi ingegnosi trucchi di scena. Nonostante il successo folgorante, Dexter ha però sempre desiderato conoscere la vera magia, e a questo proposito i ritagli bruciacchiati e strappati che aveva trovato durante la guerra lo intrigavano: erano estratti del famigerato Necronomicon. Dexter sfruttò le sue ricchezze per cercare la verità riguardo questo antico sapere, e ciò che trovò lo fece inorridire: sapeva di essere, con ogni probabilità, l'unica persona munita delle capacità necessarie per impedire al male di inghiottire il mondo intero.",
+        "back_text": "<b>Dimensione del Mazzo</b>: 30 carte.\n<b>Opzioni del Mazzo</b>: Carte Mistico ([mystic]) di livello 0-5, carte Canaglia ([rogue]) di livello 0-2, carte neutrali di livello 0-5.\n<b>Requisiti del Mazzo </b>(non considerati nella dimensione del mazzo)<b>:</b> Presenza Scenica, Ritagli Occulti, 1 debolezza base casuale."
+    },
+    {
+        "code": "07005",
+        "flavor": "\"Lasciate le vostre paure al molo.\"",
+        "name": "Silas Marsh",
+        "subname": "Il Marinaio",
+        "text": "[reaction] Dopo che hai rivelato 1 segnalino caos durante una prova di abilità che stai effettuando: Rimetti 1 abilità che hai investito in questa prova nella tua mano. (Limite di una volta per round.)\n<b>Effetto di </b>[elder_sign]<b>:</b> +0. Puoi investire 1 abilità dalla tua pila degli scarti in questa prova. Dopo che questa prova è terminata, rimetti quell'abilità nella tua mano invece di scartarla.",
+        "traits": "Vagabondo.",
+        "back_flavor": "Silas Marsh aveva sempre amato il mare, fin da bambino quando trotterellava sulle spiagge salmastre. Diventare un marinaio fu la decisione più facile che avesse mai preso; la sua corporatura robusta e la sua abilità nel prevedere il tempo atmosferico gli procurarono una buona reputazione a bordo di tutte le imbarcazioni. C'era soltanto una cosa che lo turbava: in sogno gli comparivano in continuazione alcune inquietanti città sommerse, reclamate dagli abissi e popolate da strane creature. Questi sogni continuavano a chiamarlo, risvegliando in lui qualcosa che pensava di essersi lasciato alle spalle assieme alla sua città d'origine, Innsmouth.",
+        "back_text": "<b>Dimensione del Mazzo</b>: 30 carte.\n<b>Opzioni del Mazzo</b>: Carte Sopravvissuto ([survivor]) di livello 0-5, carte neutrali di livello 0-5, abilità [[Innato]] di livello 0-2.\n<b>Requisiti del Mazzo </b>(non considerati nella dimensione del mazzo)<b>:</b> Arpione della Controcorrente, Rete di Silas, Richiamo della Sirena, 1 debolezza base casuale."
     },
     {
         "code": "07006",
-        "name": "Guardian Angel",
-        "text": "Sister Mary deck only.\n<b>This card has not yet been announced and is a placeholder.</b>",
-        "traits": "Innate."
+        "name": "Angelo Custode",
+        "text": "Solo nel mazzo di Sorella Mary.\nPuoi assegnare all'Angelo Custode i danni inflitti agli altri investigatori nel tuo luogo e nei luoghi collegati al tuo.\n[reaction] Quando 1 o più danni sono assegnati all'Angelo Custode: Aggiungi un pari ammontare di segnalini [bless] al sacchetto del caos.",
+        "traits": "Rituale. Benedetto."
     },
     {
         "code": "07007",
-        "name": "Crisis of Faith",
-        "text": "<b>Revelation</b> - For each [bless] token in the chaos bag, you must either replace it with a [curse] token or take 1 horror.",
-        "traits": "Madness."
+        "name": "Crisi di Fede",
+        "text": "<b>Rivelazione</b> - Per ogni segnalino [bless] nel sacchetto del caos, scegli se sostituirlo con 1 segnalino [curse] oppure subire 1 orrore.",
+        "traits": "Follia."
     },
     {
         "code": "07008",
-        "name": "Obscure Studies",
-        "text": "Amanda Sharpe deck only.\n<b>This card has not yet been announced and is a placeholder.</b>",
-        "traits": "Innate."
+        "name": "Studi Oscuri",
+        "text": "Solo mazzo di Amanda Sharpe.\nVeloce. Gioca solo quando lanci una prova di abilità.\nRimetti nella tua mano la carta sotto Amanda Sharpe e colloca gli Studi Oscuri sotto di lei.",
+        "traits": "Intuizione."
     },
     {
         "code": "07009",
-        "name": "Whispers from the Deep",
-        "text": "<b>This card has not yet been announced and is a placeholder.</b>",
-        "traits": "Madness."
+        "name": "Sussurri dal Profondo",
+        "text": "Le icone di quest'abilità vengono sottratte dal tuo valore di abilità invece che aggiunte.\n<b>Obbligo</b> - Quando scegli una carta da collocare sotto Amanda Sharpe, se i Sussurri dal Profondo sono nella tua mano: Scegli i Sussurri dal Profondo.",
+        "traits": "Maledizione."
+    },
+    {
+        "code": "07010",
+        "name": "Tra le Ombre",
+        "text": "Solo mazzo di Trish Scarborough.\nVeloce. Gioca solo dopo che il tuo turno è iniziato.\nDisimpegnati da ogni nemico impegnato con te. Fino alla fine del round, i nemici non possono impegnarti e non puoi infliggere danni ai nemici.",
+        "traits": "Tattica."
+    },
+    {
+        "code": "07011",
+        "name": "Agenti dell'Ombra",
+        "text": "<b>Preda</b> - Solo Trish Scarborough.\nCacciatore.\nFinché gli Agenti dell'Ombra sono impegnati con te, puoi scoprire indizi solo indagando.\n<b>Obbligo</b> - Dopo che gli Agenti dell'Ombra sono stati elusi: Scartateli.",
+        "traits": "Umanoide. Cultista."
+    },
+    {
+        "code": "07012",
+        "name": "Presenza Scenica",
+        "text": "Solo mazzo di Dexter Drake .\n[reaction] Dopo che un supporto è entrato in gioco sotto il tuo controllo: Fino alla fine del round, ricevi +2 a ogni tua abilità finché stai risolvendo una capacità innescata da quel supporto.",
+        "traits": "Talento."
+    },
+    {
+        "code": "07013",
+        "name": "Ritagli Occulti",
+        "text": "I Ritagli Occulti non possono essere giocati usando un'azione di gioco.\nFinché i Ritagli Occulti sono nella tua mano, ricevi -2 [willpower].\nFinché i Ritagli Occulti sono in gioco, ricevi -1 [willpower].",
+        "traits": "Oggetto."
+    },
+    {
+        "code": "07014",
+        "name": "Arpione della Controcorrente",
+        "text": "Sol mazzo di Silas Marsh.\n[action]: <b>Combatti.</b> Ricevi +1 [combat] in questo attacco. Se hai investito 1 o più abilità in questa prova di abilità, infliggi +1 danno in questo attacco. Quando questa prova di abilità termina, puoi rimettere l'Arpione della Controcorrente nella tua mano per rimettere tutte le tue abilità investite nela tua mano invece di scartarle.",
+        "traits": "Oggetto. Arma. Mischia.",
+        "slot": "Mano"
+    },
+    {
+        "code": "07015",
+        "name": "Rete di Silas",
+        "text": "Solo mazzo di Silas Marsh.\n[action]: <b>Eludi.</b> Ricevi +1 [agility] in questo tentativo di elusione. Se hai successo e hai investito 1 o più abilità in questa prova di abilità, puoi eludere automaticamente 1 altro nemico impegnato con te. Quando questa prova di abilità termina, puoi rimettere la Rete di Silas nella tua mano per rimettere tutte le tue abilità investite nella tua mano invece di scartarle.",
+        "traits": "Oggetto. Strumento.",
+        "slot": "Mano"
+    },
+    {
+        "code": "07016",
+        "name": "Richiamo della Sirena",
+        "text": "<b>Rivelazione</b> - Metti in gioco il Richiamo della Sirena nella tua area di minaccia.\nCome costo aggiuntivo per investire 1 o più carte in una prova di abilità, devi pagare 1 risorsa per ogni icona abilità corrispondente su quelle carte.\n[action] [action]: Scarta il Richiamo della Sirena.",
+        "traits": "Maledizione."
+    },
+    {
+        "code": "07017",
+        "name": "Libro dei Salmi",
+        "text": "Utilizzo (4 segreti).\n[action] Spendi 1 segreto: Cura 1 orrore a un investigatore nel tuo luogo. Aggiungi 2 segnalini [bless] al sacchetto del caos.",
+        "traits": "Oggetto. Tomo. Benedetto.",
+        "slot": "Mano"
     },
     {
         "code": "07018",
-        "name": "Blessed Blade",
-        "text": "[action] If Blessed Blade is ready: <b>Fight.</b> You get +1 [combat] for this attack. If a [bless] or [elder_sign] token is revealed during this attack, this attack deals +1 damage. Before revealing chaos token(s) for this attack, you may exhaust Blessed Blade to add 1 [bless] token to the chaos bag.",
-        "traits": "Item. Weapon. Melee. Blessed.",
-        "slot": "Hand"
+        "name": "Lama Benedetta",
+        "text": "[action] Se la Lama Benedetta è pronta: <b>Combatti.</b> Ricevi +1 [combat] in questo attacco. Se riveli un segnalino [bless] o [elder_sign], infliggi +1 danno in questo attacco. Prima di rivelare i segnalini caos in questo attacco, puoi esaurire la Lama Benedetta per aggiungere 1 segnalino [bless] al sacchetto del caos.",
+        "traits": "Oggetto. Arma. Mischia. Benedetto.",
+        "slot": "Mano"
     },
     {
         "code": "07019",
-        "name": "Rite of Sanctification",
-        "text": "Seal (up to 5 [bless]). If Rite of Sanctification has no tokens sealed on it, discard it.\n[reaction] When an investigator at your location plays a card, exhaust Rite of Sanctification and release a chaos token sealed on it: Reduce the cost of that card by 2.",
-        "traits": "Ritual. Blessed.",
-        "slot": "Arcane"
+        "name": "Rito di Beatificazione",
+        "text": "Sigillo (fino a 5 [bless]). Se non ci sono segnalini sigillati sul Rito di Beatificazione, scartalo.\n[reaction] Quando un investigatore nel tuo luogo gioca una carta, esaurisci il Rito di Beatificazione e libera 1 segnalino caos sigillato su di esso: Riduci di 2 il costo di quella carta.",
+        "traits": "Rituale. Benedetto.",
+        "slot": "Arcano"
+    },
+    {
+        "code": "07020",
+        "name": "Mano del Destino",
+        "text": "Veloce. Gioca solo quando un nemico attacca un investigatore nel tuo luogo.\nAnnulla quell'attacco. Poi aggiungi un ammontare di segnalini [bless] al sacchetto del caos pari al totale dei valori di Danno e Orrore del nemico attaccante.",
+        "traits": "Incantesimo. Benedetto."
+    },
+    {
+        "code": "07021",
+        "name": "Cifrario Crittografico",
+        "text": "Utilizzo (3 segreti).\n[fast] Esaurisci il Cifrario Crittografico e spendi 1 segreto: <b>Indaga.</b> Aumenta di 1 il valore di Oscurità del tuo luogo in questa indagine.\n[action] Esaurisci il Cifrario Crittografico e spendi 1 segreto: <b>Indaga.</b> Riduci di 2 il valore di Oscurità del tuo luogo in questa indagine.",
+        "traits": "Oggetto. Strumento.",
+        "slot": "Mano"
     },
     {
         "code": "07022",
-        "name": "Cryptic Grimoire",
-        "subname": "Untranslated",
-        "text": "[action]: Add 1 [curse] token to the chaos bag.\n[action] If there are 10 [curse] tokens in the chaos bag, discard Cryptic Grimoire: Record in your Campaign Log that \"you have translated the grimoire.\" Replace 5 [curse] tokens in the chaos bag with 5 [bless] tokens.",
-        "traits": "Item. Tome. Occult.",
-        "slot": "Hand"
+        "name": "Grimorio Criptico",
+        "subname": "Non Tradotto",
+        "text": "[action]: Aggiungi 1 segnalino [curse] al sacchetto del caos.\n[action] Se ci sono 10 segnalini [curse] nel sacchetto del caos, scarta il Grimorio Criptico: Annota nel Diario della Campagna che \"il grimorio è stato tradotto\". Sostituisci 5 segnalini [curse] nel sacchetto del caos con 5 segnalini [bless].",
+        "traits": "Oggetto. Tomo. Occulto.",
+        "slot": "Mano"
+    },
+    {
+        "code": "07023",
+        "name": "Studi Approfonditi",
+        "text": "Come costo aggiuntivo per giocare gli Studi Approfonditi, aggiungi 2 segnalini [curse] al sacchetto del caos.\nGli investigatori nel tuo luogo pescano un totale di 3 carte <i>(scegli tu quante carte pesca ogni investigatore)</i>.",
+        "traits": "Intuizione. Maledetto."
+    },
+    {
+        "code": "07024",
+        "name": "Piano d'Azione",
+        "text": "Se questa prova di abilità è effettuata prima o durante la prima azione di questo turno, il Piano d'Azione ottiene [willpower] [agility].\nSe questa prova di abilità è effettuata tra la prima e la terza azione di questo turno, pesca 1 carta se ha successo.\nSe questa prova di abilità è effettuata durante o dopo la terza azione di questo turno, il Piano d'Azione ottiene [combat] [intellect].",
+        "traits": "Allenamento."
+    },
+    {
+        "code": "07025",
+        "name": "Automatica Calibro 25",
+        "text": "Veloce. Utilizzo (4 munizioni).\n[action] Spendi 1 munizione: <b>Combatti.</b> Se il nemico attaccato è esaurito, ricevi +2 [combat] e infliggi +1 danno in questo attacco.",
+        "traits": "Oggetto. Arma. Arma da Fuoco. Illecito.",
+        "slot": "Mano"
+    },
+    {
+        "code": "07026",
+        "name": "Rituale Oscuro",
+        "text": "Sigillo (fino a 5 [curse]).\n<b>Obbligo</b> - Alla fine della Fase dei Miti: Scegli se spendere 1 risorsa oppure scartare il Rituale Oscuro.",
+        "traits": "Rituale. Maledetto.",
+        "slot": "Arcano"
     },
     {
         "code": "07027",
-        "flavor": "Now you see me...",
-        "name": "Obfuscation",
-        "text": "Fast. Uses (3 charges).\n[reaction] When an enemy makes an attack of opportunity against you, spend 1 charge: Cancel that attack.",
-        "traits": "Spell.",
-        "slot": "Arcane"
+        "flavor": "Ora mi vedi...",
+        "name": "Offuscamento",
+        "text": "Veloce. Utilizzo (3 cariche).\n[reaction] Quando un nemico effettua un attacco di opportunità contro di te, spendi 1 carica: Annulla quell'attacco.",
+        "traits": "Incantesimo.",
+        "slot": "Arcano"
     },
     {
         "code": "07028",
-        "name": "Faustian Bargain",
-        "text": "As an additional cost to play Faustian Bargain, add 2 [curse] tokens to the chaos bag.\nInvestigators at your location gain a total of 5 resources, distributed as you wish.",
-        "traits": "Pact. Cursed."
+        "name": "Patto col Diavolo",
+        "text": "Come costo aggiuntivo per giocare il Patto col Diavolo, aggiungi 2 segnalini [curse] al sacchetto del caos.\nGli investigatori nel tuo luogo ottengono un totale di 5 risorse, distribute come preferisci.",
+        "traits": "Patto. Maledetto."
     },
     {
         "code": "07029",
-        "name": "Sword Cane",
-        "text": "Playing Sword Cane does not provoke attacks of opportunity.\n[reaction] After Sword Cane enters play: Immediately trigger its \"[action]\" ability without paying its cost.\n[action] Exhaust Sword Cane: <b>Fight</b>/<b>Evade.</b> You may use your [willpower] in place of your [combat] or [agility] for this attack or evasion attempt.",
-        "traits": "Item. Relic. Weapon. Melee.",
-        "slot": "Hand"
+        "name": "Bastone Animato",
+        "text": "Giocare il Bastone Animato non provoca attacchi di opportunità.\n[reaction] Dopo che il Bastone Animato è entrato in gioco: Innesca immediatamente la sua capacità [action] senza pagarne il costo.\n[action] Esaurisci il Bastone Animato: <b>Combatti</b>/<b>Eludi.</b> Puoi usare [willpower] invece di [combat] o [agility] in questo attacco o tentativo di elusione.",
+        "traits": "Oggetto. Reliquia. Arma. Mischia.",
+        "slot": "Mano"
     },
     {
         "code": "07030",
-        "name": "Tides of Fate",
-        "text": "Fast. Play during any [fast] window, or at the start of the round.\nReplace all [curse] tokens in the chaos bag with an equal number of [bless] tokens. At the end of the round, replace all [bless] tokens in the chaos bag with an equal number of [curse] tokens.",
-        "traits": "Spell. Blessed."
+        "name": "Correnti del Destino",
+        "text": "Veloce. Gioca solo durante una finestra [fast] oppure all'inizio del round.\nSostituisci tutti i segnalini [curse] nel sacchetto del caos con un pari ammontare di segnalini [bless]. Alla fine del round, sostituisci tutti i segnalini [bless] nel sacchetto del caos con un pari ammontare di segnalini [curse].",
+        "traits": "Incantesimo. Benedetto."
     },
     {
         "code": "07031",
-        "name": "Ward of Radiance",
-        "text": "Fast. Play when an investigator at your location draws a non-weakness treachery card.\nReveal 5 random chaos tokens from the chaos bag\nIf a [bless] or [elder_sign] token is revealed, cancel that treachery card's revelation effect.",
-        "traits": "Insight. Blessed."
+        "name": "Interdizione Radiante",
+        "text": "Veloce. Gioca solo quando un investigatore nel tuo luogo pesca una carta sventura non debolezza.\nRivela 5 segnalini caos.\nSe riveli un segnalino [bless] o [elder_sign], annulla la capacità Rivelazione di quella carta sventura.",
+        "traits": "Intuizione. Benedetto."
     },
     {
         "code": "07032",
-        "name": "Promise of Power",
-        "text": "After you commit Promise of Power to a skill test, add 1 [curse] token to the chaos bag. If you cannot, take 2 horror instead.",
-        "traits": "Practiced. Cursed."
+        "name": "Promessa di Potere",
+        "text": "Dopo che hai investito la Promessa di Potere in una prova di abilità, aggiungi 1 segnalino [curse] al sacchetto del caos. Se non puoi farlo, subisci invece 2 orrori.",
+        "traits": "Allenamento. Maledetto."
     },
     {
         "code": "07033",
-        "name": "Token of Faith",
-        "text": "[reaction] After a skill test ends in which 1 or more [curse] or [auto_fail] tokens were revealed, exhaust Token of Faith: Add that many [bless] tokens to the chaos bag.",
-        "traits": "Item. Charm.",
-        "slot": "Accessory"
+        "name": "Simbolo di Fede",
+        "text": "[reaction] Dopo che una prova di abilità in cui sono stati rivelati 1 o più segnalini [curse] o [auto_fail] è terminata, esaurisci il Simbolo di Fede: Aggiungi un pari ammontare di segnalini [bless] al sacchetto del caos.",
+        "traits": "Oggetto. Amuleto.",
+        "slot": "Accessorio"
+    },
+    {
+        "code": "07034",
+        "name": "Rinsaldare la Fede",
+        "text": "Veloce. Gioca solo durante una finestra [fast].\nAggiungi 4 segnalini [bless] al sacchetto del caos.",
+        "traits": "Sorte. Benedetto."
     },
     {
         "code": "07035",
-        "name": "Predestined",
-        "text": "Max 1 committed per skill test.\nYou may commit Predestined to any type of test.\nIf this test fails, either add 2 [bless] tokens to the chaos bag or remove 2 [curse] tokens from the chaos bag.",
-        "traits": "Fortune. Blessed."
+        "name": "Predestinato",
+        "text": "Massimo 1 investimento per prova di abilità.\nPuoi investire Predestinato in qualsiasi tipo di prova.\nSe questa prova fallisce, puoi scegliere se aggiungere 2 segnalini [bless] al sacchetto del caos oppure rimuovere 2 segnalini [curse] dal sacchetto del caos.",
+        "traits": "Sorte. Benedetto."
+    },
+    {
+        "code": "07036",
+        "flavor": "L'amore è l'incantesimo più forte che esista.",
+        "name": "Benamato",
+        "text": "Se riveli un segnalino [bless] durante questa prova, puoi rimuovere dal gioco Benamato per sostituire gli effetti di quel segnalino con il seguente: \"Hai successo automaticamente. <i>(Non rivelare un altro segnalino. Dopo che questa prova è terminata, rimetti questo segnalino nel sacchetto del caos.)</i>\"",
+        "traits": "Innato. Benedetto."
+    },
+    {
+        "code": "07037",
+        "name": "Sfidare la Sorte",
+        "text": "Veloce. Gioca solo durante una finestra [fast].\nAggiungi 3 segnalini [curse] al sacchetto del caos. Poi aggiungi 3 segnalini [bless] al sacchetto del caos e pesca 1 carta.",
+        "traits": "Sorte. Benedetto. Maledetto."
+    },
+    {
+        "code": "07038",
+        "name": "Seguace Maledetto",
+        "text": "<b>Generazione</b> - Il luogo più lontano da te.\nSfuggente.\n<b>Obbligo</b> - Alla fine della Fase dei Nemici: Aggiungete 1 segnalino [curse] al sacchetto del caos.",
+        "traits": "Humanoid. Cultist. Maledetto."
     },
     {
         "code": "07039",
-        "flavor": "We all have wings, but they have not been of any avail to us and if we could tear them off, we would do so.\n- Franz Kafka, \"The Blue Octavo Notebooks\"",
-        "name": "Dread Curse",
-        "text": "<b>Revelation</b> - Add 5 [curse] tokens to the chaos bag.",
-        "traits": "Curse."
+        "flavor": "Noi tutti abbiamo le ali, ma non ci sono servite a niente e, se potessimo, ce le strapperemmo di dosso.\n- Franz Kafka, \"Quaderni in Ottavo\"",
+        "name": "Maledizione Terrificante",
+        "text": "<b>Rivelazione</b> - Aggiungi 5 segnalini [curse] al sacchetto del caos.",
+        "traits": "Meledizione."
+    },
+    {
+        "code": "07040",
+        "name": "Giorno del Giudizio",
+        "text": "<b>Rivelazione</b> - Assegna il Giorno del Giudizio alla trama attuale. Poi cerca nel sacchetto del caos 1 segnalino [elder_sign] e sigillalo sul Giorno del Giudizio.\n<b>Carta ispirata agli eventi delle Arkham Nights 2018.</b>",
+        "traits": "Ultimi Giorni."
     }
 ]

--- a/translations/it/packs.json
+++ b/translations/it/packs.json
@@ -1,11 +1,15 @@
 [
     {
         "code": "aon",
-        "name": "All or Nothing"
+        "name": "Tutto o Niente"
     },
     {
         "code": "apot",
         "name": "Lo Spettro della Verità"
+    },
+    {
+        "code": "bad",
+        "name": "Sangue Amaro"
     },
     {
         "code": "bbt",
@@ -14,6 +18,10 @@
     {
         "code": "blob",
         "name": "La Melma Che Divorò Ogni Cosa"
+    },
+    {
+        "code": "bob",
+        "name": "Blood of Baalshandor"
     },
     {
         "code": "bota",
@@ -42,6 +50,10 @@
     {
         "code": "def",
         "name": "Lo Scoglio del Diavolo"
+    },
+    {
+        "code": "dre",
+        "name": "Dark Revelations"
     },
     {
         "code": "dsm",
@@ -80,8 +92,16 @@
         "name": "Assassinio all'Hotel Excelsior"
     },
     {
+        "code": "hoth",
+        "name": "Hour of the Huntress"
+    },
+    {
         "code": "icc",
         "name": "Nelle Grinfie del Caos"
+    },
+    {
+        "code": "iotv",
+        "name": "Ire of the Void"
     },
     {
         "code": "itd",
@@ -133,19 +153,23 @@
     },
     {
         "code": "rtdwl",
-        "name": "Ritorno a... l'Eredità di Dunwich"
+        "name": "Ritorno a... L'Eredità di Dunwich"
     },
     {
         "code": "rtnotz",
-        "name": "Ritorno a... la Notte della Zelota"
+        "name": "Ritorno a... La Notte della Zelota"
     },
     {
         "code": "rtptc",
-        "name": "Ritorno a... la Strada per Carcosa"
+        "name": "Ritorno a... La Strada per Carcosa"
+    },
+    {
+        "code": "rttcu",
+        "name": "Ritorno a... Il Circolo Spezzato"
     },
     {
         "code": "rttfa",
-        "name": "Ritorno a... l'Era Dimenticata"
+        "name": "Ritorno a... L'Era Dimenticata"
     },
     {
         "code": "sfk",
@@ -176,6 +200,14 @@
         "name": "I Divoratori di Sogni"
     },
     {
+        "code": "tdg",
+        "name": "The Deep Gate"
+    },
+    {
+        "code": "tdor",
+        "name": "The Dirge of Reason"
+    },
+    {
         "code": "tdoy",
         "name": "Abissi di Yoth"
     },
@@ -186,6 +218,10 @@
     {
         "code": "tfa",
         "name": "L'Era Dimenticata"
+    },
+    {
+        "code": "tftbw",
+        "name": "To Fight the Black Wind"
     },
     {
         "code": "tic",


### PR DESCRIPTION
Italian packs update:
- added missing "return to..."
- added missing  (untranslated) books
- updated (community translated) parallel scenarios

Italian investigator cards added:
- "The Innsmouth's Conspiracy" deluxe pack (tic/tic)
- "In Too Deep" mythos pack (tic/itd)
- "Devil's Reef" mythos pack (tic/def)
- "Horror in High Gear" mythos pack (tic/hhg)