### PR TITLE
Fix typo in Quick Learner

### DIFF
--- a/pack/investigator/ste.json
+++ b/pack/investigator/ste.json
@@ -468,7 +468,7 @@
         "permanent": true,
         "position": 30,
         "quantity": 2,
-        "text": "Permanent.\nDuring or before your first action of each of your turns, each skill test you perform gets +1 difficulty.\nDuring or after your third action of each of your turns, each skill test you performed gets -1 difficulty.",
+        "text": "Permanent.\nDuring or before your first action of each of your turns, each skill test you perform gets +1 difficulty.\nDuring or after your third action of each of your turns, each skill test you perform gets -1 difficulty.",
         "traits": "Condition.",
         "type_code": "asset",
         "xp": 4


### PR DESCRIPTION
The database text incorrectly differs from the card text