### PR TITLE
Add "The Beyond" to Parallel Joe's deck requirements.

### DIFF
--- a/pack/parallel/ltr.json
+++ b/pack/parallel/ltr.json
@@ -25,7 +25,7 @@
             "error": "You cannot have more than 5 Survivor cards."
         }
     ],
-    "deck_requirements": "size:30, card:02012:90050, card:02013:90051, random:subtype:basicweakness",
+    "deck_requirements": "size:30, card:02012:90050, card:02013:90051, card:90052, random:subtype:basicweakness",
     "side_deck_options": [
       {
         "trait": ["ally"],


### PR DESCRIPTION
"The Beyond" was missing from the deck requierments. Adding this to the parallel Joe's requirements.