### PR TITLE
Fix position number mistake in Black Stars Rise pack

### DIFF
--- a/pack/ptc/bsr_encounter.json
+++ b/pack/ptc/bsr_encounter.json
@@ -436,7 +436,7 @@
         "code": "03295",
         "double_sided": true,
         "encounter_code": "black_stars_rise",
-        "encounter_position": 224,
+        "encounter_position": 24,
         "faction_code": "mythos",
         "illustrator": "Andreas Rocha",
         "name": "Knight's Hall",


### PR DESCRIPTION
fix position number mistake