### PR TITLE
Fix typo in zh-cn translation for 'key'

### DIFF
--- a/translations/zh-cn/types.json
+++ b/translations/zh-cn/types.json
@@ -29,7 +29,7 @@
     },
     {
         "code": "key",
-        "name": "密鑰"
+        "name": "密钥"
     },
     {
         "code": "location",


### PR DESCRIPTION
Fix typo in zh-cn translation for 'key'