### PR TITLE
Fix some GER typos

### DIFF
--- a/translations/de/pack/core/core.json
+++ b/translations/de/pack/core/core.json
@@ -77,7 +77,7 @@
         "code": "01009",
         "name": "Das Necronomicon",
         "subname": "Übersetzung von John Dee",
-        "text": "<b>Enthüllung</b> - Bringe Das Necronomicon mir 3 Horror in deiner Bedrohungszone ins Spiel. Diese Karte kann das Spiel nicht verlassen, solange sich 1 oder mehr Horror darauf befinden.\nBehandle jedes [elder_sign], das du auf einem Chaosmarker enthüllst, als [auto_fail].\n[action]: Bewege 1 Horror von Das Necronomicon auf Daisy Walker. Falls sich dann kein Horror auf Das Necronomicon befindet, lege diese Karte ab.",
+        "text": "<b>Enthüllung</b> - Bringe Das Necronomicon mit 3 Horror in deiner Bedrohungszone ins Spiel. Diese Karte kann das Spiel nicht verlassen, solange sich 1 oder mehr Horror darauf befinden.\nBehandle jedes [elder_sign], das du auf einem Chaosmarker enthüllst, als [auto_fail].\n[action]: Bewege 1 Horror von Das Necronomicon auf Daisy Walker. Falls sich dann kein Horror auf Das Necronomicon befindet, lege diese Karte ab.",
         "traits": "Gegenstand. Buch.",
         "slot": "Hand"
     },

--- a/translations/de/pack/dwl/wda.json
+++ b/translations/de/pack/dwl/wda.json
@@ -64,7 +64,7 @@
         "code": "02269",
         "name": "Juwel von Aureolus",
         "subname": "Geschenk des Homunkuli",
-        "text": "[reaction] Nachdem ein [skull]-, [cultist]-, [tablet]-, [elder_thing]-, oder [auto_fail]-Symbol während einer Fertigkeitsprobe enthüllt worden ist, erschöpfe Juwel von Aureolus: Ziehe 1 Karte oder erhalte 2 Ressourcen.",
+        "text": "[reaction] Nachdem ein [skull]-, [cultist]-, [tablet]-, [elder_thing]-, oder [auto_fail]-Symbol während einer Fertigkeitsprobe an deinem Ort enthüllt worden ist, erschöpfe Juwel von Aureolus: Ziehe 1 Karte oder erhalte 2 Ressourcen.",
         "traits": "Gegenstand. Relikt.",
         "slot": "Zubehör"
     },


### PR DESCRIPTION
There were multiple words missing from Juwel of Aureolus for some reason:
![grafik](https://github.com/user-attachments/assets/10dcd522-3fc9-4dbb-8b3e-c5383a2c6245)
