### PR TITLE
metadata errors

### DIFF
--- a/pack/fhv/fhvc.json
+++ b/pack/fhv/fhvc.json
@@ -2876,7 +2876,7 @@
     "pack_code": "fhvc",
     "position": 125,
     "quantity": 4,
-    "text": "Hunter. Alert.\nX is the current darkness level.\n<b>Prey</b> Investigator with the Vale Lantern only.\n<b>Forced</b> - After Stalking Hybrid attacks you, if you control the Vale Lantern: Flip the Vale Lantern to its [[Unlit]] side and place it at your location.",
+    "text": "Hunter. Alert.\nX is the current darkness level.\n<b>Prey</b> - Investigator with the Vale Lantern only.\n<b>Forced</b> - After Stalking Hybrid attacks you, if you control the Vale Lantern: Flip the Vale Lantern to its [[Unlit]] side and place it at your location.",
     "traits": "Creature. Monster. Mutated.",
     "type_code": "enemy"
   },

--- a/pack/return/rtdwl_encounter.json
+++ b/pack/return/rtdwl_encounter.json
@@ -318,7 +318,7 @@
         "position": 29,
         "quantity": 1,
         "shroud": 1,
-        "text": "Freight Car is connected to the locations to the left and right of it.\n<b>Forced</b> - At the end of the round: Each investigator on the Freight Car must test [agility] (1). Each investigator who fails must test [agility] (1) again. each investigator who fails this second test is pulled into the vortex above and is defeated.",
+        "text": "Freight Car is connected to the locations to the left and right of it.\n<b>Forced</b> - At the end of the round: Each investigator on the Freight Car must test [agility] (1). Each investigator who fails must test [agility] (1) again. Each investigator who fails this second test is pulled into the vortex above and is defeated.",
         "traits": "Train.",
         "type_code": "location"
     },

--- a/pack/side/film_fatale_encounter.json
+++ b/pack/side/film_fatale_encounter.json
@@ -486,7 +486,7 @@
     "position": 27,
     "quantity": 1,
     "shroud": 4,
-    "text": "<b>Forced</b> - At the end of the round; if there are no clues on High Ruler's Bastion: Place clues on this location up to its clue value.\n[free] If the Saturnite Monarch is in the victory display: Place 1 shard on Helios Telescope. (Max once per game.)",
+    "text": "<b>Forced</b> - At the end of the round, if there are no clues on High Ruler's Bastion: Place clues on this location up to its clue value.\n[free] If the Saturnite Monarch is in the victory display: Place 1 shard on Helios Telescope. (Max once per game.)",
     "traits": "Cosmos.",
     "type_code": "location"
   },

--- a/pack/tdc/tdcc.json
+++ b/pack/tdc/tdcc.json
@@ -550,7 +550,7 @@
         "position": 27,
         "quantity": 1,
         "shroud": -2,
-        "text": "X is this location's level.\n<b>Forced</b> - While a [[Deep One]] enemy is moving, Drowned Shanty is considered to be connected to each other fully flooded location and vice versa.",
+        "text": "X is this location's level.\nWhile a [[Deep One]] enemy is moving, Drowned Shanty is considered to be connected to each other fully flooded location and vice versa.",
         "traits": "R'lyeh. Walkway.",
         "type_code": "location"
     },

--- a/pack/tic/lod_encounter.json
+++ b/pack/tic/lod_encounter.json
@@ -334,7 +334,7 @@
         "position": 290,
         "quantity": 1,
         "shroud": 5,
-        "text": "<b>Forced</b> - After Doorway to the Depths is revealed: Place the set-aside green key on the location with the most clues.\n[action] Investigators at the Doorway to the Depths spend the green key and 3 [per_investigator] clues, as a group: Remember that you have \"unlocked the final depths\".",
+        "text": "<b>Forced</b> - After Doorway to the Depths is revealed: Place the set-aside green key on the location with the most clues.\n[action] Investigators at the Doorway to the Depths spend the green key and 3 [per_investigator] clues, as a group: Remember that you have \"unlocked the final depths.\"",
         "traits": "Cave.",
         "type_code": "location"
     },


### PR DESCRIPTION
Resolves #1626

In part. Outstanding issues are (1) Beyond the scope of a metadata fix:

- Catacombs of Kom el Shoqafa: the front image for one of the three versions (Den of the Beast) has erroneously been used for the front image of the other two versions (Bloody Nexus and Ancient Tomb)
- Cliffs of Insanity (the back side of 2/9 of the City of Remnants): its back image has erroneously also been used for its front

and (2) require a discussion about how/whether apps utilize the existing `back_traits` field

- The traits on most of the Summit locations (from the Obsidian Canyons encounter set) are screwed up; they should all be "R'lyeh. Summit." but instead they all say they are whatever traits are on their back