### PR TITLE
Update PL translation of Leather Jacket

### DIFF
--- a/translations/pl/pack/investigator/win.json
+++ b/translations/pl/pack/investigator/win.json
@@ -53,7 +53,7 @@
     {
         "code": "60310",
         "flavor": "\"Myślisz, że kurtka zrobi z ciebie dobrą partię?\"\n\"E tam, ja dobrze wiem, że jestem świetną partią. Teraz po prostu będą to wiedzieć też inni!\"",
-        "name": "Leather Jacket",
+        "name": "Skórzana kurtka",
         "text": "Szybka.",
         "traits": "Przedmiot. Pancerz.",
         "slot": "Body"

--- a/translations/pl/pack/ptc/ptc.json
+++ b/translations/pl/pack/ptc/ptc.json
@@ -224,7 +224,7 @@
     {
         "code": "03030",
         "flavor": "\"McGlen, czy ty chcesz nas obu pozabijać?\"\n\"Nie tym razem, koleś. Nie tym razem.\"",
-        "name": "Odważny manewr",
+        "name": "Brawurowy manewr",
         "text": "Szybka. Zagraj, kiedy twój test umiejętności zakończy się sukcesem.\nDostajesz +2 do wartości umiejętności do tego testu.",
         "traits": "Gambit."
     },


### PR DESCRIPTION
https://github.com/Kamalisk/arkhamdb/issues/647 and https://github.com/Kamalisk/arkhamdb/issues/648 point out corrections for the Polish translated names of Leather Jacket and Daring Maneuver. I'm not a Polish speaker, but those translations check out according to a quick search/reference against upgraded Daring Maneuver.  So, this PR updates the card names.