### PR TITLE
fix wrong version of revised core rite of seeking

### DIFF
--- a/pack/core/rcore.json
+++ b/pack/core/rcore.json
@@ -671,7 +671,7 @@
 
     {
         "code": "01689",
-        "duplicate_of": "02028",
+        "duplicate_of": "51007",
         "pack_code": "rcore",
         "position": 189,
         "quantity": 2


### PR DESCRIPTION
it's rite of seeking (2), not (0) -- this has been commented on here at arkhamdb: https://arkhamdb.com/card/01689. i own the revised core and have confirmed that the card is supposed to be level 2.