### PR TITLE
German card title daring

### DIFF
--- a/translations/de/pack/tde/sfk.json
+++ b/translations/de/pack/tde/sfk.json
@@ -7,7 +7,7 @@
     },
     {
         "code": "06111",
-        "name": "Unerschrocken",
+        "name": "Wagemutig",
         "text": "Trage diese Karte nur zu einer Fertigkeitsprobe während eines Angriffs oder eines Entkommen-Versuchs gegen einen Gegner bei. Jener Gegner erhält für die Dauer dieser Fertigkeitsprobe Zurückschlagen und Alarmiert. Nachdem diese Probe beendet ist, ziehe 1 Karte.",
         "traits": "Angeboren."
     },


### PR DESCRIPTION
As was reported to zzorba (ArkhamCards), the german card title for Daring was incorrect.