### PR TITLE
link tindalos locations

### DIFF
--- a/pack/side/mtt_encounter.json
+++ b/pack/side/mtt_encounter.json
@@ -74,6 +74,7 @@
         "type_code": "act"
     },
     {
+        "back_link": "87005b",
         "clues": 0,
         "code": "87005a",
         "encounter_code": "machinations_through_time_single_group",


### PR DESCRIPTION
I didn't make either side `hidden` because I don't think that's apt in this case (especially since the two sides are part of two different encounter sets, technically), but if I need to make one side hidden to prevent issues, let me know. Attempts to resolve #1580 