### PR TITLE
Remove deck_limit from Mysterious Syringe

### DIFF
--- a/pack/side/lol_encounter.json
+++ b/pack/side/lol_encounter.json
@@ -799,7 +799,6 @@
     {
         "code": "70041",
         "cost": null,
-        "deck_limit": 1,
         "encounter_code": "in_the_labyrinths_of_lunacy",
         "encounter_position": 23,
         "faction_code": "neutral",


### PR DESCRIPTION
This card has an encounter back and is not supposed to go in player decks.