### PR TITLE
Remove explicit `sanity: null` assignments

### DIFF
--- a/pack/return/rttcu_encounter.json
+++ b/pack/return/rttcu_encounter.json
@@ -896,7 +896,6 @@
         "pack_code": "rttcu",
         "position": 61,
         "quantity": 4,
-        "sanity": null,
         "text": "While you control Nightgaunt Steed, you may enter empty space as if it were a location.\n<b>Forced</b> - After you enter empty space, Nightgaunt Steed takes 1 direct damage.\n<b>Forced</b> - If Nightgaunt Steed leaves play, remove it from the game and move to the nearest revealed location.",
         "traits": "Monster. Nightgaunt.",
         "type_code": "asset"

--- a/pack/side/blbe_encounter.json
+++ b/pack/side/blbe_encounter.json
@@ -280,7 +280,6 @@
     "pack_code": "blbe",
     "position": 12,
     "quantity": 1,
-    "sanity": null,
     "text": "During the enemy phase, each ready enemy at Armored Car’s location attacks it, instead of any other target.\nDuring the investigation phase, investigators at this location may spend 1 [per_investigator] actions, as a group, to move Armored Car to a connecting location.",
     "traits": "Vehicle.",
     "type_code": "asset"

--- a/pack/side/blob_encounter.json
+++ b/pack/side/blob_encounter.json
@@ -546,7 +546,6 @@
         "pack_code": "blob",
         "position": 30,
         "quantity": 1,
-        "sanity": null,
         "skill_agility": 1,
         "skill_wild": 1,
         "text": "[fast] Defeat a non-[[Elite]] enemy at your location with 2 or less remaining health. Then, heal all damage from Pet Oozeling, place 1 resource on it, and reveal X chaos tokens, where X is the number of resources on it. If an [auto_fail] symbol is revealed, you are defeated and suffer 1 physical trauma.",

--- a/pack/tic/itm_encounter.json
+++ b/pack/tic/itm_encounter.json
@@ -575,7 +575,6 @@
         "pack_code": "itm",
         "position": 338,
         "quantity": 4,
-        "sanity": null,
         "slot": "Body",
         "text": "You ignore the <b>Forced</b> ability on the current agenda.\n<b>Forced</b> - When any amount of damage would be placed on you: Place 1 of that damage on Diving Suit.\n<b>Forced</b> - When Diving Suit leaves play: Remove it from the game.",
         "traits": "Item. Armor.",

--- a/translations/ru/pack/tic/itm_encounter.json
+++ b/translations/ru/pack/tic/itm_encounter.json
@@ -575,7 +575,6 @@
         "pack_code": "itm",
         "position": 338,
         "quantity": 4,
-        "sanity": null,
         "slot": "Body",
         "text": "You ignore the <b>Forced</b> ability on the current agenda.\n<b>Forced</b> - When any amount of damage would be placed on you: Place 1 of that damage on Diving Suit.\n<b>Forced</b> - When Diving Suit leaves play: Remove it from the game.",
         "traits": "Item. Armor.",


### PR DESCRIPTION
Player cards don't need to have `sanity: null` set explicitly, this removes the few occurrences where it slipped in.