### PR TITLE
Add chapter and replaced flags for packs to better display pack lists

### DIFF
--- a/packs.json
+++ b/packs.json
@@ -1,15 +1,18 @@
 [
     {
         "cgdb_id": 1,
+        "chapter": 1,
         "code": "core",
         "cycle_code": "core",
         "date_release": "2016-11-10",
         "name": "Core Set",
         "position": 1,
+        "replaced": true,
         "size": 184
     },
     {
         "cgdb_id": 1,
+        "chapter": 1,
         "code": "rcore",
         "cycle_code": "core",
         "date_release": "2020-10-01",
@@ -18,6 +21,7 @@
         "size": 195
     },
     {
+        "chapter": 2,
         "code": "core_2026",
         "cycle_code": "core",
         "date_release": "2026-04-30",
@@ -27,383 +31,468 @@
     },
     {
         "cgdb_id": 2,
+        "chapter": 1,
         "code": "dwl",
         "cycle_code": "dwl",
         "date_release": "2017-01-12",
         "name": "The Dunwich Legacy",
         "position": 1,
+        "replaced": true,
         "size": 104
     },
     {
         "cgdb_id": 3,
+        "chapter": 1,
         "code": "tmm",
         "cycle_code": "dwl",
         "date_release": "2017-02-16",
         "name": "The Miskatonic Museum",
         "position": 2,
+        "replaced": true,
         "size": 42
     },
     {
         "cgdb_id": 4,
+        "chapter": 1,
         "code": "tece",
         "cycle_code": "dwl",
         "date_release": "2017-03-16",
         "name": "The Essex County Express",
         "position": 3,
+        "replaced": true,
         "size": 37
     },
     {
         "cgdb_id": 5,
+        "chapter": 1,
         "code": "bota",
         "cycle_code": "dwl",
         "date_release": "2017-04-13",
         "name": "Blood on the Altar",
         "position": 4,
+        "replaced": true,
         "size": 41
     },
     {
         "cgdb_id": 6,
+        "chapter": 1,
         "code": "uau",
         "cycle_code": "dwl",
         "date_release": "2017-05-11",
         "name": "Undimensioned and Unseen",
         "position": 5,
+        "replaced": true,
         "size": 35
     },
     {
         "cgdb_id": 7,
+        "chapter": 1,
         "code": "wda",
         "cycle_code": "dwl",
         "date_release": "2017-06-08",
         "name": "Where Doom Awaits",
         "position": 6,
+        "replaced": true,
         "size": 39
     },
     {
         "cgdb_id": 8,
+        "chapter": 1,
         "code": "litas",
         "cycle_code": "dwl",
         "date_release": "2017-07-06",
         "name": "Lost in Time and Space",
         "position": 7,
+        "replaced": true,
         "size": 35
     },
     {
         "cgdb_id": 11,
+        "chapter": 1,
         "code": "ptc",
         "cycle_code": "ptc",
         "date_release": "2017-09-14",
         "name": "The Path to Carcosa",
         "position": 1,
+        "replaced": true,
         "size": 110
     },
     {
         "cgdb_id": 12,
+        "chapter": 1,
         "code": "eotp",
         "cycle_code": "ptc",
         "date_release": "2017-10-26",
         "name": "Echoes of the Past",
         "position": 2,
+        "replaced": true,
         "size": 41
     },
     {
         "cgdb_id": 13,
+        "chapter": 1,
         "code": "tuo",
         "cycle_code": "ptc",
         "date_release": "2017-11-24",
         "name": "The Unspeakable Oath",
         "position": 3,
+        "replaced": true,
         "size": 43
     },
     {
         "cgdb_id": 14,
+        "chapter": 1,
         "code": "apot",
         "cycle_code": "ptc",
         "date_release": "2017-12-21",
         "name": "A Phantom of Truth",
         "position": 4,
+        "replaced": true,
         "size": 39
     },
     {
         "cgdb_id": 15,
+        "chapter": 1,
         "code": "tpm",
         "cycle_code": "ptc",
         "date_release": "2018-01-25",
         "name": "The Pallid Mask",
         "position": 5,
+        "replaced": true,
         "size": 35
     },
     {
         "cgdb_id": 16,
+        "chapter": 1,
         "code": "bsr",
         "cycle_code": "ptc",
         "date_release": "2018-02-22",
         "name": "Black Stars Rise",
         "position": 6,
+        "replaced": true,
         "size": 43
     },
     {
         "cgdb_id": 17,
+        "chapter": 1,
         "code": "dca",
         "cycle_code": "ptc",
         "date_release": "2018-03-22",
         "name": "Dim Carcosa",
         "position": 7,
+        "replaced": true,
         "size": 45
     },
     {
         "cgdb_id": 19,
+        "chapter": 1,
         "code": "tfa",
         "cycle_code": "tfa",
         "date_release": "2018-05-10",
         "name": "The Forgotten Age",
         "position": 1,
+        "replaced": true,
         "size": 102
     },
     {
         "cgdb_id": 20,
+        "chapter": 1,
         "code": "tof",
         "cycle_code": "tfa",
         "date_release": "2018-06-14",
         "name": "Threads of Fate",
         "position": 2,
+        "replaced": true,
         "size": 47
     },
     {
         "cgdb_id": 21,
+        "chapter": 1,
         "code": "tbb",
         "cycle_code": "tfa",
         "date_release": "2018-07-19",
         "name": "The Boundary Beyond",
         "position": 3,
+        "replaced": true,
         "size": 43
     },
     {
         "cgdb_id": 22,
+        "chapter": 1,
         "code": "hote",
         "cycle_code": "tfa",
         "date_release": "2018-08-16",
         "name": "Heart of the Elders",
         "position": 4,
+        "replaced": true,
         "size": 38
     },
     {
         "cgdb_id": 23,
+        "chapter": 1,
         "code": "tcoa",
         "cycle_code": "tfa",
         "date_release": "2018-09-13",
         "name": "The City of Archives",
         "position": 5,
+        "replaced": true,
         "size": 36
     },
     {
         "cgdb_id": 24,
+        "chapter": 1,
         "code": "tdoy",
         "cycle_code": "tfa",
         "date_release": "2018-10-11",
         "name": "The Depths of Yoth",
         "position": 6,
+        "replaced": true,
         "size": 39
     },
     {
         "cgdb_id": 25,
+        "chapter": 1,
         "code": "sha",
         "cycle_code": "tfa",
         "date_release": "2018-11-15",
         "name": "Shattered Aeons",
         "position": 7,
+        "replaced": true,
         "size": 46
     },
     {
         "cgdb_id": 29,
+        "chapter": 1,
         "code": "tcu",
         "cycle_code": "tcu",
         "date_release": "2019-01-31",
         "name": "The Circle Undone",
         "position": 1,
+        "replaced": true,
         "size": 109
     },
     {
         "cgdb_id": 30,
+        "chapter": 1,
         "code": "tsn",
         "cycle_code": "tcu",
         "date_release": "2019-03-14",
         "name": "The Secret Name",
         "position": 2,
+        "replaced": true,
         "size": 42
     },
     {
         "cgdb_id": 31,
+        "chapter": 1,
         "code": "wos",
         "cycle_code": "tcu",
         "date_release": "2019-04-04",
         "name": "The Wages of Sin",
         "position": 3,
+        "replaced": true,
         "size": 40
     },
     {
         "cgdb_id": 32,
+        "chapter": 1,
         "code": "fgg",
         "cycle_code": "tcu",
         "date_release": "2019-05-02",
         "name": "For the Greater Good",
         "position": 4,
+        "replaced": true,
         "size": 43
     },
     {
         "cgdb_id": 33,
+        "chapter": 1,
         "code": "uad",
         "cycle_code": "tcu",
         "date_release": "2019-06-06",
         "name": "Union and Disillusion",
         "position": 5,
+        "replaced": true,
         "size": 44
     },
     {
         "cgdb_id": 34,
+        "chapter": 1,
         "code": "icc",
         "cycle_code": "tcu",
         "date_release": "2019-07-05",
         "name": "In the Clutches of Chaos",
         "position": 6,
+        "replaced": true,
         "size": 60
     },
     {
         "cgdb_id": 35,
+        "chapter": 1,
         "code": "bbt",
         "cycle_code": "tcu",
         "date_release": "2019-07-26",
         "name": "Before the Black Throne",
         "position": 7,
+        "replaced": true,
         "size": 60
     },
     {
         "cgdb_id": 37,
+        "chapter": 1,
         "code": "tde",
         "cycle_code": "tde",
         "date_release": "2019-09-27",
         "name": "The Dream-Eaters",
         "position": 1,
+        "replaced": true,
         "size": 109
     },
     {
         "cgdb_id": 39,
+        "chapter": 1,
         "code": "sfk",
         "cycle_code": "tde",
         "date_release": "2019-11-15",
         "name": "The Search for Kadath",
         "position": 2,
+        "replaced": true,
         "size": 45
     },
     {
         "cgdb_id": 40,
+        "chapter": 1,
         "code": "tsh",
         "cycle_code": "tde",
         "date_release": "2019-12-13",
         "name": "A Thousand Shapes of Horror",
         "position": 3,
+        "replaced": true,
         "size": 40
     },
     {
         "cgdb_id": 41,
+        "chapter": 1,
         "code": "dsm",
         "cycle_code": "tde",
         "date_release": "2020-01-10",
         "name": "Dark Side of the Moon",
         "position": 4,
+        "replaced": true,
         "size": 39
     },
     {
         "cgdb_id": 42,
+        "chapter": 1,
         "code": "pnr",
         "cycle_code": "tde",
         "date_release": "2020-02-07",
         "name": "Point of No Return",
         "position": 5,
+        "replaced": true,
         "size": 42
     },
     {
         "cgdb_id": 43,
+        "chapter": 1,
         "code": "wgd",
         "cycle_code": "tde",
         "date_release": "2020-03-06",
         "name": "Where the Gods Dwell",
         "position": 6,
+        "replaced": true,
         "size": 47
     },
     {
         "cgdb_id": 44,
+        "chapter": 1,
         "code": "woc",
         "cycle_code": "tde",
         "date_release": "2020-06-05",
         "name": "Weaver of the Cosmos",
         "position": 7,
+        "replaced": true,
         "size": 32
     },
     {
         "cgdb_id": 52,
+        "chapter": 1,
         "code": "tic",
         "cycle_code": "tic",
         "date_release": "2020-10-02",
         "name": "The Innsmouth Conspiracy",
         "position": 1,
+        "replaced": true,
         "size": 108
     },
     {
         "cgdb_id": 53,
+        "chapter": 1,
         "code": "itd",
         "cycle_code": "tic",
         "date_release": "2020-11-06",
         "name": "In Too Deep",
         "position": 2,
+        "replaced": true,
         "size": 44
     },
     {
         "cgdb_id": 54,
+        "chapter": 1,
         "code": "def",
         "cycle_code": "tic",
         "date_release": "2020-12-04",
         "name": "Devil Reef",
         "position": 3,
+        "replaced": true,
         "size": 60
     },
     {
         "cgdb_id": 55,
+        "chapter": 1,
         "code": "hhg",
         "cycle_code": "tic",
         "date_release": "2021-01-08",
         "name": "Horror in High Gear",
         "position": 4,
+        "replaced": true,
         "size": 60
     },
     {
         "cgdb_id": 56,
+        "chapter": 1,
         "code": "lif",
         "cycle_code": "tic",
         "date_release": "2021-02-19",
         "name": "A Light in the Fog",
         "position": 5,
+        "replaced": true,
         "size": 60
     },
     {
         "cgdb_id": 57,
+        "chapter": 1,
         "code": "lod",
         "cycle_code": "tic",
         "date_release": "2021-03-19",
         "name": "The Lair of Dagon",
         "position": 6,
+        "replaced": true,
         "size": 60
     },
     {
         "cgdb_id": 58,
+        "chapter": 1,
         "code": "itm",
         "cycle_code": "tic",
         "date_release": "2021-05-21",
         "name": "Into the Maelstrom",
         "position": 7,
+        "replaced": true,
         "size": 60
     },
     {
+        "chapter": 1,
         "code": "eoep",
         "cycle_code": "eoe",
         "date_release": "2021-09-10",
@@ -412,6 +501,7 @@
         "size": 300
     },
     {
+        "chapter": 1,
         "code": "eoec",
         "cycle_code": "eoe",
         "date_release": "2021-11-12",
@@ -420,6 +510,7 @@
         "size": 300
     },
     {
+        "chapter": 1,
         "code": "tskp",
         "cycle_code": "tsk",
         "date_release": "2022-09-30",
@@ -428,6 +519,7 @@
         "size": 300
     },
     {
+        "chapter": 1,
         "code": "tskc",
         "cycle_code": "tsk",
         "date_release": "2022-11-18",
@@ -436,6 +528,7 @@
         "size": 300
     },
     {
+        "chapter": 1,
         "code": "fhvp",
         "cycle_code": "fhv",
         "date_release": "2023-02-16",
@@ -444,6 +537,7 @@
         "size": 300
     },
     {
+        "chapter": 1,
         "code": "fhvc",
         "cycle_code": "fhv",
         "date_release": "2022-02-24",
@@ -452,6 +546,7 @@
         "size": 300
     },
     {
+        "chapter": 1,
         "code": "tdcp",
         "cycle_code": "tdc",
         "date_release": "2025-02-07",
@@ -460,6 +555,7 @@
         "size": 300
     },
     {
+        "chapter": 1,
         "code": "tdcc",
         "cycle_code": "tdc",
         "date_release": "2025-03-31",
@@ -468,6 +564,7 @@
         "size": 300
     },
     {
+        "chapter": 1,
         "cgdb_id": 9,
         "code": "cotr",
         "cycle_code": "side_stories",
@@ -477,6 +574,7 @@
         "size": 36
     },
     {
+        "chapter": 1,
         "cgdb_id": 10,
         "code": "coh",
         "cycle_code": "side_stories",
@@ -486,6 +584,7 @@
         "size": 40
     },
     {
+        "chapter": 1,
         "cgdb_id": 18,
         "code": "lol",
         "cycle_code": "side_stories",
@@ -495,6 +594,7 @@
         "size": 70
     },
     {
+        "chapter": 1,
         "cgdb_id": 27,
         "code": "guardians",
         "cycle_code": "side_stories",
@@ -504,6 +604,7 @@
         "size": 58
     },
     {
+        "chapter": 1,
         "code": "hotel",
         "cycle_code": "side_stories",
         "date_release": "2019-10-25",
@@ -512,6 +613,7 @@
         "size": 78
     },
     {
+        "chapter": 1,
         "code": "blob",
         "cycle_code": "side_stories",
         "date_release": "2020-07-03",
@@ -520,6 +622,7 @@
         "size": 78
     },
     {
+        "chapter": 1,
         "code": "wog",
         "cycle_code": "side_stories",
         "date_release": "2020-07-03",
@@ -528,6 +631,7 @@
         "size": 78
     },
     {
+        "chapter": 1,
         "code": "mtt",
         "cycle_code": "side_stories",
         "date_release": "2022-02-04",
@@ -536,6 +640,7 @@
         "size": 78
     },
     {
+        "chapter": 1,
         "code": "fof",
         "cycle_code": "side_stories",
         "date_release": "2023-04-01",
@@ -544,6 +649,7 @@
         "size": 78
     },
     {
+        "chapter": 1,
         "code": "blbe",
         "cycle_code": "side_stories",
         "date_release": "2023-08-01",
@@ -552,6 +658,7 @@
         "size": 78
     },
     {
+        "chapter": 1,
         "code": "hoth",
         "cycle_code": "promotional",
         "date_release": "2017-10-13",
@@ -560,6 +667,7 @@
         "size": 3
     },
     {
+        "chapter": 1,
         "code": "tdor",
         "cycle_code": "promotional",
         "date_release": "2018-02-22",
@@ -568,6 +676,7 @@
         "size": 3
     },
     {
+        "chapter": 1,
         "code": "iotv",
         "cycle_code": "promotional",
         "date_release": "2017-12-07",
@@ -576,6 +685,7 @@
         "size": 3
     },
     {
+        "chapter": 1,
         "code": "tdg",
         "cycle_code": "promotional",
         "date_release": "2018-06-07",
@@ -584,6 +694,7 @@
         "size": 3
     },
     {
+        "chapter": 1,
         "code": "tftbw",
         "cycle_code": "promotional",
         "date_release": "2018-04-05",
@@ -592,6 +703,7 @@
         "size": 3
     },
     {
+        "chapter": 1,
         "code": "bob",
         "cycle_code": "promotional",
         "date_release": "2020-06-05",
@@ -600,6 +712,7 @@
         "size": 3
     },
     {
+        "chapter": 1,
         "code": "dre",
         "cycle_code": "promotional",
         "date_release": "2020-11-06",
@@ -608,6 +721,7 @@
         "size": 3
     },
     {
+        "chapter": 1,
         "code": "promo",
         "cycle_code": "promotional",
         "date_release": "2016-12-14",
@@ -616,6 +730,7 @@
         "size": 9
     },
     {
+        "chapter": 1,
         "cgdb_id": 26,
         "code": "rtnotz",
         "cycle_code": "return",
@@ -625,6 +740,7 @@
         "size": 48
     },
     {
+        "chapter": 1,
         "cgdb_id": 28,
         "code": "rtdwl",
         "cycle_code": "return",
@@ -634,6 +750,7 @@
         "size": 73
     },
     {
+        "chapter": 1,
         "cgdb_id": 36,
         "code": "rtptc",
         "cycle_code": "return",
@@ -643,6 +760,7 @@
         "size": 78
     },
     {
+        "chapter": 1,
         "cgdb_id": 46,
         "code": "rttfa",
         "cycle_code": "return",
@@ -652,6 +770,7 @@
         "size": 80
     },
     {
+        "chapter": 1,
         "code": "rttcu",
         "cycle_code": "return",
         "date_release": "2021-06-24",
@@ -661,6 +780,7 @@
     },
     {
         "cgdb_id": 47,
+        "chapter": 1,
         "code": "nat",
         "cycle_code": "investigator",
         "date_release": "2020-08-28",
@@ -670,6 +790,7 @@
     },
     {
         "cgdb_id": 48,
+        "chapter": 1,
         "code": "har",
         "cycle_code": "investigator",
         "date_release": "2020-08-28",
@@ -679,6 +800,7 @@
     },
     {
         "cgdb_id": 49,
+        "chapter": 1,
         "code": "win",
         "cycle_code": "investigator",
         "date_release": "2020-08-28",
@@ -688,6 +810,7 @@
     },
     {
         "cgdb_id": 50,
+        "chapter": 1,
         "code": "jac",
         "cycle_code": "investigator",
         "date_release": "2020-08-28",
@@ -697,6 +820,7 @@
     },
     {
         "cgdb_id": 51,
+        "chapter": 1,
         "code": "ste",
         "cycle_code": "investigator",
         "date_release": "2020-08-28",
@@ -705,6 +829,7 @@
         "size": 60
     },
     {
+        "chapter": 1,
         "code": "rod",
         "cycle_code": "parallel",
         "date_release": "2020-05-05",
@@ -713,6 +838,7 @@
         "size": 7
     },
     {
+        "chapter": 1,
         "code": "aon",
         "cycle_code": "parallel",
         "date_release": "2020-08-13",
@@ -721,6 +847,7 @@
         "size": 9
     },
     {
+        "chapter": 1,
         "code": "bad",
         "cycle_code": "parallel",
         "date_release": "2020-12-03",
@@ -729,6 +856,7 @@
         "size": 7
     },
     {
+        "chapter": 1,
         "code": "btb",
         "cycle_code": "parallel",
         "date_release": "2021-06-18",
@@ -737,6 +865,7 @@
         "size": 13
     },
     {
+        "chapter": 1,
         "code": "rtr",
         "cycle_code": "parallel",
         "date_release": "2021-12-30",
@@ -745,6 +874,7 @@
         "size": 9
     },
     {
+        "chapter": 1,
         "code": "otr",
         "cycle_code": "parallel",
         "date_release": "2023-07-28",
@@ -753,6 +883,7 @@
         "size": 3
     },
     {
+        "chapter": 1,
         "code": "ltr",
         "cycle_code": "parallel",
         "date_release": "2023-10-13",
@@ -761,6 +892,7 @@
         "size": 13
     },
     {
+        "chapter": 1,
         "code": "ptr",
         "cycle_code": "parallel",
         "date_release": "2023-10-30",
@@ -769,6 +901,7 @@
         "size": 3
     },
     {
+        "chapter": 1,
         "code": "rop",
         "cycle_code": "parallel",
         "date_release": "2024-01-01",
@@ -777,6 +910,7 @@
         "size": 16
     },
     {
+        "chapter": 1,
         "code": "hfa",
         "cycle_code": "parallel",
         "date_release": "2024-03-21",
@@ -785,6 +919,7 @@
         "size": 3
     },
     {
+        "chapter": 1,
         "code": "pap",
         "cycle_code": "parallel",
         "date_release": "2024-08-07",
@@ -793,6 +928,7 @@
         "size": 3
     },
     {
+        "chapter": 1,
         "code": "enc",
         "cycle_code": "parallel",
         "date_release": "2025-10-29",
@@ -801,6 +937,7 @@
         "size": 11
     },
     {
+        "chapter": 1,
         "code": "tmg",
         "cycle_code": "side_stories",
         "date_release": "2024-08-23",
@@ -809,6 +946,7 @@
         "size": 78
     },
     {
+        "chapter": 1,
         "code": "aof",
         "cycle_code": "parallel",
         "date_release": "2024-10-30",
@@ -817,11 +955,144 @@
         "size": 3
     },
     {
+        "chapter": 1,
         "code": "film_fatale",
         "cycle_code": "side_stories",
         "date_release": "2025-08-15",
         "name": "Film Fatale",
         "position": 12,
         "size": 78
+    },
+    {
+        "chapter": 1,
+        "code": "dwlp",
+        "cycle_code": "dwl",
+        "date_release": "2024-01-12",
+        "name": "The Dunwich Legacy Investigator Expansion",
+        "reprint_packs": ["dwl", "tmm", "tece", "bota", "uau", "wda", "litas"],
+        "reprint_type": "player",
+        "position": 1,
+        "size": 104
+    },
+    {
+        "chapter": 1,
+        "code": "dwlc",
+        "cycle_code": "dwl",
+        "date_release": "2024-01-12",
+        "name": "The Dunwich Legacy Campaign Expansion",
+        "reprint_packs": ["dwl", "tmm", "tece", "bota", "uau", "wda", "litas"],
+        "reprint_type": "campaign",
+        "position": 2,
+        "size": 104
+    },
+     {
+        "chapter": 1,
+        "code": "ptcp",
+        "cycle_code": "ptc",
+        "date_release": "2024-01-25",
+        "name": "The Path to Carcosa Investigator Expansion",
+        "reprint_packs": ["ptc", "eotp", "tuo", "apot", "tpm", "bsr", "dca"],
+        "reprint_type": "player",
+        "position": 1,
+        "size": 110
+    },
+    {
+        "chapter": 1,
+        "code": "ptcc",
+        "cycle_code": "ptc",
+        "date_release": "2024-01-25",
+        "name": "The Path to Carcosa Campaign Expansion",
+        "reprint_packs": ["ptc", "eotp", "tuo", "apot", "tpm", "bsr", "dca"],
+        "reprint_type": "campaign",
+        "position": 2,
+        "size": 110
+    },
+    {
+        "chapter": 1,
+        "code": "tfap",
+        "cycle_code": "tfa",
+        "date_release": "2024-05-10",
+        "name": "The Forgotten Age Investigator Expansion",
+        "reprint_packs": ["tfa", "tof", "tbb", "hote", "tcoa", "tdoy", "sha"],
+        "reprint_type": "player",
+        "position": 1,
+        "size": 102
+    },
+    {
+        "chapter": 1,
+        "code": "tfac",
+        "cycle_code": "tfa",
+        "date_release": "2024-05-10",
+        "name": "The Forgotten Age Campaign Expansion",
+        "reprint_packs": ["tfa", "tof", "tbb", "hote", "tcoa", "tdoy", "sha"],
+        "reprint_type": "campaign",
+        "position": 2,
+        "size": 102
+    },
+     {
+        "chapter": 1,
+        "code": "tcup",
+        "cycle_code": "tcu",
+        "date_release": "2024-01-31",
+        "name": "The Circle Undone Investigator Expansion",
+        "reprint_packs": ["tcu", "tsn", "wos", "fgg", "uad", "icc", "bbt"],
+        "reprint_type": "player",
+        "position": 1,
+        "size": 109
+    },
+    {
+        "chapter": 1,
+        "code": "tcuc",
+        "cycle_code": "tcu",
+        "date_release": "2024-01-31",
+        "name": "The Circle Undone Campaign Expansion",
+        "reprint_packs": ["tcu", "tsn", "wos", "fgg", "uad", "icc", "bbt"],
+        "reprint_type": "campaign",
+        "position": 2,
+        "size": 109
+     },
+    {
+        "chapter": 1,
+        "code": "tdep",
+        "cycle_code": "tde",
+        "date_release": "2024-09-27",
+        "name": "The Dream-Eaters Investigator Expansion",
+        "reprint_packs": ["tde", "sfk", "tsh", "dsm", "pnr", "wgd", "woc"],
+        "reprint_type": "player",
+        "position": 1,
+        "size": 109
+    },
+    {
+        "chapter": 1,
+        "code": "tdec",
+        "cycle_code": "tde",
+        "date_release": "2024-09-27",
+        "name": "The Dream-Eaters Campaign Expansion",
+        "reprint_packs": ["tde", "sfk", "tsh", "dsm", "pnr", "wgd", "woc"],
+        "reprint_type": "campaign",
+        "position": 2,
+        "size": 109
+    },
+    {
+        "chapter": 1,
+        "code": "ticp",
+        "cycle_code": "tic",
+        "date_release": "2024-10-02",
+        "name": "The Innsmouth Conspiracy Investigator Expansion",
+        "reprint_packs": ["tic", "itd", "def", "hhg", "lif", "lod", "itm"],
+        "reprint_type": "player",
+        "position": 1,
+        "size": 108
+    },
+    {
+        "chapter": 1,
+        "code": "ticc",
+        "cycle_code": "tic",
+        "date_release": "2024-10-02",
+        "name": "The Innsmouth Conspiracy Campaign Expansion",
+        "reprint_packs": ["tic", "itd", "def", "hhg", "lif", "lod", "itm"],
+        "reprint_type": "campaign",
+        "position": 2,
+        "size": 108
     }
 ]

--- a/schema/pack_schema.json
+++ b/schema/pack_schema.json
@@ -41,7 +41,7 @@
         "reprint_type": {
             "type": "string",
             "minLength": 1
-        }
+        },
         "name": {
             "minLength": 1,
             "type": "string"

--- a/schema/pack_schema.json
+++ b/schema/pack_schema.json
@@ -35,6 +35,13 @@
         "replaced": {
             "type": "boolean"
         },
+        "reprint_packs": {
+            "type": "array"
+        },
+        "reprint_type": {
+            "type": "string",
+            "minLength": 1
+        }
         "name": {
             "minLength": 1,
             "type": "string"

--- a/schema/pack_schema.json
+++ b/schema/pack_schema.json
@@ -29,6 +29,12 @@
                 }
             ]
         },
+        "chapter": {
+            "type": "integer"
+        },
+        "replaced": {
+            "type": "boolean"
+        },
         "name": {
             "minLength": 1,
             "type": "string"


### PR DESCRIPTION
Added support for chapter, so a pack can be marked as chapter 1 or 2, currently just for the new core set, and is currently optional.

Also added a replaced flag, to mark all the old packs as replaced, so they can be displayed seperately to clean up the pack lists for most recent players.

Also added virtual packs for the reprints, which list which packs and types of cards they reprint. 