### PR TITLE
Mark Marie's promo cards as reprints of TCU

### DIFF
--- a/pack/promo/promo.json
+++ b/pack/promo/promo.json
@@ -40,6 +40,7 @@
         "duplicate_of": "05018",
         "pack_code": "promo",
         "position": 2,
+        "quantity": 1,
         "restrictions": "investigator:99001"
     },
     {
@@ -47,6 +48,7 @@
         "duplicate_of": "05019",
         "pack_code": "promo",
         "position": 3,
+        "quantity": 1,
         "restrictions": "investigator:99001"
     }
 ]


### PR DESCRIPTION
Temporarlly incorrect, but should do the right thing with regards to hiding them