### PR TITLE
Correct clue threshold in One Last Job

### DIFF
--- a/pack/tdc/tdcc.json
+++ b/pack/tdc/tdcc.json
@@ -56,6 +56,7 @@
     {
         "back_link": "11504b",
         "clues": 2,
+        "clues_fixed": true,
         "code": "11504",
         "encounter_code": "one_last_job",
         "encounter_position": 4,


### PR DESCRIPTION
the two copies of Questioning the Gangs have clue thresholds set up differently, believe clues_fixed is the correct way to handle this.