### PR TITLE
back_subnames, formatting fixes, and FAQ 2.3 errata 

### DIFF
--- a/pack/dwl/dwl_encounter.json
+++ b/pack/dwl/dwl_encounter.json
@@ -273,6 +273,7 @@
     },
     {
         "back_flavor": "You come to a locked door at the top of the stairs leading to the third floor of the administration building. Through its frosted window, you glimpse a shadow darting across the hall.",
+        "back_subname": "The Night is Still Young",
         "back_text": "The door leading into the Faculty Offices is locked. You cannot move into the Faculty Offices.",
         "clues": 2,
         "code": "02054",
@@ -294,6 +295,7 @@
     },
     {
         "back_flavor": "You come to a locked door at the top of the stairs leading to the third floor of the administration building. Through its frosted window, you glimpse a shadow darting across the hall... or maybe it's just your imagination.",
+        "back_subname": "The Hour is Late",
         "back_text": "The door leading into the Faculty Offices is locked. You cannot move into the Faculty Offices.",
         "clues": 0,
         "code": "02055",

--- a/pack/dwl/litas_encounter.json
+++ b/pack/dwl/litas_encounter.json
@@ -170,6 +170,7 @@
         "type_code": "act"
     },
     {
+        "back_subname": "Unfettered by Reality",
         "clues": 0,
         "code": "02320",
         "double_sided": true,

--- a/pack/eoe/eoec.json
+++ b/pack/eoe/eoec.json
@@ -2825,6 +2825,7 @@
     },
     {
         "back_flavor": "\"...our study of the decadent sculptures brought about a change in our immediate objective. This of course had to do with the chiselled avenues to the black inner world, of whose existence we had not known before....\"\n - H. P. Lovecraft, <i>At the Mountains of Madness</i>",
+        "back_subname": "Entrance to the Depths",
         "back_text": "The passageway into the undercity is hidden. You cannot enter the Hidden Tunnel.",
         "clues": 2,
         "code": "08630",
@@ -3185,6 +3186,7 @@
     },
     {
         "back_flavor": "-the black pit - the carven rim - the proto-shoggoths - the windowless solids with five dimensions - the nameless cylinder - the elder pharos - the primal white jelly - the wings - the eyes in darkness - the moon-ladder - the original - the eternal - the undying-",
+        "back_subname": "Primordial Seal",
         "back_text": "A wall of churning miasma blocks the ancient gateway. Investigators and enemies cannot enter The Gate of Y'quaa. The Gate of Y'quaa cannot have attachments.",
         "clues": 1,
         "code": "08649",
@@ -3897,6 +3899,7 @@
     },
     {
         "back_flavor": "\"Thank heaven we did not slacken our run. The curling mist had thickened again, and was driving ahead with increased speed; whilst the straying penguins in our rear were squawking and screaming...\"\n - H. P. Lovecraft, <i>At the Mountains of Madness</i>",
+        "back_subname": "A Way Out",
         "back_text": "Hidden Tunnel is connected to the location to its left.",
         "clues": 0,
         "code": "08686",

--- a/pack/fhv/fhvc.json
+++ b/pack/fhv/fhvc.json
@@ -446,7 +446,7 @@
     "position": 22,
     "quantity": 1,
     "subname": "Alien Meteorite",
-    "text": "Uses (4 brilliance).\n[reaction] When a scenario card effect would discard any number of cards from your hand, exhaust Prismatic Shard and spend 1 brilliance: Ignore that effect and draw that many cards, instead.",
+    "text": "Uses (4 brilliance).\n[reaction] When a scenario card or weakness card effect would discard any number of cards from your hand, exhaust Prismatic Shard and spend 1 brilliance: Ignore that effect and draw that many cards, instead.",
     "traits": "Item. Relic. Colour.",
     "type_code": "asset"
   },
@@ -1779,7 +1779,7 @@
     "quantity": 1,
     "shroud": 3,
     "text": "<b>Forced</b> - After you fail a skill test while attempting to evade at Weed-Choked Beach: Lose 1 action.\n<b>Forced</b> - When you would leave Weed-Choked Beach: Reveal a chaos token. If a [skull], [tablet], [elder_thing], or [auto_fail] is revealed, you must either cancel the effects of the move or discard an [[Item]] asset you control.",
-    "traits": "Coastal.",
+    "traits": "Coastal. Cave.",
     "type_code": "location"
   },
   {

--- a/pack/ptc/apot_encounter.json
+++ b/pack/ptc/apot_encounter.json
@@ -209,6 +209,7 @@
     },
     {
         "back_flavor": "Le Théâtre du Grand-Guignol specializes in horror shows of a graphic and sometimes amoral nature. It is among the smallest venues in Paris, and one of the most popular.",
+        "back_subname": "Theatre of the Great Puppet",
         "clues": 1,
         "code": "03211",
         "double_sided": true,

--- a/pack/ptc/tuo_encounter.json
+++ b/pack/ptc/tuo_encounter.json
@@ -171,6 +171,7 @@
     },
     {
         "back_flavor": "The pleasant atmosphere of the reception area disappeared as soon as Dr. Mintz shut the thick iron door behind them. The temperature dropped to a clammy chill, and a foul, sharp stench hung in the air.\n- Mallory O’Meara, The Investigators of Arkham Horror",
+        "back_subname": "Western Patient Wing",
         "clues": 0,
         "code": "03168",
         "double_sided": true,
@@ -191,6 +192,7 @@
     },
     {
         "back_flavor": "The pleasant atmosphere of the reception area disappeared as soon as Dr. Mintz shut the thick iron door behind them. The temperature dropped to a clammy chill, and a foul, sharp stench hung in the air.\n- Mallory O’Meara, The Investigators of Arkham Horror",
+        "back_subname": "Western Patient Wing",
         "clues": 1,
         "code": "03169",
         "double_sided": true,
@@ -211,6 +213,7 @@
     },
     {
         "back_flavor": "The pleasant atmosphere of the reception area disappeared as soon as Dr. Mintz shut the thick iron door behind them. The temperature dropped to a clammy chill, and a foul, sharp stench hung in the air.\n- Mallory O’Meara, The Investigators of Arkham Horror",
+        "back_subname": "Eastern Patient Wing",
         "clues": 0,
         "code": "03170",
         "double_sided": true,
@@ -231,6 +234,7 @@
     },
     {
         "back_flavor": "The pleasant atmosphere of the reception area disappeared as soon as Dr. Mintz shut the thick iron door behind them. The temperature dropped to a clammy chill, and a foul, sharp stench hung in the air.\n- Mallory O’Meara, The Investigators of Arkham Horror",
+        "back_subname": "Eastern Patient Wing",
         "clues": 1,
         "code": "03171",
         "double_sided": true,

--- a/pack/return/rtdwl_encounter.json
+++ b/pack/return/rtdwl_encounter.json
@@ -375,6 +375,7 @@
     },
     {
         "back_flavor": "…it is hard to prevent the impression of a faint, malign odour about the village street, as of the massed mould and decay of centuries.\n-H. P. Lovecraft, \"The Dunwich Horror\"",
+        "back_subname": "Silent Decay",
         "clues": 0,
         "code": "51033",
         "double_sided": true,
@@ -652,6 +653,7 @@
     {
         "back_flavor": "The long slope of Sentinel Hill rises before you, cresting in the jagged edges of Sentinel Peak.",
         "back_illustrator": "Patrick McEvoy",
+        "back_subname": "Warped and Twisted",
         "clues": 3,
         "clues_fixed": true,
         "code": "51048",
@@ -673,6 +675,7 @@
     {
         "back_flavor": "When you try to follow the path leading farther up Sentinel Hill, you somehow end up walking in a perpetual loop. Each time you stop to get your bearings, you find yourself back at the base of the hill again.",
         "back_illustrator": "Patrick McEvoy",
+        "back_subname": "Warped and Twisted",
         "back_text": "The path leading farther up the hill is masked. You cannot move into Ascending Path.",
         "clues": 3,
         "clues_fixed": true,

--- a/pack/return/rtnotz_encounter.json
+++ b/pack/return/rtnotz_encounter.json
@@ -35,6 +35,7 @@
     },
     {
         "back_flavor": "You’ve been investigating the strange events occurring in Arkham for several months now. Your desk is covered in newspaper articles, police reports, and witness accounts.",
+        "back_subname": "Aberrant Gateway",
         "clues": 1,
         "code": "50013",
         "double_sided": true,

--- a/pack/return/rtptc_encounter.json
+++ b/pack/return/rtptc_encounter.json
@@ -546,6 +546,7 @@
     },
     {
         "back_flavor": "Le Théâtre du Grand-Guignol specializes in horror shows of a graphic and sometimes amoral nature. It is among the smallest venues in Paris, and one of the most popular.",
+        "back_subname": "Theatre of the Great Puppet",
         "clues": 1,
         "code": "52042",
         "double_sided": true,

--- a/pack/return/rttfa_encounter.json
+++ b/pack/return/rttfa_encounter.json
@@ -52,6 +52,7 @@
     },
     {
         "back_flavor": "The sun sets over the temple ruins, bathing the stone in warm light. The sounds of the rainforest are distant by the time you cross underneath the painted entryway. Inside, the halls are plunged into darkness.",
+        "back_subname": "Rearranged by Time",
         "clues": 1,
         "code": "53019",
         "double_sided": true,
@@ -771,6 +772,7 @@
         "type_code": "act"
     },
     {
+        "back_subname": "Southern Corridors",
         "back_text": "This location is connected to Halls of Pnakotus <i>(Eastern Corridors)</i> and Halls of Pnakotus <i>(Western Corridors)</i>, and vice versa.",
         "clues": 1,
         "clues_fixed": true,

--- a/pack/side/fof_encounter.json
+++ b/pack/side/fof_encounter.json
@@ -459,6 +459,7 @@
         "type_code": "location"
     },
     {
+        "back_subname": "Sanctum of Fortune",
         "back_text": "You cannot enter Relic Room.\nVault Door gains: \"[action] Take 1 damage and 1 horror unless an investigator \"found Abarran's sigil\": Test [willpower] or [agility] (4). If you succeed, investigators at Vault Door may spend 4 [per_investigator] clues, as a group, to reveal Relic Room.",
         "clues": 1,
         "code": "88022",

--- a/pack/side/wog_encounter.json
+++ b/pack/side/wog_encounter.json
@@ -359,7 +359,7 @@
         "position": 19,
         "quantity": 1,
         "shroud": 2,
-        "text": "[action]: Test [willpower] (4). If you succeed, gain 1 clue <i>(from the token pool)<i>.",
+        "text": "[action]: Test [willpower] (4). If you succeed, gain 1 clue <i>(from the token pool)</i>.",
         "traits": "Montréal.",
         "type_code": "location"
     },

--- a/pack/side/wog_encounter.json
+++ b/pack/side/wog_encounter.json
@@ -437,6 +437,7 @@
         "type_code": "location"
     },
     {
+        "back_subname": "Unsealed",
         "back_text": "While there are 6 [per_investigator] or more clues around Hub Dimension, your group has \"sealed off the Hub Dimension.\"",
         "back_flavor": "A vast network of cosmic tunnels where gravity is warped in a surreal web of astral dimensions.",
         "clues": 0,

--- a/pack/tcu/fgg_encounter.json
+++ b/pack/tcu/fgg_encounter.json
@@ -132,6 +132,7 @@
     },
     {
         "back_flavor": "As you approach the gates of the Lodge’s manor in French Hill, you are surprised to see several automobiles parked nearby, in the street. Light shines in several of the windows of the manor. Is there a gathering of some sort here tonight?",
+        "back_subname": "We've Been Expecting You",
         "clues": 0,
         "code": "05204",
         "double_sided": true,
@@ -152,6 +153,7 @@
     },
     {
         "back_flavor": "As you approach the gates of the Lodge’s manor in French Hill, you are surprised to see several automobiles parked nearby, in the street. Light shines in several of the windows of the manor. Is there a gathering of some sort here tonight?",
+        "back_subname": "Members Only",
         "clues": 1,
         "code": "05205",
         "double_sided": true,
@@ -173,6 +175,7 @@
     {
         "back_flavor": "The front entrance to the Lodge’s manor is guarded by two men in trenchcoats, who nod to you as you approach.",
         "back_illustrator": "Yoann Boissonnet",
+        "back_subname": "We've Been Expecting You",
         "back_text": "The entrance to the Silver Twilight Lodge is guarded. You cannot enter the Lobby.\nLodge Gates gains: \"[action]: <b>Parley.</b> The guards recognize you from the Meiger estate and let you pass. Reveal the Lobby.\"",
         "clues": 0,
         "code": "05206",
@@ -194,6 +197,7 @@
     {
         "back_flavor": "The front entrance to the Lodge’s manor is guarded by two men in trenchcoats. Perhaps there is another way into the building...",
         "back_illustrator": "Yoann Boissonnet",
+        "back_subname": "Members Only",
         "clues": 1,
         "code": "05207",
         "double_sided": true,
@@ -215,6 +219,7 @@
     {
         "back_flavor": "Several locked windows along the basement level of the manor reveal the dark cellar within.",
         "back_illustrator": "Yoann Boissonnet",
+        "back_subname": "We've Been Expecting You",
         "clues": 1,
         "code": "05208",
         "double_sided": true,
@@ -236,6 +241,7 @@
     {
         "back_flavor": "Several windows along the basement level of the manor reveal the dark cellar within.",
         "back_illustrator": "Yoann Boissonnet",
+        "back_subname": "Members Only",
         "back_text": "The rear entrance to the Silver Twilight Lodge is hidden. You cannot enter the Lodge Cellar.\nLodge Gates gains: \"[action] Investigators at the Lodge Gates spend 1 [per_investigator] clues, as a group: Reveal the Lodge Cellar.\"",
         "clues": 0,
         "code": "05209",

--- a/pack/tcu/icc_encounter.json
+++ b/pack/tcu/icc_encounter.json
@@ -375,6 +375,7 @@
     },
     {
         "back_flavor": "As you approach Hangman’s Hill once more, a torrent of spirits ascend into the sky from the graveyard below. The spirits howl in torment as they surround the city, their cries becoming a music of its own.",
+        "back_subname": "Where It All Ends",
         "clues": 0,
         "code": "05302",
         "double_sided": true,
@@ -394,6 +395,7 @@
     },
     {
         "back_flavor": "As you approach the manor of the Lodge once more, you find it dark and empty. It seems that its members are still laying low, at least for the time being.",
+        "back_subname": "Shrouded in Mystery",
         "clues": 1,
         "code": "05303",
         "double_sided": true,
@@ -414,6 +416,7 @@
     },
     {
         "back_flavor": "As you approach Hangman’s Hill once more, you find it devoid of any activity - from the living or otherwise. It seems the coven has left this place behind, at least for the time being.",
+        "back_subname": "Shrouded in Mystery",
         "clues": 1,
         "code": "05304",
         "double_sided": true,
@@ -434,6 +437,7 @@
     },
     {
         "back_flavor": "As you approach the manor of the Lodge once more, bright light shines from behind its windows. You can hear faint chanting from within.",
+        "back_subname": "Where It All Ends",
         "clues": 0,
         "code": "05305",
         "double_sided": true,

--- a/pack/tde/dsm_encounter.json
+++ b/pack/tde/dsm_encounter.json
@@ -260,6 +260,7 @@
     },
     {
         "back_flavor": "\"...while in a black cave on a far unhallowed summit of the moon-mountains still vainly waited the crawling chaos Nyarlathotep.\" - H. P. Lovecraft, <u>The Dream-Quest of Unknown Kadath</u>",
+        "back_subname": "Dark Side",
         "clues": 1,
         "code": "06219",
         "double_sided": true,
@@ -298,6 +299,7 @@
     },
     {
         "back_flavor": "\"The dead temples on the mountains were so placed that they could have glorified no wholesome or suitable gods...\" - H. P. Lovecraft, <u>The Dream-Quest of Unknown Kadath</u>",
+        "back_subname": "Light Side",
         "clues": 1,
         "code": "06221",
         "double_sided": true,

--- a/pack/tde/tde_encounter.json
+++ b/pack/tde/tde_encounter.json
@@ -114,6 +114,7 @@
     },
     {
         "back_flavor": "You are no longer in your own world.\nA spiral of twisting stone steps hang suspended in the aether with no visible means of support. At the bottom of the steps, there is an island landing, also floating in the void, where a tall, golden gateway leads into a brightly lit cavern.",
+        "back_subname": "Of Lighter Slumber",
         "clues": 1,
         "code": "06045",
         "double_sided": true,
@@ -153,6 +154,7 @@
     },
     {
         "back_flavor": "\"So asking a farewell blessing of the priests and thinking shrewdly on his course, he boldly descended the seven hundred steps to the Gate of Deeper Slumber.\" - H. P. Lovecraft, <u>The Dream-Quest of Unknown Kadath</u>",
+        "back_subname": "Of Deeper Slumber",
         "clues": 1,
         "code": "06047",
         "double_sided": true,

--- a/pack/tde/wgd_encounter.json
+++ b/pack/tde/wgd_encounter.json
@@ -253,7 +253,7 @@
         "encounter_code": "where_the_gods_dwell",
         "encounter_position": 14,
         "faction_code": "mythos",
-        "flavor": "\"Save for that one tower room the onyx castle atop Kadath was dark, and the masters were not there.\"\n- H. P. Lovecraft, <u>The Dream-Quest of Unknown Kadath,/u>",
+        "flavor": "\"Save for that one tower room the onyx castle atop Kadath was dark, and the masters were not there.\"\n- H. P. Lovecraft, <u>The Dream-Quest of Unknown Kadath</u>",
         "illustrator": "Sergey Glushakov",
         "name": "The Great Hall",
         "pack_code": "wgd",

--- a/pack/tfa/sha_encounter.json
+++ b/pack/tfa/sha_encounter.json
@@ -195,6 +195,7 @@
     },
     {
         "back_flavor": "At the center of the chamber lies the Nexus: a bottomless pit in the Earth, ringed by futuristic machinery no doubt built by those who came before humanity. Inside this pit is a swirling soup of eldritch energy; glowing strands of ethereal light that ripple, fold, and weave among one another. As you approach, a fragment of stone chips from the brim and falls into the portal, vanishing from existence.",
+        "back_subname": "Unraveling the Threads",
         "clues": 1,
         "code": "04324",
         "double_sided": true,

--- a/pack/tfa/tcoa_encounter.json
+++ b/pack/tfa/tcoa_encounter.json
@@ -222,6 +222,7 @@
     },
     {
         "back_flavor": "At this point, it appeared, the desert’s sands lay directly upon a floor of some titan structure of earth’s youth - how preserved through aeons of geologic convulsion I could not then and cannot now even attempt to guess. - H. P. Lovecraft, <u>The Shadow out of Time</u>",
+        "back_subname": "Northern Corridors",
         "clues": 1,
         "clues_fixed": true,
         "code": "04248",
@@ -243,6 +244,7 @@
     },
     {
         "back_flavor": "At this point, it appeared, the desert’s sands lay directly upon a floor of some titan structure of earth’s youth - how preserved through aeons of geologic convulsion I could not then and cannot now even attempt to guess. - H. P. Lovecraft, <u>The Shadow out of Time</u>",
+        "back_subname": "Eastern Corridors",
         "clues": 1,
         "clues_fixed": true,
         "code": "04249",
@@ -264,6 +266,7 @@
     },
     {
         "back_flavor": "At this point, it appeared, the desert’s sands lay directly upon a floor of some titan structure of earth’s youth - how preserved through aeons of geologic convulsion I could not then and cannot now even attempt to guess. - H. P. Lovecraft, <u>The Shadow out of Time</u>",
+        "back_subname": "Western Corridors",
         "clues": 1,
         "clues_fixed": true,
         "code": "04250",

--- a/pack/tic/itm_encounter.json
+++ b/pack/tic/itm_encounter.json
@@ -344,6 +344,7 @@
     },
     {
         "back_flavor": "As you descend the familiar steps, something tugs at your memories. You've been here before, haven't you?",
+        "back_subname": "Sanctuary of Father Dagon",
         "clues": 3,
         "code": "07328",
         "double_sided": true,
@@ -363,6 +364,7 @@
     },
     {
         "back_flavor": "Amidst the sound of cascading waterfalls, the deep rumbling of something enormous stirring emanates from below. Each of the thing's breaths resounds throughout the city, shaking the walls, filling your heart with fear, and yet, calling to you.",
+        "back_subname": "High Temple of Mother Hydra",
         "clues": 3,
         "code": "07329",
         "double_sided": true,

--- a/pack/tic/lif_encounter.json
+++ b/pack/tic/lif_encounter.json
@@ -277,6 +277,7 @@
     },
     {
         "back_flavor": "Rickety wooden stairways cut through the crust of the cliffside, leading deeper underground.",
+        "back_subname": "Lower Depths",
         "clues": 0,
         "code": "07245",
         "double_sided": true,
@@ -296,6 +297,7 @@
     },
     {
         "back_flavor": "Rickety wooden stairways cut through the crust of the cliffside, leading deeper underground.",
+        "back_subname": "Final Depths",
         "clues": 0,
         "code": "07246",
         "double_sided": true,

--- a/pack/tsk/tskc.json
+++ b/pack/tsk/tskc.json
@@ -2943,6 +2943,7 @@
   },
   {
     "back_flavor": "The stock exchange building in Alexandria is more than just a place of business, it seems - it is also the Claret Knight's chosen hiding place for the Key you are searching for.",
+    "back_subname": "Locus Safeguard",
     "back_text": "The entrance to the offices is secure. Unless The Claret Knight is the only Key Locus in play, enemies cannot enter The Bourse (if an enemy would spawn here, spawn it at a connecting location instead).",
     "clues": 2,
     "code": "09642",
@@ -2963,6 +2964,7 @@
   },
   {
     "back_flavor": "It seems the Coterie has set up shop in Alexandria's stock exchange building. What better place to hide than in plain sight?",
+    "back_subname": "Coterie Post",
     "back_text": "The entrance to the offices is guarded. You cannot enter The Bourse unless it is the only Key Locus in play.",
     "clues": 3,
     "code": "09643",
@@ -2984,6 +2986,7 @@
   },
   {
     "back_flavor": "The Bourse is the site of Alexandria's stock exchange, cementing the city as a major economic center for Egypt. It is a bustling place during the day, with many carriages and automobiles parked nearby at all hours, and dozens of people entering and exiting.",
+    "back_subname": "Commercial Center",
     "clues": 1,
     "code": "09644",
     "double_sided": true,
@@ -3093,6 +3096,7 @@
   },
   {
     "back_flavor": "The necropolis is home to several prominent dead, but is also the lair of something far more terrifying.",
+    "back_subname": "Den of the Beast",
     "back_text": "The way into the catacombs is hidden. You cannot enter the Catacombs of Kom el Shoqafa unless it is the only Key Locus in play.",
     "clues": 2,
     "code": "09650",
@@ -3114,6 +3118,7 @@
   },
   {
     "back_text": "The way into the catacombs is blocked. You cannot enter the Catacombs of Kom el Shoqafa. The Beast in a Cowl of Crimson cannot leave Catacombs of Kom el Shoqafa.\n<b>Forced</b> - If there is 6 or more doom on the current agenda: Reveal Catacombs of Kom el Shoqafa.",
+    "back_subname": "Bloody Nexus",
     "clues": 2,
     "code": "09651",
     "double_sided": true,
@@ -3135,6 +3140,7 @@
   },
   {
     "back_flavor": "Kom el Shoqafa - meaning Mound of Shards - is the site of many tombs, statues and other ancient relics, a conflux of Egyptian, Roman, and Greek influences. It is now partially underwater and closed to the public. Who knows what other secrets lie buried within?",
+    "back_subname": "Ancient Tomb",
     "clues": 1,
     "code": "09652",
     "double_sided": true,
@@ -3507,6 +3513,7 @@
   },
   {
     "back_flavor": "This busy railway stop brings in travelers from all over the world, near and far. The recently completed platform now connects Kuala Lumpur to Singapore and Siam.",
+    "back_subname": "East Wing",
     "clues": 1,
     "code": "09667",
     "double_sided": true,
@@ -3526,6 +3533,7 @@
   },
   {
     "back_flavor": "The western wing of the station is veiled in a heavy fog. Glimmering shapes flit to and fro in the haze.",
+    "back_subname": "West Wing",
     "clues": 1,
     "code": "09668",
     "double_sided": true,
@@ -4610,6 +4618,7 @@
     "type_code": "location"
   },
   {
+    "back_subname": "Ruinous Conflux",
     "back_text": "The Red-Gloved Man cannot be defeated.\nThe way to The Towering Vertex is impossibly perplexing. In order for an investigator to enter The Towering Vertex, concealed mini-cards around Gravity-Defying Climb must be exposed in the following sequence: <b>First, City of Remnants (L); second, City of Remnants (M); third, City of Remnants (R)</b>.",
     "clues": 0,
     "code": "09714",

--- a/schema/card_schema.json
+++ b/schema/card_schema.json
@@ -26,6 +26,11 @@
             "minLength": 1,
             "type": "string"
         },
+        "back_subname": {
+            "description": "Subname on the back of location cards. Use this if the subname is present on the unrevealed side of a location.",
+            "minLength": 1,
+            "type": "string"
+        },
         "back_text": {
             "description": "Text on the back of `double_sided` cards. Only use this if the back text is different from the front.",
             "minLength": 1,


### PR DESCRIPTION
Resolves #1581 for applicable location cards up through (but **not** yet including) The Drowned City.

Also fixes some minor formatting issues on some cards that were causing erroneous display on ArkhamDB, and implemented errata for two cards from Feast of Hemlock Vale that did not yet appear to be implemented.
