### PR TITLE
Fix for issue #1363

### DIFF
--- a/pack/fhv/fhvp.json
+++ b/pack/fhv/fhvp.json
@@ -1531,7 +1531,7 @@
     "quantity": 1,
     "text": "Permanent. Exceptional.\n[reaction] Before you draw your opening hand: Search your deck for up to 3 different Trick cards, and attach them facedown to Bewitching. Shuffle your deck.\n[reaction] When you engage an enemy, exhaust Bewitching: Either draw 1 attached card, or search the top 9 cards of your deck for a copy of an attached card, draw it, and shuffle your deck.",
     "traits": "Talent. Trick.",
-    "type_code": "event",
+    "type_code": "asset",
     "xp": 3
   },
   {


### PR DESCRIPTION
Changed type for 'Bewitching' (card 10079) from 'event' to 'asset'.

Quick fix for a type error on a card from Feast of Hemlock Vale.