### PR TITLE
Add missing encounter attributes to backsides

### DIFF
--- a/pack/eoe/eoec.json
+++ b/pack/eoe/eoec.json
@@ -1037,6 +1037,8 @@
     },
     {
         "code": "08556b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 8,
         "faction_code": "mythos",
         "flavor": "You wander for what seems like hours through the myriad reflections. The further you venture from where you arrived, the more distant reality becomes. There are many paths to take through the hallucination. Places you recognize from your memories, and others you do not, taken from the memories of your companions.\nAs the shape of the mirage changes around you, you consider which prison might be worse - the one that reveals its true, deadly nature? Or the one that hides it?",
         "hidden": true,
@@ -1066,6 +1068,8 @@
     },
     {
         "code": "08557b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 9,
         "faction_code": "mythos",
         "flavor": "Eliyah and his companion, Anyu, shimmer into view along the outskirts of the camp. \"Where have you been?\" Takada says, also appearing before your very eyes.]\n\"It is foolish to venture out alone,\" Dr. Sinha joins in the scolding.\n\"Relax. I wasn’t alone,\" Eliyah replies, his gloved hand gently petting Anyu’s neck.\nThe physician rolls her eyes and departs, but Takada remains, folding her arms across her chest. \"There is still a lot to do before we head out, you know,\" she states.\nEliyah sighs and nods. \"I know. Just...anxious. Something about this place...\" he trails off.\nTakada nods. \"Yes. I feel it, too.\"",
         "hidden": true,
@@ -1095,6 +1099,8 @@
     },
     {
         "code": "08558b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 10,
         "faction_code": "mythos",
         "flavor": "Ellsworth appears in a shimmer of mirage-light, staring out over the railing into the cold, blue ocean. \"Beautiful, isn’t it?\" he says.\nCookie and Claypool appear nearby, carrying several crates of supplies between them. \"Y’know what would be beautiful?\" Cookie hollers. \"If maybe yeh helped out a lil’ bit. Think yeh might get off yer ass for a minute ’n pitch in, Ellsworth?\"\nThe explorer nods with a soft sigh and takes the weight from Claypool’s hands, nodding aside for him to take a break. Claypool gives him a gentle, knowing smile.",
         "hidden": true,
@@ -1124,6 +1130,8 @@
     },
     {
         "code": "08559b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 11,
         "faction_code": "mythos",
         "flavor": "Three figures shimmer into view as they cross one another in the darkened halls. \"Professor,\" you hear Dr. Kensler’s voice acknowledge, and her outline becomes defined. Professor Dyer and his protégé appear next. \"I do hope you’ll consider my proposal,\" she continues. If she truly cared one way or the other, her tone of voice surely does not reveal it.\nIn response, Dyer simply glances at Danforth, who appears to be staring behind her - far, far behind her. \"Well. In any event...\" she adjusts her glasses, and enters the door labeled with her name.\nDyer shakes his head with a sigh, but Danforth is the one who breaks the silence. \"I...I think we should go.\"",
         "hidden": true,
@@ -1153,6 +1161,8 @@
     },
     {
         "code": "08560b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 12,
         "faction_code": "mythos",
         "flavor": "\"You really think I can’t navigate a simple maze?\" Ellsworth chuckles. He looks several years young instead of his comfortable jacket and trousers. The figure he speaks to stands just out of view, a dark silhouette with a muffled, indistinct voice. \"Fine,\" the explorer replies with a roll of his eyes. He hands the figure his champagne glass and loosens his tie. \"But when I get back, you are going to tell me what this is really all about.\"",
         "hidden": true,
@@ -1182,6 +1192,8 @@
     },
     {
         "code": "08561b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 13,
         "faction_code": "mythos",
         "flavor": "When Eliyah materializes into view, you are stunned to see him without his steadfast companion, Anyu. He holds an unfamiliar woman’s hands, her wavy hair the color of a brilliant ruby. The two young lovers stare into one another’s eyes as the old train approaches. \"How long do you think you will be gone?\"\n\"I...I’m not sure,\" he confesses. \"It is a lengthy journey. Alaska is a hell of a big place.\"\n\"So, this is goodbye, then,\" the woman says. She wipes angry tears from her eyes. \"Will you write?\"\n\"I’ll try, but...\" he glances away.\n\"Right, right,\" she says, understanding. The train pulls into the station, its piercing squeal muffling their words. \"You...fool.\" She leans up and kisses his cheek. \"You are a fool, Eliyah.\"\n\"I...I know,\" he replies. \"I know.\"",
         "hidden": true,
@@ -1211,6 +1223,8 @@
     },
     {
         "code": "08562b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 14,
         "faction_code": "mythos",
         "flavor": "\"Hell of a test run!\" Cookie yells over the roar of the rushing wind. The two of them are up in one of Takada's aeroplanes - this must have happened just after she completed work on the first plane, before the lot of you set off toward the peaks, and the events that ensued.\n\"Get used to it!\" Takada shouts from the pilot’s seat. \"Weather’s gonna be rough anytime we’re in the air. Don’t worry though, she’ll hold.\" You see the grim copilot hold back a smile. \"You’re enjoying this, aren’t you?\" Takada chimes.\n\"Naw,\" Cookie lies. \"Just been a while, is all.\"",
         "hidden": true,
@@ -1240,6 +1254,8 @@
     },
     {
         "code": "08563b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 15,
         "faction_code": "mythos",
         "flavor": "These are the sledges missing from Lake’s camp,\" Professor Dyer remarks, shimmering into view. He doesn’t sound particularly surprised - it seems they must have accounted for this possibility.\nDanforth is already at the first of the sledges, examining its contents. \"Here’s the gasoline stove, the fuel, all of their research instruments...\" he trails off. \"God, what is that awful stench?\" He motions toward the farthest sledge, the tarpaulin strapped around its cargo bulging oddly.\n\"Danforth, don’t-\" Dyer calls out, but it’s too late. The moment Danforth removes the tarpaulin, he staggers backward, covering his mouth and nose. Frozen and preserved beneath the tarpaulin are the corpses of a young explorer and one of his sled dogs. \"Gedney,\" Dyer whispers.",
         "hidden": true,
@@ -1269,6 +1285,8 @@
     },
     {
         "code": "08564b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 16,
         "faction_code": "mythos",
         "flavor": "\"Thank you for...for inviting me here, Dr. Sinha,\" Dr. Kensler says quietly, her outline shimmering into view. She and Dr. Sinha sit next to one another in the almost-empty theatre. The lights are dim and the curtain drawn, but the show has not yet begun.\n\"Of course. And just Mala is fine.\"\nKensler flinches and clears her throat. \"Then call me Amy.\"\n\"I already do,\" the physician replies as the screen in front of them kindles to life.",
         "hidden": true,
@@ -1298,6 +1316,8 @@
     },
     {
         "code": "08565b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 17,
         "faction_code": "mythos",
         "flavor": "Claypool stares up at the ruins with a twinkle of wonder in his eyes. \"Marvelous, isn’t it, William?\" Behind him, Professor Dyer materializes within the mirage. Both of them are at least a decade younger, perhaps more. You note Claypool did not address the professor by his title.\n\"Marvelous and mysterious,\" Dyer replies. \"Nobody knows the true purpose of this site. Perhaps nobody ever will.\"\n\"But that’s why we do this, right?\" Claypool says with a grin. \"To learn the truth.\"\nDyer glances back at the youth, lines of worry pulling at his eyes. \"Yes,\" he whispers, \"the truth.\"",
         "hidden": true,
@@ -1327,6 +1347,8 @@
     },
     {
         "code": "08566b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 18,
         "faction_code": "mythos",
         "flavor": "A teenage girl shimmers into view. You recognize Takada’s chestnut eyes and thin, straight hair. Her cheeks are stained with tears and rain. She waves as the old, rickety aeroplane takes off. You don’t recognize the design - this must have been over a decade ago. \"Don’t worry, kiddo.\" The man next to her grips her shoulder encouragingly. \"He’ll be back soon,\" he reassures her, his voice soft with compassion. \"You’ll see.\"",
         "hidden": true,
@@ -1357,6 +1379,8 @@
     },
     {
         "code": "08567b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 19,
         "faction_code": "mythos",
         "flavor": "Eliyah sits huddled up against a tree, a torrent of snow falling around him. In his arms, Anyu whines. Blood soaks his gloves, staining the dog’s fur red as he holds her tight. \"I know, girl,\" he chants, \"I know, I know. We...we are going to be okay. You and me, girl. Anyu, right? That was your name?\" The dog peers up into his eyes. \"We will be okay, Anyu. I promise you.\"",
         "hidden": true,
@@ -1387,6 +1411,8 @@
     },
     {
         "code": "08568b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 20,
         "faction_code": "mythos",
         "flavor": "Danforth screams and throws his covers aside. Sweat drenches his forehead and drips down his cheeks. \"Just a dream,\" he whispers. \"Just a dream, just a dream.\" He collapses from his bed, dabs his head with a handkerchief, and wanders over to the nearby window to peer outside. The shape he sees on the other side causes him to leap back in fear, crashing into the opposite wall. \"No...no!\"",
         "hidden": true,
@@ -1417,6 +1443,8 @@
     },
     {
         "code": "08569b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 21,
         "faction_code": "mythos",
         "flavor": "Dyer shakes the man’s hand vigorously, a smile beaming across his face. \"You have no idea how much this means to me,\" he exclaims. \"This will be a journey of profound importance. For all of us.\"\nYou recognize the man he speaks to - it is the late Professor Lake, one of many who ventured with Dyer to Antarctica and never returned.\n\"Yes, William,\" Lake replies, his eyes dribbling over with terrible black ichor. \"This expedition will change everything.\"",
         "hidden": true,
@@ -1447,6 +1475,8 @@
     },
     {
         "code": "08570b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 22,
         "faction_code": "mythos",
         "flavor": "A young Dr. Sinha appears by the bedside, her face contorted with grief. You have never seen her so stricken. A nurse places a hand on top of Dr. Sinha’s in consolation, but she bats it away. \"Don’t,\" she barks, choking back a sob.\n\"There is nothing more you could have done, Doctor,\" the nurse says.\n\"There is always more that can be done,\" Dr. Sinha shouts. \"We could have been smarter! Faster!\" Her hands shake as she tries to make a fist. Black miasma seeps from between her knuckles. \"We - I - this is my fault. All my fault.\"",
         "hidden": true,
@@ -1477,6 +1507,8 @@
     },
     {
         "code": "08571b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 23,
         "faction_code": "mythos",
         "flavor": "Dr. Kensler sits at her desk, struggling to focus on her work. Various papers sit in neat piles around her, and the bookshelf is perfectly ordered, just as you would expect from the professor. But the journal she writes in is cluttered and unkempt. She runs her hand through her hair, undoing her ponytail. \"No, no, no...\" she mutters, ripping a piece of paper from the book. You spot a photograph serving as a bookmark, keeping her page as she shuts the journal angrily. She opens one of her desk drawers and throws the crumpled paper inside, barely noticing the way the drawer bubbles over with miasma, and the putrid gray mist emanating from within...",
         "hidden": true,
@@ -1507,6 +1539,8 @@
     },
     {
         "code": "08572b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 24,
         "faction_code": "mythos",
         "flavor": "Rain patters against the face of the statue as Ellsworth examines the inscription at its foundation. \"This one isn’t like the rest,\" he murmurs to himself. \"This isn’t Rapa Nui. This isn’t one of the mo‘ai at all.\" The statue in the mirage cracks open, and miasma begins to seep from inside...",
         "hidden": true,
@@ -1537,6 +1571,8 @@
     },
     {
         "code": "08573b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 25,
         "faction_code": "mythos",
         "flavor": "Through the din of war - a hail of gunfire and mortars so loud it shakes the earth - Cookie reloads his rifle, slowly and methodically. \"Sergeant Fredericks!\" a voice calls out to him. His companion ducks through the trench as another nearby explosion kicks up a spray of mud. \"Germans broke the line last night. They’re circling around. We have to get out of here!\"\nCookie affixes a bayonet to the end of his rifle. \"Did the lieutenant give the order?\" he asks.\n\"Lieutenant Williams is dead,\" the soldier replies, the fear in his voice palpable. \"Sir...you’re in charge.\"",
         "hidden": true,
@@ -1567,6 +1603,8 @@
     },
     {
         "code": "08574b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 26,
         "faction_code": "mythos",
         "flavor": "\"According to Inuit legend, this megalith has stood here since before humanity walked the Earth,\" a young Avery recounts, examining the runic language along its surface.\n\"I don’t know about any of that, but it is definitely ancient. That’s not even the weirdest part, though.\" \"What is?\" one of the other explorers asks, pulling his hood down to get a better view of the towering structure.\n\"See for yourself,\" Claypool says, unfolding a map and placing it against the smooth stone. Drawn over the map’s surface are many rings and lines depicting various weather patterns. \"This thing...is like a lightning rod.\"",
         "hidden": true,
@@ -1601,6 +1639,8 @@
     },
     {
         "code": "08575b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 27,
         "faction_code": "mythos",
         "flavor": "\"We almost died that day. Anyu and I,\" the real Eliyah says as the mirage fades. Anyu licks his gloved hand and whines. \"We were the only two that survived. And nobody ever believed me when I told them about the creature that attacked us. They turned me into a pariah. I thought...maybe I was crazy, after all.\" He shudders as he recalls the shape the mirage took. \"But now I know. What attacked us that day was real.\"",
         "hidden": true,
@@ -1635,6 +1675,8 @@
     },
     {
         "code": "08576b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 28,
         "faction_code": "mythos",
         "flavor": "\"I will never forget that day. The day I lost my first patient.\" She crosses her arms as the mirage fades. Her eyes are tired and worn. \"They tell you it happens to even the best of us, but even so, we are never prepared. I was not foolish enough to vow that I would never lose another one. I knew that was a fantasy.\" She glances at you knowingly. \"Instead, I simply vowed never to get attached. So do not be upset at my distance. It is for my own sake. So if - when - I lose you, I am not lost, myself.\"",
         "hidden": true,
@@ -1669,6 +1711,8 @@
     },
     {
         "code": "08577b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 29,
         "faction_code": "mythos",
         "flavor": "\"He never did come home,\" Takada whispers, choking on her words. \"I spent my whole life following in his footsteps. I thought...I thought if I did, maybe...\" she wipes the tears - and inky miasma - from her eyes. \"He’s gone. Gone forever.\"",
         "hidden": true,
@@ -1703,6 +1747,8 @@
     },
     {
         "code": "08578b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 30,
         "faction_code": "mythos",
         "flavor": "As the mirage dissolves, you watch a young Sergeant James Fredericks command his men to flee, a hail of bullets and mortar fire following in their wake. \"Kid never did make it back,\" the real Cookie says, grinding his teeth. \"Very few of us did that day. And for what?\" He spits. The roar of gunfire fades into the distance. \"For what?\"",
         "hidden": true,
@@ -1737,6 +1783,8 @@
     },
     {
         "code": "08579b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 31,
         "faction_code": "mythos",
         "flavor": "\"We never should have gone,\" the real Dyer whispers as the shape of Professor Lake fades into the mirage. \"I should have convinced him. I should have...but I was too greedy, too eager.\" he chokes. \"And now, here I am again. You and I, we have led these people to their ends. Even if we survive, we will never forget what we have done to these people. What we have risked.\"",
         "hidden": true,
@@ -1771,6 +1819,8 @@
     },
     {
         "code": "08580b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 32,
         "faction_code": "mythos",
         "flavor": "\"It’s here, it’s here,\" the real Danforth mutters as he sees the miasma dripping from the cracked window. \"It was always here, always here and I returned, returned to hear that accursed sound...\" He continues to watch in horror as the miasma retreats, returning his dormitory to its natural state. It takes several minutes for him to stop shaking.",
         "hidden": true,
@@ -1805,6 +1855,8 @@
     },
     {
         "code": "08581b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 33,
         "faction_code": "mythos",
         "flavor": "\"After that, there was no going back,\" the real Claypool explains. \"We had opened Pandora’s box, so to speak. I could no longer bury my head in the sand. There are forces out there beyond our comprehension. Things that science cannot explain. Just as I could not explain that stone’s meteorological impact on the region. Nor could I explain the nature of the storm that hit us after we uncovered it.\"\nYou ask Claypool what happened to the other man who was with him that day. He grinds his teeth and shakes his head.",
         "hidden": true,
@@ -1839,6 +1891,8 @@
     },
     {
         "code": "08582b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 34,
         "faction_code": "mythos",
         "flavor": "\"I...I remember this,\" the real Ellsworth says, staring at his own memory. \"This is what made me want to become an explorer. To discover things like this. Ancient secrets, left behind by God knows what. But the more I discover, the more I think that perhaps there are parts of the Earth better left alone. Perhaps all of this is the fault of people like me, who refuse to let history lie. Arrogant fools, the lot of us.\"",
         "hidden": true,
@@ -1873,6 +1927,8 @@
     },
     {
         "code": "08583b",
+        "encounter_code": "fatal_mirage",
+        "encounter_position": 35,
         "faction_code": "mythos",
         "flavor": "Dr. Kensler - the real one - eyes you coldly. \"This memory is not for you,\" she warns. \"Though I suppose you have no more control over this than I do.\" You cannot help but be a little curious what kind of academic work would rattle somebody like her, so you ask. \"It was not academic in nature,\" she confesses, running her hand idly along the vision of her office desk, before pulling the photograph out from inside the journal and examining it in private. \"I was never very skilled in expressing myself in...matters of the heart,\" she says, and the photograph fades in her hands, along with the rest of the mirage. \"Come along. I do not wish to remain here any longer,\" she states.",
         "hidden": true,

--- a/pack/side/guardians_encounter.json
+++ b/pack/side/guardians_encounter.json
@@ -413,6 +413,8 @@
     {
         "back_link": "83022a",
         "code": "83022b",
+        "encounter_code": "the_nights_usurper",
+        "encounter_position": 7,
         "faction_code": "mythos",
         "flavor": "The gateway beyond this corridor leads to a place beyond the physical world. A place where dreams and reality converge.\nYou steady your thoughts and stare into the abyss. The abyss embraces you.",
         "hidden": true,
@@ -444,6 +446,8 @@
     {
         "back_link": "83023a",
         "code": "83023b",
+        "encounter_code": "the_nights_usurper",
+        "encounter_position": 8,
         "faction_code": "mythos",
         "flavor": "As you traverse the vast abyss, you are surprised to find others wandering through the cavernous mist, mesmerized and confused. You don't recognize them as patients from the incident in Cairo. The Brotherhood must have sent these victims here recently. With the knowledge you have now, you could try to awaken them - or guide them to Xzharah as sacrifices.",
         "hidden": true,
@@ -474,6 +478,8 @@
     {
         "back_link": "83024a",
         "code": "83024b",
+        "encounter_code": "the_nights_usurper",
+        "encounter_position": 9,
         "faction_code": "mythos",
         "flavor": "As you explore the volcanic tunnels, you find brutalized corpses of dozens of winged creatures: some black and faceless, with membranous wings and dark horns; others huge and scaly, with bat-like wings and heads like a horse's. Continuing deeper down the tunnels, you come across more of the faceless creatures restrained by thick iron chains. Prisoners of Xzharah, you imagine. They make no sound as you approach, their uncanny heads turning towards you.",
         "hidden": true,
@@ -504,6 +510,8 @@
     {
         "back_link": "83025a",
         "code": "83025b",
+        "encounter_code": "the_nights_usurper",
+        "encounter_position": 10,
         "faction_code": "mythos",
         "flavor": "After what feels like an eternity, you finally reach the top of the subterranean stairs, where a trapdoor leads you to the surface. You find yourself in the large central plaza of a ruined city on the shoreline of a beautiful sky-blue ocean. A pair of colossal winged lion statues guards the entrance to the stairway.",
         "hidden": true,
@@ -533,6 +541,8 @@
     {
         "back_link": "83026a",
         "code": "83026b",
+        "encounter_code": "the_nights_usurper",
+        "encounter_position": 11,
         "faction_code": "mythos",
         "flavor": "The mist grows ever thicker as you make your way deeper into the depths of the abyss. Finally, you come across an open chamber where the mist has receded, and you are greeted by a tall statue of an elderly man with a great bear and a mane of long hair. He rides a chariot formed from a huge seashell, which is pulled by beasts both wondrous and strange.",
         "hidden": true,
@@ -567,6 +577,8 @@
     },
     {
         "code": "83027b",
+        "encounter_code": "the_nights_usurper",
+        "encounter_position": 12,
         "faction_code": "mythos",
         "flavor": "The Chosen One's words are grim whispers that worm their way into your ears. \"The Day of Nephren-Ka shall come, and the road shall be paved with blood,\" he promises. \"Prove your loyalty and you shall be rewarded. When the Day arrives, you alone shall be spared. Refuse, and be consumed. Then I alone shall rule this place.\"",
         "hidden": true,
@@ -656,6 +668,8 @@
     {
         "back_link": null,
         "code": "83031b",
+        "encounter_code": "brotherhood_of_the_beast",
+        "encounter_position": 1,
         "faction_code": "mythos",
         "flavor": "\"I didn't have a choice!\" Layla cries. \"The things I've read… The records I've translated… They all point to one thing,\" she claims. \"Destruction. Ruin. We can't stop it. All we can do is forge a place for our loved ones in the rubble.\" You tell her that you will do everything in your power to stop this 'destruction', but she shakes her head, tears in her eyes. \"It's a fool's errand. But… \" Layla takes a deep breath as she considers her options. \"Promise you'll keep my daughter and my son safe, and I'll help you in any way I can.\"",
         "hidden": true,
@@ -694,6 +708,8 @@
     {
         "back_link": null,
         "code": "83032b",
+        "encounter_code": "brotherhood_of_the_beast",
+        "encounter_position": 2,
         "faction_code": "mythos",
         "flavor": "Despite your best efforts, Dr. Moore slips away while you are occupied by his 'bodyguard'. With the creature defeated, and you hot on his trail, you suspect he will try to escape the city while he has the chance.",
         "hidden": true,
@@ -731,6 +747,8 @@
     {
         "back_link": null,
         "code": "83033b",
+        "encounter_code": "brotherhood_of_the_beast",
+        "encounter_position": 3,
         "faction_code": "mythos",
         "flavor": "Nadia's faith is shaken. Scared and confused, she finally gives in. \"There is only one residence in Cairo they told us to spare,\" she explains. \"None of us know why, or what their connection is to the Brotherhood. All we know is they were not to be disturbed.\" She hesitantly gives you a small brass key. \"… So maybe it's time to disturb them. The building's door is marked with lamb's blood.\"",
         "hidden": true,
@@ -768,6 +786,8 @@
     {
         "back_link": null,
         "code": "83034b",
+        "encounter_code": "brotherhood_of_the_beast",
+        "encounter_position": 4,
         "faction_code": "mythos",
         "flavor": "\"All right, all right,\" Farid relents, \" I'm a businessman, not a soldier. Strike a deal with me, and I'll tell you what I know. Then I'll skip out of town and be out of your hair.\" You ask what he wants. \"There's a vault in the abandoned temple to the east. Word is, there are a lot of old, valuable artifacts in there. The kind that would fetch a high price on the black market.\" He grins toothily. \"Get me into that temple, and I'm all yours. Deal?\"",
         "hidden": true,
@@ -804,6 +824,8 @@
     {
         "back_link": null,
         "code": "83035b",
+        "encounter_code": "brotherhood_of_the_beast",
+        "encounter_position": 5,
         "faction_code": "mythos",
         "flavor": "Despite his mortal wounds, the assassin grins wickedly. \"The Day is coming,\" he says between a fit of coughs. \"You think killing me will stop it? Fools! The Beast will devour you all!\" He cackles with his final breath, then falls silent.\nYou are quick to search his belongings before any bystanders spot the body. Among the many strange curios on his person, you find a small leather-bound journal with a cryptic inscription:\nOur tribute soaks the abyssal blade\nA thousand souls never to wake\nWith this our Chosen shall arise\nAnd the day is ever nigh!",
         "hidden": true,
@@ -841,6 +863,8 @@
     {
         "back_link": null,
         "code": "83036b",
+        "encounter_code": "brotherhood_of_the_beast",
+        "encounter_position": 6,
         "faction_code": "mythos",
         "flavor": "\"I'll be dead soon anyway,\" Professor Taylor admits with a deep sigh. \"If it's not you, or the Brotherhood, it'll be the tumor in my lung.\" He dumps the ashes in his pipe and sets it on his table before turning back towards you. \"Fine. I'm certain it'll be the death of both of us, but I'll help you out. Don't know what you expect of me, exactly. I suppose if you found one of the Brotherhood's artifacts, I could study it for you.\"",
         "hidden": true,

--- a/pack/tde/dsm_encounter.json
+++ b/pack/tde/dsm_encounter.json
@@ -171,6 +171,8 @@
     },
     {
         "code": "06214b",
+        "encounter_code": "dark_side_of_the_moon",
+        "encounter_position": 9,
         "faction_code": "mythos",
         "hidden": true,
         "name": "Off the Galley",

--- a/pack/tde/pnr_encounter.json
+++ b/pack/tde/pnr_encounter.json
@@ -153,6 +153,8 @@
     },
     {
         "code": "06254b",
+        "encounter_code": "point_of_no_return",
+        "encounter_position": 8,
         "faction_code": "mythos",
         "flavor": "Hisses and uncanny voices pursue you throughout this web of darkened, intersecting tunnels. You believe the myriad paths might lead all the way to the surface of the Dreamlands, considering the vastness of this network of caverns. It is a wonder you can even find your way back to where you started. However, you are not alone when you emerge...",
         "hidden": true,
@@ -183,6 +185,8 @@
     },
     {
         "code": "06255b",
+        "encounter_code": "point_of_no_return",
+        "encounter_position": 9,
         "faction_code": "mythos",
         "flavor": "The kingdom of the Gugs is surrounded by a colossal wall. Inside, cylindrical towers rise high into the mist, each one windowless and made of grey stone, with large looming doorways at the bottom. One black tower stands paramount among the others, rising into the very ceiling of the Underworld. You do not make it very far before you spot the sentry standing guard outside the city's walls: a tremendous creature with huge furry arms and an obscene toothy maw extending vertically through its head.",
         "hidden": true,
@@ -212,6 +216,8 @@
     },
     {
         "code": "06256b",
+        "encounter_code": "point_of_no_return",
+        "encounter_position": 10,
         "faction_code": "mythos",
         "flavor": "Step after step, you scale the tower until you reach the heavy trapdoor at the top. When you push the stone aside, a column of bright light pierces through the shaft, blinding you. The surface! You emerge in an area thick with trees and mystical fog. After so many hours spent underground, the cool breeze feels wonderful. Many curious eyes watch you from the surrounding woods. Though you long to stay and explore more of these wilds, you know your true goal lies back down in the caverns below the surface.",
         "hidden": true,
@@ -243,6 +249,8 @@
     },
     {
         "code": "06257b",
+        "encounter_code": "point_of_no_return",
+        "encounter_position": 11,
         "faction_code": "mythos",
         "hidden": true,
         "name": "A Strange Ghoul",
@@ -273,6 +281,8 @@
     },
     {
         "code": "06258b",
+        "encounter_code": "point_of_no_return",
+        "encounter_position": 12,
         "faction_code": "mythos",
         "flavor": "Looking out over the barren vale, you get a sense for the threats that dwell below. Underneath the plateau upon which you stand, a forest of obscene, pale fungi extends for miles. Beyond that is a great heap of bones, like an ocean pouring forth in all directions. You swear you can see something crawling or worming its way along the surface of the bones, but perhaps it's just your imagination. In the distance, great sharp peaks of stone loom over the vale. Black, winged creatures fly around the summits, searching for prey. You see no sign of this \"ocean of pitch\" Pickman described, though you do notice a wide cavern opening along a wall of stone to the right of the vale below...",
         "hidden": true,
@@ -304,6 +314,8 @@
     },
     {
         "code": "06259b",
+        "encounter_code": "point_of_no_return",
+        "encounter_position": 13,
         "faction_code": "mythos",
         "flavor": "Traversing this canyon of cadavers and monstrous remains is laborious enough, but it is the churning and digging below the surface that causes you to hate this awful place. What sort of monstrosity could span the entirety of this ocean of bones? Your answer presents itself as you come across a great pit in the ravine. It is swallowing the bones and scraps of rotten meat like a whirlpool. When you reach the base of the tunnel and realize its true purpose, a shudder courses through you. It was made by an enormous creature: the thing that dwells below the sea of bones.",
         "hidden": true,
@@ -333,6 +345,8 @@
     },
     {
         "code": "06260b",
+        "encounter_code": "point_of_no_return",
+        "encounter_position": 14,
         "faction_code": "mythos",
         "flavor": "You climb to the top of the hazardous peaks to survey the lands below. From this vantage point, you are able to see the movements of the various creatures that live in the vale. Soaring all around the peaks are black, winged things that somehow scowl at you with empty, expressionless faces. Upon the cliff that hangs over the vale, ghoul eyes watch your progress with morbid curiosity. The mound of bones and detritus below the precipice is home to nothing but the churning and dredging of something massive under the surface. To your left, the misty vale extends for miles until it reaches an enormous stone wall. Opposite the wall, far in the distance, you barely make out the shape of a city in the darkness. Incomprehensible whispers and mocking laughter seep into your ears. You dare no further study.",
         "hidden": true,
@@ -363,6 +377,8 @@
     },
     {
         "code": "06261b",
+        "encounter_code": "point_of_no_return",
+        "encounter_position": 15,
         "faction_code": "mythos",
         "hidden": true,
         "name": "The Way Out",
@@ -392,6 +408,8 @@
     },
     {
         "code": "06262b",
+        "encounter_code": "point_of_no_return",
+        "encounter_position": 16,
         "faction_code": "mythos",
         "flavor": "From the depths of the pitch-black ocean, the creatures suddenly emerge. They are similar to spiders in shape, but that is where the similarities end. Their bodies appear to be made from the same tarry substance as the ocean itself, and their eyes glow crimson red in the dark fog over the sea. The spiders surround your vessel and attempt to pull it - and you - into the depths.",
         "hidden": true,
@@ -422,6 +440,8 @@
     },
     {
         "code": "06263b",
+        "encounter_code": "point_of_no_return",
+        "encounter_position": 17,
         "faction_code": "mythos",
         "flavor": "The ocean's waves are steady and slow, like rolling pits of sludge, but eventually you find a spot where the ocean is eerily still, and all is silent. You peer over the edge of your boat and gaze into the depths. Somewhere in the black vastness below is your destination...",
         "hidden": true,
@@ -452,6 +472,8 @@
     },
     {
         "code": "06264b",
+        "encounter_code": "point_of_no_return",
+        "encounter_position": 18,
         "faction_code": "mythos",
         "flavor": "Though there is no wind in the dark caverns of the Underworld, enormous maelstroms of pitch attack your vessel from all sides. You struggle to remain in control of your boat as the whirlpools hurl you into pandemonium.",
         "hidden": true,
@@ -482,6 +504,8 @@
     },
     {
         "code": "06265b",
+        "encounter_code": "point_of_no_return",
+        "encounter_position": 19,
         "faction_code": "mythos",
         "hidden": true,
         "name": "Center of the Sea",

--- a/pack/tde/sfk_encounter.json
+++ b/pack/tde/sfk_encounter.json
@@ -173,6 +173,8 @@
     },
     {
         "code": "06127b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 9,
         "faction_code": "mythos",
         "flavor": "As you walk the streets of the town, a horde of cats slowly congregates around you, following you everywhere you go.",
         "hidden": true,
@@ -204,6 +206,8 @@
     {
         "code": "06128b",
         "faction_code": "mythos",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 10,
         "flavor": "The wilds of the Skai region may appear peaceful, but they are far from safe. You are compelled to travel slowly and take in the beauty and tranquility of this realm, but your dawdling makes you a target for the vicious creatures that call the wetlands home.",
         "hidden": true,
         "name": "Dreamlike Horrors",
@@ -233,6 +237,8 @@
     },
     {
         "code": "06129b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 11,
         "faction_code": "mythos",
         "flavor": "In the port city of Dylath-Leen, you consult with the elders of the city. They believe that the truth of Kadath was hidden for a reason, and they call you a fool for searching for it. Even so, they tell you what little they know of the forsaken peak. Though you are far from finding Kadath, it is clear now that it cannot be in this region. \"We'll need to find a ship captain,\" Randolph muses. \"This journey will be much longer still. The isle of Oriab lies to the south, and I have heard of a great mountain there. To the west lies the ancient land of Mnar, where many secrets lie hidden. To the east is the Timeless Realm ruled by the wise King Kuranes. North of there is a forbidden land where none dare tread...\"",
         "hidden": true,
@@ -263,6 +269,8 @@
     },
     {
         "code": "06130b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 12,
         "faction_code": "mythos",
         "flavor": "You study the pillars within Kadatheron for many hours, losing yourself in the vast, storied histories of the Dreamlands. What was first a focused search for the whereabouts of the castle of the gods soon becomes an obsession with all things inscribed upon the cylinders. Hours, days, weeks; who knows how much time you lose to your research. Though you learn much, the time you spend here is a boon to those who pursue you. You are only able to pry yourself free from the cylinders when you feel the ominous gaze of something sinister watching you from afar...",
         "hidden": true,
@@ -294,6 +302,8 @@
     },
     {
         "code": "06131b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 13,
         "faction_code": "mythos",
         "flavor": "Although this city-state was founded ages ago and stood for over a thousand years, it is no more. The tales tell of a single night in which Sarnath fell. Now very little of it remains: only a vast marsh where the city once stood tall and proud. Among the ruins you find no standing buildings, but rubble of marble, brick, and chalcedony. But as you approach the remains, lightning splits the sky. There is a blinding flash. As you blink your eyes, everything changes. Where before no city stood, now there looms a ghostly image of Sarnath as it once was. Near the lake, where the lightning struck, you find a curious and ancient idol of green stone. It is coated with seaweed and chiseled in the likeness of a great water lizard. One of the gods of this realm, perhaps?",
         "hidden": true,
@@ -325,6 +335,8 @@
     },
     {
         "code": "06132b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 14,
         "faction_code": "mythos",
         "flavor": "It is said that the people of Sarnath were the ones who destroyed the city of Ib thousands of years ago. From what you can gather, the inhabitants of Ib had committed no crime other than possessing a disturbing appearance and carving strange sculptures upon the grey monoliths within their city. However, the retribution Sarnath faced was far greater than their own sin. Even now, long after the destruction of Ib, creatures resembling the city's inhabitants still haunt the Nameless Lake, hunting down intruders like the warriors of Sarnath who destroyed their civilization so long ago. Intruders such as yourself.",
         "hidden": true,
@@ -356,6 +368,8 @@
     },
     {
         "code": "06133b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 15,
         "faction_code": "mythos",
         "flavor": "High above the walls of Ilek-Vad stands the marvelous Palace of Rainbows, its towers faceted so the sunlight forms bright rainbows when it strikes the palace each dawn. You are surprised to learn that the citizenry of Ilek-Vad - people of all stations and, indeed, even outsiders such as yourself - are free to visit the palace grounds and walk its smooth glass streets lined with fragrant gardens. You are able to meet with the king of Ilek-Vad, who is said to know the music of the Moon, and he is happy to share with you his knowledge of the Dreamlands. You never, ever want to leave.",
         "hidden": true,
@@ -385,6 +399,8 @@
     },
     {
         "code": "06134b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 16,
         "faction_code": "mythos",
         "flavor": "Throughout these perilous and hellish lands, you are beset by nameless beasts, hazardous terrain, and creatures too bizarre to describe. Even so, you press onward in the hope that you might learn something of the gods in this forsaken place. On the third evening you spend here, you find a shrine beside a lake of fire. Tucked away among a range of volcanoes, the shrine bears a statue carved in the face of the volcanic rock, long forgotten by ancient dreamers and outsiders alike. A mark of the Dreamlands' gods, perhaps? You draw the statue's likeness in your journal and hope that it might hold some significance.",
         "hidden": true,
@@ -415,6 +431,8 @@
     },
     {
         "code": "06135b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 17,
         "faction_code": "mythos",
         "flavor": "The greatest structure within the ruined city is its crypt. Beyond its massive stone door lies a labyrinth of lightless passages wherein sleep the dead of Zulan-Thek: decaying bones of those both important and inconsequential, from simple farmers and laborers to wizards, witches, and necromancers executed for practicing their magical arts. As you traverse the shrouded halls, the only signs of life you come across are a sobbing voice whose owner you cannot ever seem to find, and the scraping of claws along the inside of a sealed stone door that you dare not open. You cannot wait to leave this ominous pit, and yet you know there may be many secrets hidden within.",
         "hidden": true,
@@ -446,6 +464,8 @@
     },
     {
         "code": "06136b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 18,
         "faction_code": "mythos",
         "flavor": "The city of Baharna is a thriving and bustling harbor where you can find all manner of trade goods, provisions, and other wares. In the marketplace, you find supplies that may aid you in your expedition to lands farther south, as well as beasts of burden to carry your belongings. It should not surprise you that the most common of these creatures are zebras, and yet you are stunned nonetheless. You could spend days perusing the bazaar and still find oddities to spark your imagination. Truly this is a land of wonders.",
         "hidden": true,
@@ -476,6 +496,8 @@
     },
     {
         "code": "06137b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 19,
         "faction_code": "mythos",
         "flavor": "As you begin your perilous climb, you realize that you are the only ones who dare to scale the mountain. Although woodsmen and lava gatherers explore its lower slopes, few brave the cliffs higher up on the northern face, and certainly none along the southern face of the mountain, which cannot be seen from the city below.\nYou eventually reach a valley of still lava, solid as rock. At the far end, a twisting, narrow path ascends the southern slope. When you reach the top, you find what you have been searching for: a face carved into the side of the mountain, hundreds of feet tall: the face of one of the Great Ones, or so it is told.",
         "hidden": true,
@@ -507,6 +529,8 @@
     },
     {
         "code": "06138b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 20,
         "faction_code": "mythos",
         "flavor": "The ruins of this settlement are vast, but it is the caverns that lie beneath that draw your interest. Deep underground, you become lost in a forbidden maze of wildly complex corridors, impossible to map. For days you scour the maze, unable to find the path to its core. Finally, you notice a dark shape, like a hazy shadow, watching you from around a corner. You pursue it until it leads you to a tomb in the center of the gargantuan cavern, surrounded by ancient tapestries depicting the once great kingdom of Tyrrhia. You wonder about the intentions of the shadow that led you here. Was it aiding you, or manipulating you? You record the story of Tyrrhia's fall before fleeing to the surface. You have no wish to stay any longer.",
         "hidden": true,
@@ -538,6 +562,8 @@
     },
     {
         "code": "06139b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 21,
         "faction_code": "mythos",
         "flavor": "Randolph stops in one of the streets of Celephaïs to meet with the old chief of the city's cats, and you recall that your companion once told you that Ulthar is not the only city of the Dreamlands in which these curious creatures dwell. The cat informs Randolph where he can find \"his old friend,\" and you are surprised when your companion leads you to a rose-crystal palace in the center of the city. Here you meet with King Kuranes, who rules this region. When you tell Kuranes of your quest, he indicates that you may find what you are looking for in the great temple that lies in the center of Hazuth-Kleg, a city beyond his Timeless Realm. But this advice comes with a warning: Once you enter the Temple of Unattainable Desires, you might never leave.",
         "hidden": true,
@@ -569,6 +595,8 @@
     },
     {
         "code": "06140b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 22,
         "faction_code": "mythos",
         "flavor": "The beautiful city of Serannian is a refuge from all the world's ills. In these turreted cloud-castles that hang in a heavenly sky, time slows to a halt. The allure of this city is ageless. You could lose yourself for years within its marbled streets and perfect gardens and never notice the difference. It is so peaceful that you nearly forget your quest, as well as the fact that your physical body still sleeps in the real world. Even so, you cannot help but wonder: Would it be better to simply stay in this tranquil realm and let your mind remain at peace, even while your body ages and withers away?",
         "hidden": true,
@@ -599,6 +627,8 @@
     },
     {
         "code": "06141b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 23,
         "faction_code": "mythos",
         "flavor": "Deep within the run-down city of Hazuth-Kleg, along the street of the pantheon, lies the Temple of Unattainable Desires. It is a grand temple of onyx, its iron gate fashioned to look like a mass of twisted and intermingled serpents with amethyst eyes. Lanterns cast a baleful red glow at the entrance. You shudder at the thought of what profane rituals might transpire within its unhallowed halls, and yet, your gut tells you this awful place may hold the answers you seek.",
         "hidden": true,
@@ -630,6 +660,8 @@
     },
     {
         "code": "06142b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 24,
         "faction_code": "mythos",
         "flavor": "In the deepest section of the temple lies its greatest hall and its greatest curse. The moment you pass under its low, narrow doorway, you find yourself in another realm altogether: a twisted, hellish version of the city outside. The streets are lined with tottering houses that lean together so that they almost form tunnels, blotting out what passes for the sky in this nightmare realm. Only a single baleful star shines in the perpetual twilight, visible between the leaning basalt towers and twisted streets.",
         "hidden": true,
@@ -660,6 +692,8 @@
     },
     {
         "code": "06143b",
+        "encounter_code": "the_search_for_kadath",
+        "encounter_position": 25,
         "faction_code": "mythos",
         "flavor": "You traverse the tangled streets of this dark, abandoned realm for what seems like many hours. You cannot tell the passage of time, for the star that hangs above you never moves, and the rest of the sky is empty and devoid of all light. Finally you reach the square in the center of town, directly below the baleful star. Its red glare shines down on a statue depicting an otherworldly abomination. The inscription in the stone before the statue is riddled with astrological symbols and strange names, but nothing more. The moment you read one of the names, the city begins to collapse, and you are whisked away by an incomprehensible force. You awaken several hours later, your head spinning. Your arms and legs are covered in thin, bloody incisions.",
         "hidden": true,


### PR DESCRIPTION
Some hidden backsides were missing the `encounter_position` and `encounter_code` attributes (matching the frontside). This PR adds them.