### PR TITLE
Remove the back link from hub dimension

### DIFF
--- a/pack/side/wog_encounter.json
+++ b/pack/side/wog_encounter.json
@@ -437,6 +437,7 @@
         "type_code": "location"
     },
     {
+        "back_link": null,
         "back_text": "While there are 6 [per_investigator] or more clues around Hub Dimension, your group has \"sealed off the Hub Dimension.\"",
         "back_flavor": "A vast network of cosmic tunnels where gravity is warped in a surreal web of astral dimensions.",
         "clues": 0,


### PR DESCRIPTION
Currently card is linked to itself: https://arkhamdb.com/card/86024