### PR TITLE
Adds scenario and encounter sets to Revised Core

### DIFF
--- a/pack/core/rcore_encounter.json
+++ b/pack/core/rcore_encounter.json
@@ -1,0 +1,146 @@
+[
+    {
+        "alternate_of": "01104",
+        "duplicate_of": "01104",
+        "code": "01604",
+        "encounter_position": 1,
+        "pack_code": "rcore",
+        "position": 104,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01105",
+        "duplicate_of": "01105",
+        "code": "01605",
+        "encounter_position": 2,
+        "pack_code": "rcore",
+        "position": 105,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01106",
+        "duplicate_of": "01106",
+        "code": "01606",
+        "encounter_position": 3,
+        "pack_code": "rcore",
+        "position": 106,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01107",
+        "duplicate_of": "01107",
+        "code": "01607",
+        "encounter_position": 4,
+        "pack_code": "rcore",
+        "position": 107,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01108",
+        "duplicate_of": "01108",
+        "code": "01608",
+        "encounter_position": 5,
+        "pack_code": "rcore",
+        "position": 108,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01109",
+        "duplicate_of": "01109",
+        "code": "01609",
+        "encounter_position": 6,
+        "pack_code": "rcore",
+        "position": 109,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01110",
+        "duplicate_of": "01110",
+        "code": "01610",
+        "encounter_position": 7,
+        "pack_code": "rcore",
+        "position": 110,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01111",
+        "duplicate_of": "01111",
+        "code": "01611",
+        "encounter_position": 8,
+        "pack_code": "rcore",
+        "position": 111,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01112",
+        "duplicate_of": "01112",
+        "code": "01612",
+        "encounter_position": 9,
+        "pack_code": "rcore",
+        "position": 112,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01113",
+        "duplicate_of": "01113",
+        "code": "01613",
+        "encounter_position": 10,
+        "pack_code": "rcore",
+        "position": 113,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01114",
+        "duplicate_of": "01114",
+        "code": "01614",
+        "encounter_position": 11,
+        "pack_code": "rcore",
+        "position": 114,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01115",
+        "duplicate_of": "01115",
+        "code": "01615",
+        "encounter_position": 12,
+        "pack_code": "rcore",
+        "position": 115,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01116",
+        "duplicate_of": "01116",
+        "code": "01616",
+        "encounter_position": 13,
+        "pack_code": "rcore",
+        "position": 116,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01117",
+        "duplicate_of": "01117",
+        "code": "01617",
+        "encounter_position": 14,
+        "pack_code": "rcore",
+        "position": 117,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01118",
+        "duplicate_of": "01118",
+        "code": "01618",
+        "encounter_position": 15,
+        "pack_code": "rcore",
+        "position": 118,
+        "quantity": 1
+    },
+    {
+        "alternate_of": "01119",
+        "duplicate_of": "01119",
+        "code": "01619",
+        "encounter_position": 16,
+        "pack_code": "rcore",
+        "position": 119,
+        "quantity": 1
+    }
+]


### PR DESCRIPTION
People who only own the Revised Core Set won't see the included scenario or encounter cards on ArkhamDb (or in the "Arkham Cards" app) unless they also check off the original Core Set,.

This PR aims to fix the issue. Initially by adding "The Gathering" to Revised Core (checked and validated using validate.py). 
The remaining scenarios and encounter sets will be added later.