### PR TITLE
fix: correct cost on Well-Funded

### DIFF
--- a/pack/fhv/fhvp.json
+++ b/pack/fhv/fhvp.json
@@ -346,7 +346,7 @@
   },
   {
     "code": "10051",
-    "cost": 2,
+    "cost": null,
     "deck_limit": 2,
     "faction_code": "seeker",
     "flavor": "Every cent of that research grant counts.",


### PR DESCRIPTION
Well-Funded is a skill and should hence have cost `null`.