### PR TITLE
Update Hunting Parasite faction_code to neutral.

### DIFF
--- a/pack/tdc/tdcc.json
+++ b/pack/tdc/tdcc.json
@@ -725,7 +725,7 @@
         "enemy_damage": 1,
         "enemy_evade": 2,
         "enemy_fight": 2,
-        "faction_code": "mythos",
+        "faction_code": "neutral",
         "health": 1,
         "illustrator": "Stephen Somers",
         "is_unique": true,


### PR DESCRIPTION
faction_code as "mythos" causes a forbidden warning. See Parasitic Transformation (card/11583) as an example of a different campaign weakness which uses neutral faction_code instead.
<img width="593" height="347" alt="Screenshot 2025-09-08 at 14 37 34" src="https://github.com/user-attachments/assets/9da05a4d-31c6-4354-bc41-500e00264d69" />
