### PR TITLE
Fixes for FHV campaign cards

### DIFF
--- a/pack/fhv/fhvc.json
+++ b/pack/fhv/fhvc.json
@@ -1270,7 +1270,7 @@
     "faction_code": "mythos",
     "name": "The Lost Sister",
     "pack_code": "fhvc",
-    "position": 28,
+    "position": 69,
     "quantity": 1,
     "text": "Easy / Standard\n[skull]: -X. X is half the number of revealed [[Cave]] locations in play (rounded up).\n[cultist]: -1. If you succeed, heal 1 horror.\n[tablet]: -2. If you are at a [[Cave]] location, treat this token's modifier as -4 instead.\n[elder_thing]: -2. If an [[Abomination]] enemy is at your location, reveal another token.",
     "type_code": "scenario"

--- a/pack/fhv/fhvc.json
+++ b/pack/fhv/fhvc.json
@@ -1715,7 +1715,7 @@
     "position": 106,
     "quantity": 1,
     "stage": 1,
-    "text": "<b>Forced</b> - After a location is revealed: Put locations from the top of the Woods deck into play above, below, to the left, and to the right of that location.\n<b>Forced<\b> - When the investigation phase ends: Each investigator at a [Dark]] location must either draw an enemy in pursuit with the highest evade or take 1 horror (cannot be canceled).",
+    "text": "<b>Forced</b> - After a location is revealed: Put locations from the top of the Woods deck into play above, below, to the left, and to the right of that location.\n<b>Forced</b> - When the investigation phase ends: Each investigator at a [Dark]] location must either draw an enemy in pursuit with the highest evade or take 1 horror (cannot be canceled).",
     "type_code": "agenda"
   },
   {
@@ -1949,7 +1949,7 @@
     "position": 115,
     "quantity": 1,
     "shroud": 6,
-    "text": "Fecund Thicket gets -X shroud, where X is the current darkness level.\n<b>Forced<\b> - After you reveal Fecund Thicket: Test [agility] (X), where X is the current darkness level. If you fail, find the enemy in pursuit with the highest printed health and spawn it at this location.",
+    "text": "Fecund Thicket gets -X shroud, where X is the current darkness level.\n<b>Forced</b> - After you reveal Fecund Thicket: Test [agility] (X), where X is the current darkness level. If you fail, find the enemy in pursuit with the highest printed health and spawn it at this location.",
     "traits": "Forest. Dark.",
     "type_code": "location"
   },
@@ -1990,7 +1990,7 @@
     "position": 117,
     "quantity": 1,
     "shroud": 1,
-    "text": "While an enemy is moving, its location is considered to be connected to Moonlit Clearing.\n<b>Forced<\b> - After you reveal Moonlit Clearing: Test [willpower] (X), where X is the current darkness level. If you fail, find the enemy in pursuit with the highest fight and spawn it at this location.",
+    "text": "While an enemy is moving, its location is considered to be connected to Moonlit Clearing.\n<b>Forced</b> - After you reveal Moonlit Clearing: Test [willpower] (X), where X is the current darkness level. If you fail, find the enemy in pursuit with the highest fight and spawn it at this location.",
     "traits": "Forest. Lair. Dark.",
     "type_code": "location"
   },
@@ -3864,7 +3864,7 @@
     "text": "The first encounter card drawn at this location each round gains surge.\n[action]: Test [willpower] (3), then [agility] (2), then [combat] (1). If you succeed at each of these tests, draw 3 cards. Then, if the current act is Fate of the Vale (v.IV), remember that \"the investigators found gas.\"",
     "traits": "Hemlock Vale.",
     "type_code": "location"
-  },  
+  },
   {
     "back_link": "10706b",
     "clues": 0,
@@ -3901,7 +3901,7 @@
     "text": "During the enemy phase, each [[Shattered]] enemy at The Crossroads loses aloof.\n[reaction] After you successfully evade a [[Shattered]] enemy at The Crossroads by 3 or more, if the current act is Fate of the Vale (v.IV): Remember that \"the road is clear.\"",
     "traits": "Hemlock Vale. Central.",
     "type_code": "location"
-  },  
+  },
   {
     "back_link": "10707b",
     "clues": 0,
@@ -3976,7 +3976,7 @@
     "text": "[action]: Test [agility] (8). If you succeed, heal 2 damage (if you fail you may spend 2 [per_investigator] clues to automatically succeed instead). Then, if the current act is Fate of the Vale (v.IV), remember that \"the samples were found.\"",
     "traits": "Hemlock Vale.",
     "type_code": "location"
-  }, 
+  },
  {
     "back_link": "10709b",
     "clues": 0,
@@ -4051,7 +4051,7 @@
     "text": "Enemies at Tad's General Store get +1 fight.\n[reaction] After a kindling is placed on this location: Place 1 additional kindling. (Group limit once per round.)",
     "traits": "Hemlock Vale.",
     "type_code": "location"
-  }, 
+  },
   {
     "back_link": "10711b",
     "clues": 0,
@@ -4559,7 +4559,7 @@
     "text": "<b>Revelation</b> - Test [agility] (3). If you fail, choose the nearest enemy. That enemy attacks you. If you failed and no enemy was chosen, take 2 damage instead.",
     "traits": "Terror.",
     "type_code": "treachery"
-  },    
+  },
   {
     "code": "10738",
     "encounter_code": "myconids",

--- a/pack/fhv/fhvc.json
+++ b/pack/fhv/fhvc.json
@@ -2027,7 +2027,7 @@
     "encounter_position": 20,
     "faction_code": "mythos",
     "illustrator": "Lin Hsiang",
-    "name": "Western Woods",
+    "name": "Corpse Grove",
     "pack_code": "fhvc",
     "position": 119,
     "quantity": 1,

--- a/pack/fhv/fhvc.json
+++ b/pack/fhv/fhvc.json
@@ -3314,7 +3314,7 @@
     "pack_code": "fhvc",
     "position": 178,
     "quantity": 3,
-    "text": "<b>Revelation</b> – Test [intellect] (3). For each point you fail by, you must either lose 1 action or place 1 of your clues on your location.",
+    "text": "<b>Revelation</b> - Test [intellect] (3). For each point you fail by, you must either lose 1 action or place 1 of your clues on your location.",
     "traits": "Hazard.",
     "type_code": "treachery"
   },
@@ -3329,7 +3329,7 @@
     "pack_code": "fhvc",
     "position": 180,
     "quantity": 3,
-    "text": "<b>Revelation</b> – Test [willpower] (3). This test gets +2 difficulty if there is a [[Colour]] enemy at your location. For each point you fail by, you must either take 1 horror or discard 1 card at random from your hand.",
+    "text": "<b>Revelation</b> - Test [willpower] (3). This test gets +2 difficulty if there is a [[Colour]] enemy at your location. For each point you fail by, you must either take 1 horror or discard 1 card at random from your hand.",
     "traits": "Terror. Power.",
     "type_code": "treachery"
   },
@@ -4456,7 +4456,7 @@
     "pack_code": "fhvc",
     "position": 231,
     "quantity": 3,
-    "text": "Surge.\n<b>Revelation</b> – Put Captivating Gleam into play in your threat area. Limit 1 per investigator.\n<b>Forced</b> – If you have no cards in hand: Take 5 horror and discard Captivating Gleam.",
+    "text": "Surge.\n<b>Revelation</b> - Put Captivating Gleam into play in your threat area. Limit 1 per investigator.\n<b>Forced</b> - If you have no cards in hand: Take 5 horror and discard Captivating Gleam.",
     "traits": "Power. Colour.",
     "type_code": "treachery"
   },
@@ -4474,7 +4474,7 @@
     "pack_code": "fhvc",
     "position": 232,
     "quantity": 2,
-    "text": "Retaliate.\n<b>(Day [day])</b> Poisonblossom gets +1 health and +1 damage value for each overgrowth on it.\n<b>(Night [night])</b> Poisonblossom gets +1 fight and +1 damage value for each overgrowth on it.\n<b>Forced</b> – At the end of the round: Place 1 resource on Poisonblossom, as overgrowth.",
+    "text": "Retaliate.\n<b>(Day [day])</b> Poisonblossom gets +1 health and +1 damage value for each overgrowth on it.\n<b>(Night [night])</b> Poisonblossom gets +1 fight and +1 damage value for each overgrowth on it.\n<b>Forced</b> - At the end of the round: Place 1 resource on Poisonblossom, as overgrowth.",
     "traits": "Creature. Flora. Mutated.",
     "type_code": "enemy"
   },
@@ -4493,7 +4493,7 @@
     "pack_code": "fhvc",
     "position": 233,
     "quantity": 2,
-    "text": "Aloof. <b>(Night [night])</b> Elusive.\n<b>Spawn</b> – Any location (empty, if able).\n<b>Forced</b> – After Forest Watcher enters play: Place 1 doom on it.",
+    "text": "Aloof. <b>(Night [night])</b> Elusive.\n<b>Spawn</b> - Any location (empty, if able).\n<b>Forced</b> - After Forest Watcher enters play: Place 1 doom on it.",
     "traits": "Creature. Flora. Mutated.",
     "type_code": "enemy"
   },
@@ -4623,7 +4623,7 @@
     "pack_code": "fhvc",
     "position": 241,
     "quantity": 2,
-    "text": "<b>Revelation</b> - Attach to the nearest non-[[Elite]] enemy. If you cannot, search the encounter deck and discard pile for a [[Mutated]] enemy and draw it.\n<b>Forced</b> – When attached enemy is defeated: Discard cards from the top of the encounter deck until an enemy is discarded and spawn it at this location.",
+    "text": "<b>Revelation</b> - Attach to the nearest non-[[Elite]] enemy. If you cannot, search the encounter deck and discard pile for a [[Mutated]] enemy and draw it.\n<b>Forced</b> - When attached enemy is defeated: Discard cards from the top of the encounter deck until an enemy is discarded and spawn it at this location.",
     "traits": "Power. Colour.",
     "type_code": "treachery"
   },
@@ -4652,7 +4652,7 @@
     "pack_code": "fhvc",
     "position": 243,
     "quantity": 5,
-    "text": "<b>Revelation</b> - Attach Fire! to the nearest location with no copy of Fire! attached (connected to a location with Fire! attached, if able).\n[action]: Test [agility] (4). If you succeed, discard Fire!\n<b>Forced</b> – At the end of the round: Each card with health at this location takes 1 direct damage.",
+    "text": "<b>Revelation</b> - Attach Fire! to the nearest location with no copy of Fire! attached (connected to a location with Fire! attached, if able).\n[action]: Test [agility] (4). If you succeed, discard Fire!\n<b>Forced</b> - At the end of the round: Each card with health at this location takes 1 direct damage.",
     "traits": "Hazard.",
     "type_code": "treachery"
   }


### PR DESCRIPTION
- Fix bad position on _Lost Sister_ scenario.
- Fix bad name on _Corpse Grove_.
- Fix bad HTML in some Twisted Hollow cards.
- Replace dashes