### PR TITLE
Fix: Align non-translated text with english data.

### DIFF
--- a/translations/ko/pack/core/core_encounter.json
+++ b/translations/ko/pack/core/core_encounter.json
@@ -486,7 +486,7 @@
         "code": "01166",
         "flavor": "Dark forces stir against you. If you do not act quickly, a sinister plot will be fulfilled.",
         "name": "고대의 악",
-        "text": "<b>Revelation</b> - Place 1 doom on the current agenda. This effect may cause the current agenda to advance.",
+        "text": "<b>Revelation</b> - Place 1 doom on the current agenda. This effect can cause the current agenda to advance.",
         "traits": "징조."
     },
     {


### PR DESCRIPTION
In Eng, Ancient evils says "... can advance ..." 
In korean data, for no reason, says "... may advance .."