### PR TITLE
Fix Parallel Roland directives

### DIFF
--- a/pack/parallel/btb.json
+++ b/pack/parallel/btb.json
@@ -45,7 +45,7 @@
         "restrictions": "investigator:01001",
         "subname": "Due Diligence",
         "tags": "pa.",
-        "text": "Roland Banks deck only. Permanent.\n<i>Regulation</i> - You cannot fight more than twice each round.\n[fast] During a skill test while investigating, evading, or parleying, exhaust Directive: You get +2 skill value for this test for each enemy engaged with you.",
+        "text": "Roland Banks deck only. Permanent.\n<i>Regulation</i> - You cannot fight more than twice each round.\n[fast] During a skill test while investigating, evading, or parleying, exhaust this Directive: You get +2 skill value for this test for each enemy engaged with you.",
         "type_code": "asset"
     },
     {


### PR DESCRIPTION
All directives said "Roland Bank deck only." rather than "Roland Banks deck only."