### PR TITLE
Remove empty key-value pair from Fickle Fortune (09118)

### DIFF
--- a/pack/tsk/tskp.json
+++ b/pack/tsk/tskp.json
@@ -2766,7 +2766,6 @@
         "pack_code": "tskp",
         "position": 118,
         "quantity": 2,
-        "skill_intellect": 0,
         "tags": "hd.hh.",
         "text": "Max 2 [[Dilemma]] per round.\n<b>Revelation</b> - You must decide (choose one):\n- Place 1 doom on the current agenda. Each investigator heals 3 damage and 3 horror.\n- Remove 1 doom from the current agenda. Each investigator takes 1 direct damage and 1 direct horror. Remove Fickle Fortune from the game.",
         "traits": "Dilemma. Fortune.",


### PR DESCRIPTION
Unless there's a compatibility reason this needs to remain?