### PR TITLE
Allow Akachi to take cards with Charge (singular)

### DIFF
--- a/pack/ptc/ptc.json
+++ b/pack/ptc/ptc.json
@@ -107,7 +107,7 @@
                 "faction": ["mystic", "neutral"],
                 "level": { "min": 0, "max": 5 }
             },
-            { "uses": ["charges"], "level": { "min": 0, "max": 4 } },
+            { "uses": ["charges", "charge"], "level": { "min": 0, "max": 4 } },
             { "trait": ["occult"], "level": { "min": 0, "max": 0 } }
         ],
         "deck_requirements": "size:30, card:03014, card:03015, random:subtype:basicweakness",


### PR DESCRIPTION
Reading the deck validation code, matching EITHER one should be sufficient, so I believe this will work as expected to let her take the new mono-charge card.