### PR TITLE
Added missing Miskatonik trait on ES, FR and VN translations.

### DIFF
--- a/translations/es/pack/core/core_encounter.json
+++ b/translations/es/pack/core/core_encounter.json
@@ -279,7 +279,7 @@
         "name": "Peter Warren",
         "subname": "El profesor ocultista",
         "text": "<b>Aparición</b> - Universidad Miskatonic.\n[action] Gasta 2 pistas: <b>Negociar.</b> Añade a Peter Warren a la zona de victoria.",
-        "traits": "Humanoide. Sectario."
+        "traits": "Humanoide. Sectario. Miskatonic."
     },
     {
         "code": "01140",

--- a/translations/fr/pack/core/core_encounter.json
+++ b/translations/fr/pack/core/core_encounter.json
@@ -278,7 +278,7 @@
         "name": "Peter Warren",
         "subname": "Le Professeur de l'Occulte",
         "text": "<b>Génération</b> – Université Miskatonic.\n[action] Dépensez 2 indices : <b>Discussion</b>. Ajoutez Peter Warren à la pile de victoire.",
-        "traits": "Humanoïde. Cultiste."
+        "traits": "Humanoïde. Cultiste. Miskatonic."
     },
     {
         "code": "01140",

--- a/translations/vn/pack/core/core_encounter.json
+++ b/translations/vn/pack/core/core_encounter.json
@@ -278,7 +278,7 @@
         "name": "Peter Warren",
         "subname": "The Occult Professor",
         "text": "<b>Spawn</b> - Miskatonic University.\n[action] Spend 2 clues: <b>Parley.</b> Add Peter Warren to the victory display.",
-        "traits": "Humanoid. Cultist."
+        "traits": "Humanoid. Cultist. Miskatonic."
     },
     {
         "code": "01140",


### PR DESCRIPTION
Card 01139 has trait Miskatonik, but it is missing on some translations.