### PR TITLE
fix german translation of Lockpicks and Pendant of Queen

### DIFF
--- a/translations/de/pack/ptc/ptc.json
+++ b/translations/de/pack/ptc/ptc.json
@@ -231,7 +231,7 @@
     {
         "code": "03031",
         "name": "Dietriche",
-        "text": "Anwendungen (3 Vorräte). Falls Dietriche keine Vorräte hat, lege sie ab\n[action] Erschöpfe Dietriche: <b>Ermitteln.</b> Füge für diese Ermittlung deinen [agility]-Wert zum Fertigkeitswert hinzu. Falls dir die Probe gelingt, entferne 1 Vorrat von Dietriche.",
+        "text": "Anwendungen (3 Vorräte). Falls Dietriche keine Vorräte hat, lege sie ab\n[action] Erschöpfe Dietriche: <b>Ermitteln.</b> Füge für diese Ermittlung deinen [agility]-Wert zum Fertigkeitswert hinzu. Falls dir die Probe nicht um mindestens 2 Punkte gelingt, entferne 1 Vorrat von Dietriche.",
         "traits": "Gegenstand. Werkzeug. Illegal.",
         "slot": "Hand"
     },

--- a/translations/de/pack/tde/tde.json
+++ b/translations/de/pack/tde/tde.json
@@ -163,7 +163,7 @@
         "code": "06022",
         "name": "Anhänger der Königin",
         "subname": "Von nichts und wieder nichts",
-        "text": "Gebunden (Onyxstück). Anwendungen (3 Ladungen). Falls diese Karte keine Ladungen hat, lege sie als nicht im Spiel befindlich beiseite und mische 3 beiseitegelegte Kopien von Onyxstück in dein Deck.\n[fast] Erschöpfe den Anhänger der Königin und gib 1 Ladung aus: Wähle einen enthüllten Ort und wähle eins - du bewegst dich an jenen Ort, du entdeckst 1 Hinweis an jedem Ort oder du entkommst automatisch einem Gegner an jenem Ort.",
+        "text": "Gebunden (Onyxstück). Anwendungen (3 Ladungen). Falls diese Karte keine Ladungen hat, lege sie als nicht im Spiel befindlich beiseite und mische 3 beiseitegelegte Kopien von Onyxstück in dein Deck.\n[fast] Erschöpfe den Anhänger der Königin und gib 1 Ladung aus: Wähle einen enthüllten Ort und wähle eins - du bewegst dich an jenen Ort, du entdeckst 1 Hinweis an jenem Ort oder du entkommst automatisch einem Gegner an jenem Ort.",
         "traits": "Gegenstand. Relikt. Okkult.",
         "slot": "Accessory"
     },


### PR DESCRIPTION
fix for the german translation of lockpicks and Pendant of Queen