### PR TITLE
fix typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The available tags are:
 - `hd` => _Heals damage_, used for Vincent Lee.
 - `pa` => _Parley_, used for Alessandra Zorzi.
 - `se` => _Seals token_, used for ||Father Mateo.
-= `fa` => _Firearm in card text_, used for Michael McGlen.
+- `fa` => _Firearm in card text_, used for Michael McGlen.
 
 These tags have been used in the past but are unused right now:
 - `st` => _Spell trait_, used to mark whether a card had bonded spells for Marie Lambeau, which is no longer relevant, but still part of the deckbuilding rules.


### PR DESCRIPTION
README accidentally had `=` instead of `-` so McGlen card tag example was merged into the || Mateo line