### PR TITLE
Fix GER translation for Word of Command

### DIFF
--- a/translations/de/pack/tde/dsm.json
+++ b/translations/de/pack/tde/dsm.json
@@ -47,7 +47,7 @@
     {
         "code": "06202",
         "flavor": "Licht zur Rettung unserer Augen.\nWärme zur Rettung unserer Haut.\nEin Funke zur Rettung unserer Seele.",
-        "name": "Machtwort",
+        "name": "Machtgesuch",
         "text": "Benenne eine [[Zauber]]-Karte. Durchsuche dein Deck nach einer Kopie der benannten Karte und ziehe sie. Mische dein Deck.",
         "traits": "Zauber."
     },


### PR DESCRIPTION
The card is called "Machtgesuch" in German, not "Machtwort"