### PR TITLE
Apply PTC cards rename errata to the text on the cards as well

### DIFF
--- a/pack/ptc/ptc_encounter.json
+++ b/pack/ptc/ptc_encounter.json
@@ -1216,7 +1216,7 @@
         "pack_code": "ptc",
         "position": 95,
         "quantity": 2,
-        "text": "<b>Forced</b> - After Maniac engages you: Take 1 damage and deal 1 damage to Maniac.",
+        "text": "<b>Forced</b> - After Seer of the Sign engages you: Take 1 damage and deal 1 damage to Seer of the Sign.",
         "traits": "Humanoid. Possessed.",
         "type_code": "enemy"
     },
@@ -1237,7 +1237,7 @@
         "pack_code": "ptc",
         "position": 96,
         "quantity": 2,
-        "text": "<b>Forced</b> - After Young Psychopath engages you: You must either take 1 horror, or Young Psychopath gets +3 fight until the end of the investigation phase.",
+        "text": "<b>Forced</b> - After Puppet of Hastur engages you: You must either take 1 horror, or Puppet of Hastur gets +3 fight until the end of the investigation phase.",
         "traits": "Humanoid. Possessed.",
         "type_code": "enemy"
     },

--- a/pack/ptc/tuo_encounter.json
+++ b/pack/ptc/tuo_encounter.json
@@ -543,7 +543,7 @@
         "pack_code": "tuo",
         "position": 184,
         "quantity": 3,
-        "text": "<b>Spawn</b> - Nearest Asylum Halls.\n<b>Prey</b> - Most remaining sanity.\n<b>Forced</b> - When you attack Mad Patient: Take 1 horror.",
+        "text": "<b>Spawn</b> - Nearest Asylum Halls.\n<b>Prey</b> - Most remaining sanity.\n<b>Forced</b> - When you attack Haunted Patient: Take 1 horror.",
         "traits": "Humanoid. Possessed.",
         "type_code": "enemy"
     },

--- a/translations/cs/pack/ptc/ptc_encounter.json
+++ b/translations/cs/pack/ptc/ptc_encounter.json
@@ -486,14 +486,14 @@
         "code": "03095",
         "flavor": "\"Get out! Get out! Get out of my head!\"",
         "name": "Seer of the Sign",
-        "text": "<b>Forced</b> - After Maniac engages you: Take 1 damage and deal 1 damage to Maniac.",
+        "text": "<b>Forced</b> - After Seer of the Sign engages you: Take 1 damage and deal 1 damage to Seer of the Sign.",
         "traits": "Humanoid. Possessed."
     },
     {
         "code": "03096",
         "flavor": "Her eyes widened, and she picked up the knife.",
         "name": "Puppet of Hastur",
-        "text": "<b>Forced</b> - After Young Psychopath engages you: You must either take 1 horror, or Young Psychopath gets +3 fight until the end of the investigation phase.",
+        "text": "<b>Forced</b> - After Puppet of Hastur engages you: You must either take 1 horror, or Puppet of Hastur gets +3 fight until the end of the investigation phase.",
         "traits": "Humanoid. Possessed."
     },
     {

--- a/translations/cs/pack/ptc/tuo_encounter.json
+++ b/translations/cs/pack/ptc/tuo_encounter.json
@@ -222,7 +222,7 @@
         "code": "03184",
         "flavor": "Sometimes the most terrifying of foes is one’s own mind.",
         "name": "Haunted Patient",
-        "text": "<b>Spawn</b> - Nearest Asylum Halls.\n<b>Prey</b> - Most remaining sanity.\n<b>Forced</b> - When you attack Mad Patient: Take 1 horror.",
+        "text": "<b>Spawn</b> - Nearest Asylum Halls.\n<b>Prey</b> - Most remaining sanity.\n<b>Forced</b> - When you attack Haunted Patient: Take 1 horror.",
         "traits": "Humanoid. Possessed."
     },
     {

--- a/translations/es/pack/ptc/ptc_encounter.json
+++ b/translations/es/pack/ptc/ptc_encounter.json
@@ -485,15 +485,15 @@
     {
         "code": "03095",
         "flavor": "\"¡Fuera! ¡Fuera! ¡Fuera de mi cabeza!\"",
-        "name": "Maníaco",
-        "text": "<b>Obligado</b> - Después de que el Maníaco se enfrente a ti: Recibe 1 punto de daño e inflige 1 punto de daño al Maníaco.",
+        "name": "Vidente del signo",
+        "text": "<b>Obligado</b> - Después de que el Vidente del signo se enfrente a ti: Recibe 1 punto de daño e inflige 1 punto de daño al Vidente del signo.",
         "traits": "Humanoide. Lunático."
     },
     {
         "code": "03096",
         "flavor": "Abrió los ojos como platos y cogió el cuchillo.",
-        "name": "Psicópata joven",
-        "text": "<b>Obligado</b> - Después de que la Psicópata joven se enfrente a ti: Debes recibir 1 punto de horror, o bien la Psicópata joven recibe +3 a combate hasta el final de la fase de Investigación.",
+        "name": "Marioneta de Hastur",
+        "text": "<b>Obligado</b> - Después de que la Marioneta de Hastur se enfrente a ti: Debes recibir 1 punto de horror, o bien la Marioneta de Hastur recibe +3 a combate hasta el final de la fase de Investigación.",
         "traits": "Humanoide. Lunático."
     },
     {

--- a/translations/es/pack/ptc/tuo_encounter.json
+++ b/translations/es/pack/ptc/tuo_encounter.json
@@ -221,8 +221,8 @@
     {
         "code": "03184",
         "flavor": "A veces, el enemigo más aterrador es tu propia mente.",
-        "name": "Paciente loco",
-        "text": "<b>Aparición</b> - Pasillos del manicomio más cercanos.\n<b>Presa</b> - Mayor cordura restante.\n<b>Obligado</b> - Cuando ataques al Paciente loco: Recibe 1 punto de horror.",
+        "name": "Paciente perturbado",
+        "text": "<b>Aparición</b> - Pasillos del manicomio más cercanos.\n<b>Presa</b> - Mayor cordura restante.\n<b>Obligado</b> - Cuando ataques al Paciente perturbado: Recibe 1 punto de horror.",
         "traits": "Humanoide. Lunático."
     },
     {

--- a/translations/fr/pack/ptc/ptc_encounter.json
+++ b/translations/fr/pack/ptc/ptc_encounter.json
@@ -485,15 +485,15 @@
     {
         "code": "03095",
         "flavor": "« Sortez ! Sortez ! Sortez de ma tête ! »",
-        "name": "Maniaque",
-        "text": "<b>Forcé</b> - Après que le Maniaque vous a engagé : subissez 1 dégât et infligez 1 dégât au Maniaque.",
+        "name": "Annonciateur du Signe",
+        "text": "<b>Forcé</b> - Après que l'Annonciateur du Signe vous a engagé : subissez 1 dégât et infligez 1 dégât à l'Annonciateur du Signe.",
         "traits": "Humanoïde. Aliéné."
     },
     {
         "code": "03096",
         "flavor": "Ses yeux s'écarquillèrent, et elle ramassa le couteau.",
-        "name": "Jeune Psychopathe",
-        "text": "<b>Forcé</b> - Après que la Jeune Psychopathe vous a engagé : vous devez soit subir 1 horreur, soit la Jeune Psychopathe gagne +3 combat jusqu'à la fin de la phase d'Investigation.",
+        "name": "Marionnette d'Hastur",
+        "text": "<b>Forcé</b> - Après que la Marionnette d'Hastur vous a engagé : vous devez soit subir 1 horreur, soit la Marionnette d'Hastur gagne +3 combat jusqu'à la fin de la phase d'Investigation.",
         "traits": "Humanoïde. Aliéné."
     },
     {

--- a/translations/fr/pack/ptc/tuo_encounter.json
+++ b/translations/fr/pack/ptc/tuo_encounter.json
@@ -221,8 +221,8 @@
     {
         "code": "03184",
         "flavor": "Parfois le plus terrifiant de nos ennemis est notre propre esprit.",
-        "name": "Patiente Folle",
-        "text": "<b>Génération</b> - Couloir du Sous-sol le plus proche.\n<b>Proie</b> - Santé mentale restante la plus élevée.\n<b>Forcé</b> - Quand vous attaquez la Patiente Folle : subissez 1 horreur.",
+        "name": "Patiente Tourmentée",
+        "text": "<b>Génération</b> - Couloir du Sous-sol le plus proche.\n<b>Proie</b> - Santé mentale restante la plus élevée.\n<b>Forcé</b> - Quand vous attaquez la Patiente Tourmentée : subissez 1 horreur.",
         "traits": "Humanoïde. Aliéné."
     },
     {

--- a/translations/ko/pack/ptc/ptc_encounter.json
+++ b/translations/ko/pack/ptc/ptc_encounter.json
@@ -486,14 +486,14 @@
         "code": "03095",
         "flavor": "\"Get out! Get out! Get out of my head!\"",
         "name": "표식을 목도한 자",
-        "text": "<b>Forced</b> - After Maniac engages you: Take 1 damage and deal 1 damage to Maniac.",
+        "text": "<b>Forced</b> - After Seer of the Sign engages you: Take 1 damage and deal 1 damage to Seer of the Sign.",
         "traits": "인간형. 홀린."
     },
     {
         "code": "03096",
         "flavor": "Her eyes widened, and she picked up the knife.",
         "name": "하스터의 꼭두각시",
-        "text": "<b>Forced</b> - After Young Psychopath engages you: You must either take 1 horror, or Young Psychopath gets +3 fight until the end of the investigation phase.",
+        "text": "<b>Forced</b> - After Puppet of Hastur engages you: You must either take 1 horror, or Puppet of Hastur gets +3 fight until the end of the investigation phase.",
         "traits": "인간형. 홀린."
     },
     {

--- a/translations/ko/pack/ptc/tuo_encounter.json
+++ b/translations/ko/pack/ptc/tuo_encounter.json
@@ -222,7 +222,7 @@
         "code": "03184",
         "flavor": "Sometimes the most terrifying of foes is one’s own mind.",
         "name": "신들린 환자",
-        "text": "<b>Spawn</b> - Nearest Asylum Halls.\n<b>Prey</b> - Most remaining sanity.\n<b>Forced</b> - When you attack Mad Patient: Take 1 horror.",
+        "text": "<b>Spawn</b> - Nearest Asylum Halls.\n<b>Prey</b> - Most remaining sanity.\n<b>Forced</b> - When you attack Haunted Patient: Take 1 horror.",
         "traits": "인간형. 홀린."
     },
     {

--- a/translations/pt/pack/ptc/ptc_encounter.json
+++ b/translations/pt/pack/ptc/ptc_encounter.json
@@ -486,14 +486,14 @@
         "code": "03095",
         "flavor": "\"Get out! Get out! Get out of my head!\"",
         "name": "Seer of the Sign",
-        "text": "<b>Forced</b> - After Maniac engages you: Take 1 damage and deal 1 damage to Maniac.",
+        "text": "<b>Forced</b> - After Seer of the Sign engages you: Take 1 damage and deal 1 damage to Seer of the Sign.",
         "traits": "Humanoid. Possessed."
     },
     {
         "code": "03096",
         "flavor": "Her eyes widened, and she picked up the knife.",
         "name": "Puppet of Hastur",
-        "text": "<b>Forced</b> - After Young Psychopath engages you: You must either take 1 horror, or Young Psychopath gets +3 fight until the end of the investigation phase.",
+        "text": "<b>Forced</b> - After Puppet of Hastur engages you: You must either take 1 horror, or Puppet of Hastur gets +3 fight until the end of the investigation phase.",
         "traits": "Humanoid. Possessed."
     },
     {

--- a/translations/pt/pack/ptc/tuo_encounter.json
+++ b/translations/pt/pack/ptc/tuo_encounter.json
@@ -222,7 +222,7 @@
         "code": "03184",
         "flavor": "Sometimes the most terrifying of foes is one’s own mind.",
         "name": "Haunted Patient",
-        "text": "<b>Spawn</b> - Nearest Asylum Halls.\n<b>Prey</b> - Most remaining sanity.\n<b>Forced</b> - When you attack Mad Patient: Take 1 horror.",
+        "text": "<b>Spawn</b> - Nearest Asylum Halls.\n<b>Prey</b> - Most remaining sanity.\n<b>Forced</b> - When you attack Haunted Patient: Take 1 horror.",
         "traits": "Humanoid. Possessed."
     },
     {

--- a/translations/uk/pack/ptc/ptc_encounter.json
+++ b/translations/uk/pack/ptc/ptc_encounter.json
@@ -485,15 +485,15 @@
     {
         "code": "03095",
         "flavor": "\"Get out! Get out! Get out of my head!\"",
-        "name": "Maniac",
-        "text": "<b>Forced</b> - After Maniac engages you: Take 1 damage and deal 1 damage to Maniac.",
+        "name": "Seer of the Sign",
+        "text": "<b>Forced</b> - After Seer of the Sign engages you: Take 1 damage and deal 1 damage to Seer of the Sign.",
         "traits": "Humanoid. Lunatic."
     },
     {
         "code": "03096",
         "flavor": "Her eyes widened, and she picked up the knife.",
-        "name": "Young Psychopath",
-        "text": "<b>Forced</b> - After Young Psychopath engages you: You must either take 1 horror, or Young Psychopath gets +3 fight until the end of the investigation phase.",
+        "name": "Puppet of Hastur",
+        "text": "<b>Forced</b> - After Puppet of Hastur engages you: You must either take 1 horror, or Puppet of Hastur gets +3 fight until the end of the investigation phase.",
         "traits": "Humanoid. Lunatic."
     },
     {

--- a/translations/uk/pack/ptc/tuo_encounter.json
+++ b/translations/uk/pack/ptc/tuo_encounter.json
@@ -221,8 +221,8 @@
     {
         "code": "03184",
         "flavor": "Sometimes the most terrifying of foes is one’s own mind.",
-        "name": "Mad Patient",
-        "text": "<b>Spawn</b> - Nearest Asylum Halls.\n<b>Prey</b> - Most remaining sanity.\n<b>Forced</b> - When you attack Mad Patient: Take 1 horror.",
+        "name": "Haunted Patient",
+        "text": "<b>Spawn</b> - Nearest Asylum Halls.\n<b>Prey</b> - Most remaining sanity.\n<b>Forced</b> - When you attack Haunted Patient: Take 1 horror.",
         "traits": "Humanoid. Lunatic."
     },
     {

--- a/translations/vn/pack/ptc/ptc_encounter.json
+++ b/translations/vn/pack/ptc/ptc_encounter.json
@@ -485,15 +485,15 @@
     {
         "code": "03095",
         "flavor": "\"Get out! Get out! Get out of my head!\"",
-        "name": "Maniac",
-        "text": "<b>Forced</b> - After Maniac engages you: Take 1 damage and deal 1 damage to Maniac.",
+        "name": "Seer of the Sign",
+        "text": "<b>Forced</b> - After Seer of the Sign engages you: Take 1 damage and deal 1 damage to Seer of the Sign.",
         "traits": "Humanoid. Lunatic."
     },
     {
         "code": "03096",
         "flavor": "Her eyes widened, and she picked up the knife.",
-        "name": "Young Psychopath",
-        "text": "<b>Forced</b> - After Young Psychopath engages you: You must either take 1 horror, or Young Psychopath gets +3 fight until the end of the investigation phase.",
+        "name": "Puppet of Hastur",
+        "text": "<b>Forced</b> - After Puppet of Hastur engages you: You must either take 1 horror, or Puppet of Hastur gets +3 fight until the end of the investigation phase.",
         "traits": "Humanoid. Lunatic."
     },
     {

--- a/translations/vn/pack/ptc/tuo_encounter.json
+++ b/translations/vn/pack/ptc/tuo_encounter.json
@@ -221,8 +221,8 @@
     {
         "code": "03184",
         "flavor": "Sometimes the most terrifying of foes is one’s own mind.",
-        "name": "Mad Patient",
-        "text": "<b>Spawn</b> - Nearest Asylum Halls.\n<b>Prey</b> - Most remaining sanity.\n<b>Forced</b> - When you attack Mad Patient: Take 1 horror.",
+        "name": "Haunted Patient",
+        "text": "<b>Spawn</b> - Nearest Asylum Halls.\n<b>Prey</b> - Most remaining sanity.\n<b>Forced</b> - When you attack Haunted Patient: Take 1 horror.",
         "traits": "Humanoid. Lunatic."
     },
     {


### PR DESCRIPTION
Cards 03095, 03096 and 03184 were renamed in 1d1ff56, but the text on the cards were not.